### PR TITLE
Use intdiv() where possible

### DIFF
--- a/src/cose/src/Algorithm/Mac/Hmac.php
+++ b/src/cose/src/Algorithm/Mac/Hmac.php
@@ -23,7 +23,7 @@ abstract class Hmac implements Mac
         $this->checKey($key);
         $signature = hash_hmac($this->getHashAlgorithm(), $data, $key->get(-1), true);
 
-        return mb_substr($signature, 0, $this->getSignatureLength() / 8, '8bit');
+        return mb_substr($signature, 0, intdiv($this->getSignatureLength(), 8), '8bit');
     }
 
     public function verify(string $data, Key $key, string $signature): bool

--- a/src/cose/src/Algorithm/Signature/ECDSA/ECSignature.php
+++ b/src/cose/src/Algorithm/Signature/ECDSA/ECSignature.php
@@ -92,7 +92,7 @@ final class ECSignature
 
     private static function octetLength(string $data): int
     {
-        return (int) (mb_strlen($data, '8bit') / self::BYTE_SIZE);
+        return intdiv(mb_strlen($data, '8bit'), self::BYTE_SIZE);
     }
 
     private static function preparePositiveInteger(string $data): string


### PR DESCRIPTION
- Replace the manual integer division in ECSignature by an explicit call to
  intdiv().
- Use intdiv() to convert from Bits to Bytes in Hmac.

---------------

see: https://wiki.php.net/rfc/intdiv