### PR TITLE
[Bundle] Add missing required Symfony packages

### DIFF
--- a/src/symfony/composer.json
+++ b/src/symfony/composer.json
@@ -28,6 +28,9 @@
         "symfony/framework-bundle": "^6.0",
         "symfony/http-client": "^6.0",
         "symfony/psr-http-message-bridge": "^2.0",
+        "symfony/security-bundle": "^6.0",
+        "symfony/serializer": "^6.0",
+        "symfony/validator": "^6.0",
         "web-auth/webauthn-lib": "self.version",
         "web-token/jwt-signature": "^3.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

`WebauthnFactory` implements `FirewallListenerFactoryInterface` from the SecurityBundle and is always registered in the container by `security.php`. This means you currently get a fatal error when installing the bundle in an application without `SecurityBundle`.