### PR TITLE
Remove unused `symfony/process` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,6 @@
         "symfony/dependency-injection": "^6.0",
         "symfony/framework-bundle": "^6.0",
         "symfony/http-client": "^6.0",
-        "symfony/process": "^6.0",
         "symfony/psr-http-message-bridge": "^2.0",
         "symfony/uid": "^6.0",
         "thecodingmachine/safe": "^2.0",

--- a/src/webauthn/composer.json
+++ b/src/webauthn/composer.json
@@ -32,7 +32,6 @@
         "psr/http-message": "^1.0",
         "psr/log": "^2.0|^3.0",
         "spomky-labs/cbor-php": "^3.0",
-        "symfony/process": "^6.0",
         "symfony/uid": "^6.0",
         "thecodingmachine/safe": "^2.0",
         "web-auth/cose-lib": "^4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

`Symfony\Component\Process` does not appear to be referenced anywhere, making this a useless dependency.