### PR TITLE
Fix inaccurate return types

### DIFF
--- a/src/webauthn/src/PublicKeyCredentialRequestOptions.php
+++ b/src/webauthn/src/PublicKeyCredentialRequestOptions.php
@@ -128,7 +128,7 @@ class PublicKeyCredentialRequestOptions extends PublicKeyCredentialOptions
         return $this->userVerification;
     }
 
-    public static function createFromString(string $data): PublicKeyCredentialOptions
+    public static function createFromString(string $data): self
     {
         $data = json_decode($data, true);
         Assertion::isArray($data, 'Invalid data');
@@ -139,7 +139,7 @@ class PublicKeyCredentialRequestOptions extends PublicKeyCredentialOptions
     /**
      * @param mixed[] $json
      */
-    public static function createFromArray(array $json): PublicKeyCredentialOptions
+    public static function createFromArray(array $json): self
     {
         Assertion::keyExists($json, 'challenge', 'Invalid input. "challenge" is missing.');
 


### PR DESCRIPTION
The `createFromString` and `createFromArray` methods both indicate that they return the parent/extended class, while in reality they do (as expected/intended) create an instance of themselves.

The `self` return types were already present on the contract, so there was no need to adjust them there.