### PR TITLE
Consistently use inline doc comments for `@see` annotations

### DIFF
--- a/src/webauthn/src/AuthenticatorAssertionResponseValidator.php
+++ b/src/webauthn/src/AuthenticatorAssertionResponseValidator.php
@@ -101,21 +101,21 @@ class AuthenticatorAssertionResponseValidator
                 'host' => $request->getUri()->getHost(),
                 'userHandle' => $userHandle,
             ]);
-            /* @see 7.2.1 */
+            /** @see 7.2.1 */
             if (0 !== count($publicKeyCredentialRequestOptions->getAllowCredentials())) {
                 Assertion::true($this->isCredentialIdAllowed($credentialId, $publicKeyCredentialRequestOptions->getAllowCredentials()), 'The credential ID is not allowed.');
             }
 
-            /* @see 7.2.2 */
+            /** @see 7.2.2 */
             $publicKeyCredentialSource = $this->publicKeyCredentialSourceRepository->findOneByCredentialId($credentialId);
             Assertion::notNull($publicKeyCredentialSource, 'The credential ID is invalid.');
 
-            /* @see 7.2.3 */
+            /** @see 7.2.3 */
             $attestedCredentialData = $publicKeyCredentialSource->getAttestedCredentialData();
             $credentialUserHandle = $publicKeyCredentialSource->getUserHandle();
             $responseUserHandle = $authenticatorAssertionResponse->getUserHandle();
 
