### PR TITLE
Remove obsolete import from `AppleAttestationStatementSupport`

### DIFF
--- a/src/webauthn/src/AttestationStatement/AppleAttestationStatementSupport.php
+++ b/src/webauthn/src/AttestationStatement/AppleAttestationStatementSupport.php
@@ -21,7 +21,6 @@ use Cose\Key\Ec2Key;
 use Cose\Key\Key;
 use Cose\Key\RsaKey;
 use function count;
-use FG\ASN1\Universal\Sequence;
 use function Safe\openssl_pkey_get_public;
 use function Safe\sprintf;
 use Webauthn\AuthenticatorData;


### PR DESCRIPTION
`FG\ASN1\Universal\Sequence` is not referenced within this class.