### PR TITLE
Remove unused `league/uri` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
         "ext-openssl": "*",
         "beberlei/assert": "^3.2",
         "fgrosse/phpasn1": "^2.1",
-        "league/uri": "^6.0",
         "nyholm/psr7": "^1.1",
         "paragonie/constant_time_encoding": "^2.4",
         "psr/http-client": "^1.0",

--- a/src/metadata-service/composer.json
+++ b/src/metadata-service/composer.json
@@ -23,7 +23,6 @@
         "php": ">=8.1",
         "ext-json": "*",
         "beberlei/assert": "^3.2",
-        "league/uri": "^6.0",
         "paragonie/constant_time_encoding": "^2.4",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

`League\Uri` does not appear to be referenced anywhere, making this a useless dependency.