### PR TITLE
Fix repositories url

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ There are two steps to perform:
 * [Associate the device to your user (Public Key Credential Creation)](doc/webauthn/PublicKeyCredentialCreation.md)
 * [Check authentication request (Public Key Credential Request)](doc/webauthn/PublicKeyCredentialRequest.md)
 
-Install the library with Composer: `composer require web-authn/webauthn-lib`.
+Install the library with Composer: `composer require web-auth/webauthn-lib`.
 
 ## Symfony Bundles
 

--- a/doc/symfony/index.md
+++ b/doc/symfony/index.md
@@ -6,7 +6,7 @@ Webauthn Symfony Bundle
 Install the bundle with Composer:
 
 ```sh
-composer require web-authn/webauthn-symfony-bundle
+composer require web-auth/webauthn-symfony-bundle
 ```
 
 If you are using Symfony Flex then the bundle will automatically be installed.

--- a/doc/u2f/FIDO.md
+++ b/doc/u2f/FIDO.md
@@ -6,7 +6,7 @@ FIDO Universal 2nd Factor (U2F)
 Install the library with Composer:
 
 ```sh
-composer require web-authn/u2f-lib
+composer require web-auth/u2f-lib
 ```
 
 # Usage


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | v1.1
| Bug fix?      | 
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Url/name of the package are prefixed with `web-authn/`, but every packages on packagist.org begin with `web-auth/`.
The same could be done on the `composer.json` file, but I was not sure of this.