### PR TITLE
Fix handling of appid extension

### DIFF
--- a/src/webauthn/src/PublicKeyCredential.php
+++ b/src/webauthn/src/PublicKeyCredential.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Webauthn;
 
 use function Safe\json_encode;
+use Webauthn\AuthenticationExtensions\AuthenticationExtensionsClientOutputs;
 
 /**
  * @see https://www.w3.org/TR/webauthn/#iface-pkcredential
@@ -30,11 +31,17 @@ class PublicKeyCredential extends Credential
      */
     protected $response;
 
-    public function __construct(string $id, string $type, string $rawId, AuthenticatorResponse $response)
+	/**
+	 * @var AuthenticationExtensionsClientOutputs $clientExtensionResults
+	 */
+	protected $clientExtensionResults;
+
+	public function __construct(string $id, string $type, string $rawId, AuthenticatorResponse $response, AuthenticationExtensionsClientOutputs $clientExtensionResults)
     {
         parent::__construct($id, $type);
         $this->rawId = $rawId;
         $this->response = $response;
+		$this->clientExtensionResults = $clientExtensionResults;
     }
 
     public function __toString()
@@ -59,4 +66,8 @@ class PublicKeyCredential extends Credential
     {
         return new PublicKeyCredentialDescriptor($this->getType(), $this->getRawId(), $transport);
     }
+
+	public function getClientExtensionResults(): AuthenticationExtensionsClientOutputs {
+		return $this->clientExtensionResults;
+	}
 }


### PR DESCRIPTION
This fixes the compatibility with legacy U2F credentials.

First of all, thanks for maintaing this awesome library.

I'm currently developing a migration for legacy U2F credentials to Webauthn for the nextcloud app [twofactor_webauthn](https://github.com/nextcloud/twofactor_webauthn). I identified two small flaws in the handling of the appId extension which break compatibility with migrated credentials.

## 1. Authenticator vs. client extension outputs

 In the method `AuthenticatorAssertionResponseValidator::getFacedId()` the output of the extension is checked correctly but it's looked up in the wrong outputs (authenticator extension outputs). However, the appId extension is not producing any authenticator extension outputs. Instead, it only produces client extension outputs.

As a result, the appId extension is never enabled in the backend and `getFacedId()` always returns the rpId which will make the rpIdHash verification fail. If the appId extension is enabled rpIdHash should be compared to the hash of appId. 

Ref §7.2.15 of https://www.w3.org/TR/webauthn-2/#rp-op-verifying-assertion-step-rpid-hash
Ref https://www.w3.org/TR/webauthn-2/#sctn-appid-extension for more information about the appId extension (especially both types of outputs)

### The fix 

Webauthn distinguishes authentication and client extensions. The latter are not added to the authenticator extension outputs inside authenticatorData. Instead, they have to be manually retrieved and sent to the backend. 

To fix this, I added a new property clientExtensionResults to PublicKeyCredential that is automatically populated by the PublicKeyCredentialLoader. The frontend/client has to use the following code to enable this feature:

```javascript
const credentials = await navigator.credentials.get({ publicKey })
const challenge = {
    // Old code:
    id: credentials.id,
    type: credentials.type,
    rawId: credentials.rawId
    response: {
        authenticatorData: credentials.response.authenticatorData,
        // [...] omitted for brevity 
    },
    // New code:
    clientExtensionResults: credentials.getClientExtensionResults(),
}

// Send challenge back to the server
```


## 2. `$facetId` is used instead of `$rpId` for verification of origin

The verification of the rp origin should not be done using appId. The Webauthn specification does not state to handle the appId in any special way concerning the verification of origin. Only the verification of rpIdHash should be done using the appId/facetId.

This step also fails when using the appId extension because facetId/appId contains `https://` while clientDataRpId does not.

Ref §7.2.13 of https://www.w3.org/TR/webauthn-2/#sctn-verifying-assertion
Ref §10.1.2 of https://www.w3.org/TR/webauthn-2/#sctn-appid-extension (only the hash is mentioned)

### The fix

I moved the call to `getFacetId()` right before the hashing part. Now, the origin is verified using rpId and the rpIdHash verification is done using appId, if the extension is present and was handled correctly by the client.


## Conclusion

Your feedback is highly appreciated. 

If you consider this too much of a breaking change please let me know, so that I can open the PR against 4.0 (or any other branch). I could also introduce default values to the constructor of PublicKeyCredential to make clientExtensionResults optional.
