### PR TITLE
PKC Creation Options default constructor options

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,5 +27,5 @@ jobs:
           chmod +x php-coveralls.phar
           chmod +x phpcov.phar
           vendor/bin/phpunit -c phpunit.xml.dist --coverage-php build/cov/coverage.cov
-          phpcov.phar merge --clover build/logs/clover.xml build/cov
-          php-coveralls.phar --no-interaction
+          ./phpcov.phar merge --clover build/logs/clover.xml build/cov
+          ./php-coveralls.phar --no-interaction

--- a/src/symfony/src/Dto/AdditionalPublicKeyCredentialCreationOptionsRequest.php
+++ b/src/symfony/src/Dto/AdditionalPublicKeyCredentialCreationOptionsRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 Spomky-Labs
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+namespace Webauthn\Bundle\Dto;
+
+use Symfony\Component\Validator\Constraints as Assert;
+use Webauthn\PublicKeyCredentialCreationOptions;
+
+final class AdditionalPublicKeyCredentialCreationOptionsRequest
+{
+    /**
+     * @var array|null
+     */
+    public $authenticatorSelection;
+
+    /**
+     * @var string
+     *
+     * @Assert\Type("string")
+     * @Assert\Choice({PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE, PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_DIRECT, PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_INDIRECT})
+     */
+    public $attestation;
+
+    /**
+     * @var array|null
+     */
+    public $extensions;
+}

--- a/src/symfony/src/Service/AuthenticatorRegistrationHelper.php
+++ b/src/symfony/src/Service/AuthenticatorRegistrationHelper.php
@@ -93,7 +93,7 @@ class AuthenticatorRegistrationHelper
     /**
      * @throws AssertionFailedException
      */
