### PR TITLE
Set null

### DIFF
--- a/src/webauthn/src/Server.php
+++ b/src/webauthn/src/Server.php
@@ -117,7 +117,7 @@ class Server
      */
     private $securedRelyingPartyId = [];
 
-    public function __construct(PublicKeyCredentialRpEntity $relyingParty, PublicKeyCredentialSourceRepository $publicKeyCredentialSourceRepository, ?MetadataStatementRepository $metadataStatementRepository)
+    public function __construct(PublicKeyCredentialRpEntity $relyingParty, PublicKeyCredentialSourceRepository $publicKeyCredentialSourceRepository, ?MetadataStatementRepository $metadataStatementRepository = null)
     {
         if (null !== $metadataStatementRepository) {
             @trigger_error('The argument "metadataStatementRepository" is deprecated since version 3.3 and will be removed in 4.0. Please use the method "setMetadataStatementRepository".', E_USER_DEPRECATED);
@@ -142,7 +142,7 @@ class Server
         $this->publicKeyCredentialSourceRepository = $publicKeyCredentialSourceRepository;
         $this->tokenBindingHandler = new IgnoreTokenBindingHandler();
         $this->extensionOutputCheckerHandler = new ExtensionOutputCheckerHandler();
-        $this->setMetadataStatementRepository($metadataStatementRepository);
+        $this->metadataStatementRepository = $metadataStatementRepository;
     }
 
     public function setMetadataStatementRepository(MetadataStatementRepository $metadataStatementRepository): self


### PR DESCRIPTION
The ```$metadataStatementRepository``` is always ```null``` in the constructor, and the ```setMetadataStatementRepository()``` method does not allow ```null```.

As a side note, shouldn't we change the ```__construct()``` param ```?MetadataStatementRepository $metadataStatementRepository``` to ```?MetadataStatementRepository $metadataStatementRepository = null``` so people can already start to remove it in their code?