-            /* @see 7.2.2 User Handle*/
+            /** @see 7.2.2 User Handle*/
             if (null !== $userHandle) { //If the user was identified before the authentication ceremony was initiated,
                 Assertion::eq($credentialUserHandle, $userHandle, 'Invalid user handle');
                 if (null !== $responseUserHandle && '' !== $responseUserHandle) {
@@ -140,10 +140,10 @@ class AuthenticatorAssertionResponseValidator
             /** @see 7.2.6 */
             $C = $authenticatorAssertionResponse->getClientDataJSON();
 
-            /* @see 7.2.7 */
+            /** @see 7.2.7 */
             Assertion::eq('webauthn.get', $C->getType(), 'The client data type is not "webauthn.get".');
 
-            /* @see 7.2.8 */
+            /** @see 7.2.8 */
             Assertion::true(hash_equals($publicKeyCredentialRequestOptions->getChallenge(), $C->getChallenge()), 'Invalid challenge.');
 
             /** @see 7.2.9 */
@@ -160,7 +160,7 @@ class AuthenticatorAssertionResponseValidator
             $rpIdLength = mb_strlen($facetId);
             Assertion::eq(mb_substr('.'.$clientDataRpId, -($rpIdLength + 1)), '.'.$facetId, 'rpId mismatch.');
 
-            /* @see 7.2.10 */
+            /** @see 7.2.10 */
             if (null !== $C->getTokenBinding()) {
                 $this->tokenBindingHandler->check($C->getTokenBinding(), $request);
             }
@@ -169,14 +169,14 @@ class AuthenticatorAssertionResponseValidator
             $rpIdHash = hash('sha256', $facetId, true);
             Assertion::true(hash_equals($rpIdHash, $authenticatorAssertionResponse->getAuthenticatorData()->getRpIdHash()), 'rpId hash mismatch.');
 
-            /* @see 7.2.12 */
+            /** @see 7.2.12 */
             Assertion::true($authenticatorAssertionResponse->getAuthenticatorData()->isUserPresent(), 'User was not present');
-            /* @see 7.2.13 */
+            /** @see 7.2.13 */
             if (AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_REQUIRED === $publicKeyCredentialRequestOptions->getUserVerification()) {
                 Assertion::true($authenticatorAssertionResponse->getAuthenticatorData()->isUserVerified(), 'User authentication required.');
             }
 
-            /* @see 7.2.14 */
+            /** @see 7.2.14 */
             $extensionsClientOutputs = $authenticatorAssertionResponse->getAuthenticatorData()->getExtensions();
             if (null !== $extensionsClientOutputs) {
                 $this->extensionOutputCheckerHandler->check(
@@ -188,7 +188,7 @@ class AuthenticatorAssertionResponseValidator
             /** @see 7.2.15 */
             $getClientDataJSONHash = hash('sha256', $authenticatorAssertionResponse->getClientDataJSON()->getRawData(), true);
 
-            /* @see 7.2.16 */
+            /** @see 7.2.16 */
             $dataToVerify = $authenticatorAssertionResponse->getAuthenticatorData()->getAuthData().$getClientDataJSONHash;
             $signature = $authenticatorAssertionResponse->getSignature();
             $coseKey = new Key($credentialPublicKeyStream->getNormalizedData());
@@ -197,7 +197,7 @@ class AuthenticatorAssertionResponseValidator
             $signature = CoseSignatureFixer::fix($signature, $algorithm);
             Assertion::true($algorithm->verify($dataToVerify, $coseKey, $signature), 'Invalid signature.');
 
-            /* @see 7.2.17 */
+            /** @see 7.2.17 */
             $storedCounter = $publicKeyCredentialSource->getCounter();
             $responseCounter = $authenticatorAssertionResponse->getAuthenticatorData()->getSignCount();
             if (0 !== $responseCounter || 0 !== $storedCounter) {
@@ -206,7 +206,7 @@ class AuthenticatorAssertionResponseValidator
             $publicKeyCredentialSource->setCounter($responseCounter);
             $this->publicKeyCredentialSourceRepository->saveCredentialSource($publicKeyCredentialSource);
 
-            /* @see 7.2.18 */
+            /** @see 7.2.18 */
             //All good. We can continue.
             $this->logger->info('The assertion is valid');
             $this->logger->debug('Public Key Credential Source', ['publicKeyCredentialSource' => $publicKeyCredentialSource]);

--- a/src/webauthn/src/AuthenticatorAttestationResponseValidator.php
+++ b/src/webauthn/src/AuthenticatorAttestationResponseValidator.php
@@ -131,10 +131,10 @@ class AuthenticatorAttestationResponseValidator
             /** @see 7.1.2 */
             $C = $authenticatorAttestationResponse->getClientDataJSON();
 
-            /* @see 7.1.3 */
+            /** @see 7.1.3 */
             Assertion::eq('webauthn.create', $C->getType(), 'The client data type is not "webauthn.create".');
 
-            /* @see 7.1.4 */
+            /** @see 7.1.4 */
             Assertion::true(hash_equals($publicKeyCredentialCreationOptions->getChallenge(), $C->getChallenge()), 'Invalid challenge.');
 
             /** @see 7.1.5 */
@@ -154,7 +154,7 @@ class AuthenticatorAttestationResponseValidator
                 Assertion::eq('https', $scheme, 'Invalid scheme. HTTPS required.');
             }
 
-            /* @see 7.1.6 */
+            /** @see 7.1.6 */
             if (null !== $C->getTokenBinding()) {
                 $this->tokenBindingHandler->check($C->getTokenBinding(), $request);
             }
@@ -169,14 +169,14 @@ class AuthenticatorAttestationResponseValidator
             $rpIdHash = hash('sha256', $facetId, true);
             Assertion::true(hash_equals($rpIdHash, $attestationObject->getAuthData()->getRpIdHash()), 'rpId hash mismatch.');
 
-            /* @see 7.1.10 */
+            /** @see 7.1.10 */
             Assertion::true($attestationObject->getAuthData()->isUserPresent(), 'User was not present');
-            /* @see 7.1.11 */
+            /** @see 7.1.11 */
             if (AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_REQUIRED === $publicKeyCredentialCreationOptions->getAuthenticatorSelection()->getUserVerification()) {
                 Assertion::true($attestationObject->getAuthData()->isUserVerified(), 'User authentication required.');
             }
 
-            /* @see 7.1.12 */
+            /** @see 7.1.12 */
             $extensionsClientOutputs = $attestationObject->getAuthData()->getExtensions();
             if (null !== $extensionsClientOutputs) {
                 $this->extensionOutputCheckerHandler->check(
@@ -185,26 +185,26 @@ class AuthenticatorAttestationResponseValidator
                 );
             }
 
-            /* @see 7.1.13 */
+            /** @see 7.1.13 */
             $this->checkMetadataStatement($publicKeyCredentialCreationOptions, $attestationObject);
             $fmt = $attestationObject->getAttStmt()->getFmt();
             Assertion::true($this->attestationStatementSupportManager->has($fmt), 'Unsupported attestation statement format.');
 
-            /* @see 7.1.14 */
+            /** @see 7.1.14 */
             $attestationStatementSupport = $this->attestationStatementSupportManager->get($fmt);
             Assertion::true($attestationStatementSupport->isValid($clientDataJSONHash, $attestationObject->getAttStmt(), $attestationObject->getAuthData()), 'Invalid attestation statement.');
 
-            /* @see 7.1.15 */
-            /* @see 7.1.16 */
-            /* @see 7.1.17 */
+            /** @see 7.1.15 */
+            /** @see 7.1.16 */
+            /** @see 7.1.17 */
             Assertion::true($attestationObject->getAuthData()->hasAttestedCredentialData(), 'There is no attested credential data.');
             $attestedCredentialData = $attestationObject->getAuthData()->getAttestedCredentialData();
             Assertion::notNull($attestedCredentialData, 'There is no attested credential data.');
             $credentialId = $attestedCredentialData->getCredentialId();
             Assertion::null($this->publicKeyCredentialSource->findOneByCredentialId($credentialId), 'The credential ID already exists.');
 
-            /* @see 7.1.18 */
-            /* @see 7.1.19 */
+            /** @see 7.1.18 */
+            /** @see 7.1.19 */
             $publicKeyCredentialSource = $this->createPublicKeyCredentialSource(
                 $credentialId,
                 $attestedCredentialData,


### PR DESCRIPTION
Add the missing seconds asterisk to indicate that the comment is a doc comment.