-    public function generateOptions(PublicKeyCredentialUserEntity $userEntity, Request $request): PublicKeyCredentialCreationOptions
+    public function generateOptions(PublicKeyCredentialUserEntity $userEntity, Request $request, string $profile = 'default'): PublicKeyCredentialCreationOptions
     {
         $content = $request->getContent();
         Assertion::string($content, 'Invalid data');
@@ -101,7 +101,7 @@ class AuthenticatorRegistrationHelper
         $authenticatorSelection = null !== $creationOptionsRequest->authenticatorSelection ? AuthenticatorSelectionCriteria::createFromArray($creationOptionsRequest->authenticatorSelection) : null;
         $extensions = null !== $creationOptionsRequest->extensions ? AuthenticationExtensionsClientInputs::createFromArray($creationOptionsRequest->extensions) : null;
         $publicKeyCredentialCreationOptions = $this->publicKeyCredentialCreationOptionsFactory->create(
-            'default',
+            $profile,
             $userEntity,
             $this->getUserAuthenticatorList($userEntity),
             $authenticatorSelection,

--- a/src/symfony/src/Service/AuthenticatorRegistrationHelper.php
+++ b/src/symfony/src/Service/AuthenticatorRegistrationHelper.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 Spomky-Labs
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+namespace Webauthn\Bundle\Service;
+
+use Assert\Assertion;
+use Assert\AssertionFailedException;
+use RuntimeException;
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Throwable;
+use Webauthn\AuthenticationExtensions\AuthenticationExtensionsClientInputs;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\AuthenticatorAttestationResponseValidator;
+use Webauthn\AuthenticatorSelectionCriteria;
+use Webauthn\Bundle\Dto\AdditionalPublicKeyCredentialCreationOptionsRequest;
+use Webauthn\Bundle\Security\Storage\SessionStorage;
+use Webauthn\Bundle\Security\Storage\StoredData;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialDescriptor;
+use Webauthn\PublicKeyCredentialLoader;
+use Webauthn\PublicKeyCredentialSource;
+use Webauthn\PublicKeyCredentialSourceRepository;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+class AuthenticatorRegistrationHelper
+{
+    /**
+     * @var PublicKeyCredentialCreationOptionsFactory
+     */
+    private $publicKeyCredentialCreationOptionsFactory;
+
+    /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+
+    /**
+     * @var ValidatorInterface
+     */
+    private $validator;
+
+    /**
+     * @var PublicKeyCredentialSourceRepository
+     */
+    private $publicKeyCredentialSourceRepository;
+
+    /**
+     * @var PublicKeyCredentialLoader
+     */
+    private $publicKeyCredentialLoader;
+
+    /**
+     * @var AuthenticatorAttestationResponseValidator
+     */
+    private $authenticatorAttestationResponseValidator;
+
+    /**
+     * @var SessionStorage
+     */
+    private $optionsStorage;
+
+    /**
+     * @var HttpMessageFactoryInterface
+     */
+    private $httpMessageFactory;
+
+    public function __construct(PublicKeyCredentialCreationOptionsFactory $publicKeyCredentialCreationOptionsFactory, SerializerInterface $serializer, ValidatorInterface $validator, PublicKeyCredentialSourceRepository $publicKeyCredentialSourceRepository, PublicKeyCredentialLoader $publicKeyCredentialLoader, AuthenticatorAttestationResponseValidator $authenticatorAttestationResponseValidator, SessionStorage $optionsStorage, HttpMessageFactoryInterface $httpMessageFactory)
+    {
+        $this->publicKeyCredentialCreationOptionsFactory = $publicKeyCredentialCreationOptionsFactory;
+        $this->serializer = $serializer;
+        $this->validator = $validator;
+        $this->publicKeyCredentialSourceRepository = $publicKeyCredentialSourceRepository;
+        $this->publicKeyCredentialLoader = $publicKeyCredentialLoader;
+        $this->authenticatorAttestationResponseValidator = $authenticatorAttestationResponseValidator;
+        $this->optionsStorage = $optionsStorage;
+        $this->httpMessageFactory = $httpMessageFactory;
+    }
+
+    /**
+     * @throws AssertionFailedException
+     */
+    public function generateOptions(PublicKeyCredentialUserEntity $userEntity, Request $request): PublicKeyCredentialCreationOptions
+    {
+        $content = $request->getContent();
+        Assertion::string($content, 'Invalid data');
+        $creationOptionsRequest = $this->getAdditionalPublicKeyCredentialCreationOptionsRequest($content);
+        $authenticatorSelection = null !== $creationOptionsRequest->authenticatorSelection ? AuthenticatorSelectionCriteria::createFromArray($creationOptionsRequest->authenticatorSelection) : null;
+        $extensions = null !== $creationOptionsRequest->extensions ? AuthenticationExtensionsClientInputs::createFromArray($creationOptionsRequest->extensions) : null;
+        $publicKeyCredentialCreationOptions = $this->publicKeyCredentialCreationOptionsFactory->create(
+            'default',
+            $userEntity,
+            $this->getUserAuthenticatorList($userEntity),
+            $authenticatorSelection,
+            $creationOptionsRequest->attestation,
+            $extensions
+        );
+        $this->optionsStorage->store($request, new StoredData($publicKeyCredentialCreationOptions, $userEntity));
+
+        return $publicKeyCredentialCreationOptions;
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function validateResponse(PublicKeyCredentialUserEntity $user, Request $request): PublicKeyCredentialSource
+    {
+        $storedData = $this->optionsStorage->get($request);
+        $assertion = $request->getContent();
+        Assertion::string($assertion, 'Invalid assertion');
+        $assertion = trim($assertion);
+        $publicKeyCredential = $this->publicKeyCredentialLoader->load($assertion);
+        $response = $publicKeyCredential->getResponse();
+        if (!$response instanceof AuthenticatorAttestationResponse) {
+            throw new AuthenticationException('Invalid assertion');
+        }
+
+        $psr7Request = $this->httpMessageFactory->createRequest($request);
+
+        $options = $storedData->getPublicKeyCredentialOptions();
+        Assertion::isInstanceOf($options, PublicKeyCredentialCreationOptions::class, 'Invalid options');
+        $userEntity = $storedData->getPublicKeyCredentialUserEntity();
+        Assertion::notNull($userEntity, 'Invalid user');
+        Assertion::eq($user->getId(), $userEntity->getId(), PublicKeyCredentialUserEntity::class, 'Invalid user');
+
+        $publicKeyCredentialSource = $this->authenticatorAttestationResponseValidator->check(
+            $response,
+            $options,
+            $psr7Request
+        );
+        $this->publicKeyCredentialSourceRepository->saveCredentialSource($publicKeyCredentialSource);
+
+        return $publicKeyCredentialSource;
+    }
+
+    /**
+     * @throws AssertionFailedException
+     */
+    private function getAdditionalPublicKeyCredentialCreationOptionsRequest(string $content): AdditionalPublicKeyCredentialCreationOptionsRequest
+    {
+        $data = $this->serializer->deserialize($content, AdditionalPublicKeyCredentialCreationOptionsRequest::class, 'json');
+        Assertion::isInstanceOf($data, AdditionalPublicKeyCredentialCreationOptionsRequest::class, 'Invalid data');
+        $errors = $this->validator->validate($data);
+        if (\count($errors) > 0) {
+            $messages = [];
+            foreach ($errors as $error) {
+                $messages[] = $error->getPropertyPath().': '.$error->getMessage();
+            }
+            throw new RuntimeException(implode("\n", $messages));
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return PublicKeyCredentialDescriptor[]
+     */
+    private function getUserAuthenticatorList(PublicKeyCredentialUserEntity $userEntity): array
+    {
+        $list = $this->publicKeyCredentialSourceRepository->findAllForUserEntity($userEntity);
+
+        return array_map(static function (PublicKeyCredentialSource $publicKeyCredentialSource): PublicKeyCredentialDescriptor {
+            return $publicKeyCredentialSource->getPublicKeyCredentialDescriptor();
+        }, $list);
+    }
+}

--- a/src/webauthn/src/PublicKeyCredentialCreationOptions.php
+++ b/src/webauthn/src/PublicKeyCredentialCreationOptions.php
@@ -59,14 +59,14 @@ class PublicKeyCredentialCreationOptions extends PublicKeyCredentialOptions
      * @param PublicKeyCredentialParameters[] $pubKeyCredParams
      * @param PublicKeyCredentialDescriptor[] $excludeCredentials
      */
-    public function __construct(PublicKeyCredentialRpEntity $rp, PublicKeyCredentialUserEntity $user, string $challenge, array $pubKeyCredParams, ?int $timeout, array $excludeCredentials, AuthenticatorSelectionCriteria $authenticatorSelection, string $attestation, ?AuthenticationExtensionsClientInputs $extensions)
+    public function __construct(PublicKeyCredentialRpEntity $rp, PublicKeyCredentialUserEntity $user, string $challenge, array $pubKeyCredParams, ?int $timeout = null, array $excludeCredentials = [], ?AuthenticatorSelectionCriteria $authenticatorSelection = null, string $attestation = self::ATTESTATION_CONVEYANCE_PREFERENCE_NONE, ?AuthenticationExtensionsClientInputs $extensions = null)
     {
         parent::__construct($challenge, $timeout, $extensions);
         $this->rp = $rp;
         $this->user = $user;
         $this->pubKeyCredParams = array_values($pubKeyCredParams);
         $this->excludeCredentials = array_values($excludeCredentials);
-        $this->authenticatorSelection = $authenticatorSelection;
+        $this->authenticatorSelection = $authenticatorSelection ?? new AuthenticatorSelectionCriteria();
         $this->attestation = $attestation;
     }
 


### PR DESCRIPTION
This PR fixes #114 by allowing default values for the constructor of the object PublicKeyCredentialCreationOptions