### PR TITLE
Request content type can be null

### DIFF
--- a/src/symfony/src/Security/Firewall/WebauthnListener.php
+++ b/src/symfony/src/Security/Firewall/WebauthnListener.php
@@ -74,7 +74,7 @@ class WebauthnListener
 
             return;
         }
-        if (false === mb_strpos($request->getRequestFormat(), 'json') && false === mb_strpos($request->getContentType(), 'json')) {
+        if (false === mb_strpos($request->getRequestFormat(), 'json') && false === mb_strpos($request->getContentType() ?: '', 'json')) {
             $this->logger->debug('The request format and the content type are not JSON. Ignored');
 
             return;


### PR DESCRIPTION
`mb_strpos` accept only strings as first argument. Make sure the request content type is a valid string and not null.