### PR TITLE
Add link script to allow use a local clone in other projects

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: "Check file permissions"
         run: |
-          test "$(find . -type f -not -path './.git/*' -executable)" == ""
+          test "$(find ./src -type f -not -path './.git/*' -executable)" == ""
 
       - name: "Find non-printable ASCII characters"
         run: |

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -226,7 +226,7 @@ jobs:
 
       - name: "Check exported files"
         run: |
-          EXPECTED="LICENSE,README.md,SECURITY.md,composer.json,package.json"
+          EXPECTED="LICENSE,README.md,SECURITY.md,composer.json,link,package.json"
           CURRENT="$(git archive HEAD | tar --list --exclude="src" --exclude="src/*" | paste -s -d ",")"
           echo "CURRENT =${CURRENT}"
           echo "EXPECTED=${EXPECTED}"

--- a/composer.json
+++ b/composer.json
@@ -102,6 +102,7 @@
         "rector/rector": "^0.14",
         "roave/security-advisories": "dev-latest",
         "symfony/browser-kit": "^6.1",
+        "symfony/filesystem": "^6.1",
         "symfony/finder": "^6.1",
         "symfony/monolog-bundle": "^3.8",
         "symfony/phpunit-bridge": "^6.1",

--- a/link
+++ b/link
@@ -1,0 +1,62 @@
+#!/usr/bin/env php
+<?php
+
+if (!file_exists(__DIR__.'/vendor/autoload.php')) {
+    echo "Run `composer install` before you run the `link` script.\n";
+    exit(1);
+}
+
+require __DIR__.'/vendor/autoload.php';
+
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Links dependencies to components to a local clone of the main web-auth/webauthn-framework GitHub repository.
+ * Inspired by symfony/symfony and async-aws/aws
+ */
+
+$copy = false !== $k = array_search('--copy', $argv, true);
+$copy && array_splice($argv, $k, 1);
+$pathToProject = $argv[1] ?? getcwd();
+
+if (!is_dir("$pathToProject/vendor/web-auth")) {
+    echo 'Link (or copy) dependencies to components to a local clone of the main web-auth/webauthn-framework GitHub repository.'.PHP_EOL.PHP_EOL;
+    echo "Usage: $argv[0] /path/to/the/project".PHP_EOL;
+    echo '       Use `--copy` to copy dependencies instead of symlink'.PHP_EOL.PHP_EOL;
+    echo "The directory \"$pathToProject\" does not exist or the dependencies are not installed, did you forget to run \"composer install\" in your project?".PHP_EOL;
+    exit(1);
+}
+
+$packages = [];
+
+$filesystem = new Filesystem();
+$directories = glob(__DIR__.'/src/*', GLOB_ONLYDIR | GLOB_NOSORT);
+
+foreach ($directories as $dir) {
+    if ($filesystem->exists($composer = "$dir/composer.json")) {
+        $packages[json_decode(file_get_contents($composer))->name] = $dir;
+    }
+}
+
+foreach (glob("$pathToProject/vendor/web-auth/*", GLOB_ONLYDIR | GLOB_NOSORT) as $dir) {
+    $package = 'web-auth/'.basename($dir);
+    if (!$copy && is_link($dir)) {
+        echo "\"$package\" is already a symlink, skipping.".PHP_EOL;
+        continue;
+    }
+
+    if (!isset($packages[$package])) {
+        continue;
+    }
+
+    $packageDir = ('\\' === DIRECTORY_SEPARATOR || $copy) ? $packages[$package] : $filesystem->makePathRelative($packages[$package], dirname(realpath($dir)));
+    $filesystem->remove($dir);
+
+    if ($copy) {
+        $filesystem->mirror($packageDir, $dir);
+        echo "\"$package\" has been copied from \"$packages[$package]\".".PHP_EOL;
+    } else {
+        $filesystem->symlink(rtrim($packageDir, '/'), $dir);
+        echo "\"$package\" has been linked to \"$packages[$package]\".".PHP_EOL;
+    }
+}


### PR DESCRIPTION
Target branch: 4.3.x

- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Add a link script that links dependencies to components to a local clone of the main web-auth/webauthn-framework GitHub repository.
Inspired by symfony/symfony and async-aws/aws
