### PR TITLE
Added CoseAlgorithmManager to AssertionResponseValidator in PublicKeyCredentialRequest example

### DIFF
--- a/doc/webauthn/PublicKeyCredentialRequest.md
+++ b/doc/webauthn/PublicKeyCredentialRequest.md
@@ -207,6 +207,7 @@ $authenticatorAssertionResponseValidator = new AuthenticatorAssertionResponseVal
     $decoder,                              // The CBOR Decoder service
     $tokenBindingHandler,                  // The token binding handler
     $extensionOutputCheckerHandler         // The extension output checker handler  
+    $coseAlgorithmManager                  // The COSE Algorithm Manager
 );
 ``` 
 
@@ -359,6 +360,7 @@ $authenticatorAssertionResponseValidator = new AuthenticatorAssertionResponseVal
   $decoder,
   $tokenBindnigHandler,
   $extensionOutputCheckerHandler
+  $coseAlgorithmManager
 );
 
 try {


### PR DESCRIPTION
Had a hard time trying to know why following literally the webauthn-framework/doc/webauthn/PublicKeyCredentialRequest.md Response Verification example wasn't working in my tests.

Well, if $coseAlgorithmManager parameter is not present in "new AuthenticatorAssertionResponseValidator", then it's obviously null and, when that happens, the default algorithm is SHA256. Probably not the same with the one that your authenticator is using.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
