### PR TITLE
Replace fetch by XHR and remove _dispatchEvent

### DIFF
--- a/src/stimulus/Resources/assets/dist/controller.js
+++ b/src/stimulus/Resources/assets/dist/controller.js
@@ -3,93 +3,81 @@ import { startAuthentication, startRegistration } from '@simplewebauthn/browser'
 
 class default_1 extends Controller {
     initialize() {
-        this._dispatchEvent = this._dispatchEvent.bind(this);
         this._getData = this._getData.bind(this);
+        this.fetch = this.fetch.bind(this);
     }
     connect() {
-        const options = {
+        ({
             requestResultUrl: this.requestResultUrl || '/request',
             requestOptionsUrl: this.requestOptionsUrl || '/request/options',
             requestSuccessRedirectUri: this.requestSuccessRedirectUri || null,
             creationResultUrl: this.creationResultUrl || '/creation',
             creationOptionsUrl: this.creationOptionsUrl || '/creation/options',
             creationSuccessRedirectUri: this.creationSuccessRedirectUri || null,
-        };
-        this._dispatchEvent('webauthn:connect', { options });
+        });
     }
     async signin(event) {
         event.preventDefault();
         const data = this._getData();
-        const optionsHeaders = {
-            'Content-Type': 'application/json',
-        };
-        this._dispatchEvent('webauthn:request:options', { data, headers: optionsHeaders });
-        const resp = await fetch(this.requestOptionsUrlValue || '/request/options', {
-            method: 'POST',
-            headers: optionsHeaders,
-            body: JSON.stringify(data),
-        });
-        const respJson = await resp.json();
+        const resp = await this.fetch('POST', this.requestOptionsUrlValue || '/request/options', JSON.stringify(data));
+        const respJson = await resp.response;
         const asseResp = await startAuthentication(respJson);
-        const responseHeaders = {
-            'Content-Type': 'application/json',
-        };
-        this._dispatchEvent('webauthn:request:response', { response: asseResp, headers: responseHeaders });
-        const verificationResp = await fetch(this.requestResultUrlValue || '/request', {
-            method: 'POST',
-            headers: responseHeaders,
-            body: JSON.stringify(asseResp),
-        });
-        const verificationJSON = await verificationResp.json();
+        const verificationResp = await this.fetch('POST', this.requestResultUrlValue || '/request', JSON.stringify(asseResp));
+        const verificationJSON = await verificationResp.response;
         if (verificationJSON && verificationJSON.errorMessage === '') {
-            this._dispatchEvent('webauthn:request:success', verificationJSON);
             if (this.requestSuccessRedirectUriValue) {
                 window.location.replace(this.requestSuccessRedirectUriValue);
             }
         }
         else {
-            this._dispatchEvent('webauthn:request:failure', verificationJSON.errorMessage);
+            alert('Something bad happens :( - ' + verificationJSON.errorMessage);
         }
     }
     async signup(event) {
         event.preventDefault();
         const data = this._getData();
-        const optionsHeaders = {
-            'Content-Type': 'application/json',
-        };
-        this._dispatchEvent('webauthn:creation:options', { data, headers: optionsHeaders });
-        const resp = await fetch(this.creationOptionsUrlValue || '/creation/options', {
-            method: 'POST',
-            headers: optionsHeaders,
-            body: JSON.stringify(data),
-        });
-        const respJson = await resp.json();
+        const resp = await this.fetch('POST', this.creationOptionsUrlValue || '/creation/options', JSON.stringify(data));
+        const respJson = await resp.response;
         if (respJson.excludeCredentials === undefined) {
             respJson.excludeCredentials = [];
         }
         const attResp = await startRegistration(respJson);
-        const responseHeaders = {
-            'Content-Type': 'application/json',
-        };
-        this._dispatchEvent('webauthn:creation:response', { response: attResp, headers: responseHeaders });
-        const verificationResp = await fetch(this.creationResultUrlValue || '/creation', {
-            method: 'POST',
-            headers: responseHeaders,
-            body: JSON.stringify(attResp),
-        });
-        const verificationJSON = await verificationResp.json();
+        const verificationResp = await this.fetch('POST', this.creationResultUrlValue || '/creation', JSON.stringify(attResp));
+        const verificationJSON = await verificationResp.response;
         if (verificationJSON && verificationJSON.errorMessage === '') {
-            this._dispatchEvent('webauthn:creation:success', verificationJSON);
             if (this.creationSuccessRedirectUriValue) {
                 window.location.replace(this.creationSuccessRedirectUriValue);
             }
         }
         else {
-            this._dispatchEvent('webauthn:creation:failure', verificationJSON.errorMessage);
+            alert('Something bad happens :( - ' + verificationJSON.errorMessage);
         }
     }
-    _dispatchEvent(name, payload) {
-        this.element.dispatchEvent(new CustomEvent(name, { detail: payload, bubbles: true }));
+    fetch(method, url, body) {
+        return new Promise(function (resolve, reject) {
+            const xhr = new XMLHttpRequest();
+            xhr.open(method, url);
+            xhr.responseType = "json";
+            xhr.setRequestHeader('Content-Type', 'application/json');
+            xhr.onload = function () {
+                if (xhr.status >= 200 && xhr.status < 300) {
+                    resolve(xhr);
+                }
+                else {
+                    reject({
+                        status: xhr.status,
+                        statusText: xhr.statusText
+                    });
+                }
+            };
+            xhr.onerror = function () {
+                reject({
+                    status: xhr.status,
+                    statusText: xhr.statusText
+                });
+            };
+            xhr.send(body);
+        });
     }
     _getData() {
         let data = new FormData();

--- a/src/stimulus/Resources/assets/src/controller.ts
+++ b/src/stimulus/Resources/assets/src/controller.ts
@@ -21,8 +21,8 @@ export default class extends Controller {
     };
 
     initialize() {
-        this._dispatchEvent = this._dispatchEvent.bind(this);
         this._getData = this._getData.bind(this);
+        this.fetch = this.fetch.bind(this);
     }
 
     connect() {
@@ -34,88 +34,74 @@ export default class extends Controller {
             creationOptionsUrl: this.creationOptionsUrl || '/creation/options',
             creationSuccessRedirectUri: this.creationSuccessRedirectUri || null,
         };
-
-        this._dispatchEvent('webauthn:connect', {options});
     }
 
     async signin(event: Event) {
         event.preventDefault();
         const data = this._getData();
-        const optionsHeaders = {
-            'Content-Type': 'application/json',
-        };
-        this._dispatchEvent('webauthn:request:options', {data, headers: optionsHeaders});
-        const resp = await fetch(this.requestOptionsUrlValue || '/request/options', {
-            method: 'POST',
-            headers: optionsHeaders,
-            body: JSON.stringify(data),
-        });
-        const respJson = await resp.json();
+
+        const resp = await this.fetch('POST', this.requestOptionsUrlValue || '/request/options', JSON.stringify(data));
+        const respJson = await resp.response;
         const asseResp = await startAuthentication(respJson);
 
-        const responseHeaders = {
-            'Content-Type': 'application/json',
-        };
-
-        this._dispatchEvent('webauthn:request:response', {response: asseResp, headers: responseHeaders});
-        const verificationResp = await fetch(this.requestResultUrlValue || '/request', {
-            method: 'POST',
-            headers: responseHeaders,
-            body: JSON.stringify(asseResp),
-        });
-        const verificationJSON = await verificationResp.json();
+        const verificationResp = await this.fetch('POST', this.requestResultUrlValue || '/request', JSON.stringify(asseResp));
+        const verificationJSON = await verificationResp.response;
 
         if (verificationJSON && verificationJSON.errorMessage === '') {
-            this._dispatchEvent('webauthn:request:success', verificationJSON);
             if (this.requestSuccessRedirectUriValue) {
                 window.location.replace(this.requestSuccessRedirectUriValue);
             }
         } else {
-            this._dispatchEvent('webauthn:request:failure', verificationJSON.errorMessage);
+            alert('Something bad happens :( - '+verificationJSON.errorMessage);
         }
     }
 
     async signup(event: Event) {
         event.preventDefault();
         const data = this._getData();
-        const optionsHeaders = {
-            'Content-Type': 'application/json',
-        };
-        this._dispatchEvent('webauthn:creation:options', {data, headers: optionsHeaders});
-        const resp = await fetch(this.creationOptionsUrlValue || '/creation/options', {
-            method: 'POST',
-            headers: optionsHeaders,
-            body: JSON.stringify(data),
-        });
+        const resp = await this.fetch('POST', this.creationOptionsUrlValue || '/creation/options', JSON.stringify(data));
 
-        const respJson = await resp.json();
+        const respJson = await resp.response;
         if (respJson.excludeCredentials === undefined) {
             respJson.excludeCredentials = [];
         }
         const attResp = await startRegistration(respJson);
-        const responseHeaders = {
-            'Content-Type': 'application/json',
-        };
-        this._dispatchEvent('webauthn:creation:response', {response: attResp, headers: responseHeaders});
-        const verificationResp = await fetch(this.creationResultUrlValue || '/creation', {
-            method: 'POST',
-            headers: responseHeaders,
-            body: JSON.stringify(attResp),
-        });
+        const verificationResp = await this.fetch('POST', this.creationResultUrlValue || '/creation', JSON.stringify(attResp));
 
-        const verificationJSON = await verificationResp.json();
+        const verificationJSON = await verificationResp.response;
         if (verificationJSON && verificationJSON.errorMessage === '') {
-            this._dispatchEvent('webauthn:creation:success', verificationJSON);
             if (this.creationSuccessRedirectUriValue) {
                 window.location.replace(this.creationSuccessRedirectUriValue);
             }
         } else {
-            this._dispatchEvent('webauthn:creation:failure', verificationJSON.errorMessage);
+            alert('Something bad happens :( - '+verificationJSON.errorMessage);
         }
     }
 
-    _dispatchEvent(name: string, payload: any) {
-        this.element.dispatchEvent(new CustomEvent(name, {detail: payload, bubbles: true}));
+    fetch (method: string, url: string, body: string): Promise<XMLHttpRequest> {
+        return new Promise(function (resolve, reject) {
+            const xhr = new XMLHttpRequest();
+            xhr.open(method, url);
+            xhr.responseType = "json";
+            xhr.setRequestHeader('Content-Type', 'application/json')
+            xhr.onload = function () {
+                if (xhr.status >= 200 && xhr.status < 300) {
+                    resolve(xhr);
+                } else {
+                    reject({
+                        status: xhr.status,
+                        statusText: xhr.statusText
+                    });
+                }
+            };
+            xhr.onerror = function () {
+                reject({
+                    status: xhr.status,
+                    statusText: xhr.statusText
+                });
+            };
+            xhr.send(body);
+        });
     }
 
     _getData() {


### PR DESCRIPTION
Target branch: 
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [X] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

window.credentials API didn't work well on iOS when used with fetch.
This PR replace fetch usages by XMLHttpRequest with Promise.

Tested on iPhone 8 with iOS 15.7, it works much better.

I also remove this._dispatchEvent because it seems useless.
@Spomky What can we add in case of error to send the error message to the user ?
