### PR TITLE
Add missing secured_rp_ids from config in assertion response controller

### DIFF
--- a/src/symfony/src/Controller/AssertionControllerFactory.php
+++ b/src/symfony/src/Controller/AssertionControllerFactory.php
@@ -46,7 +46,7 @@ final class AssertionControllerFactory
         string $profile,
         OptionsStorage $optionStorage,
         RequestOptionsHandler $optionsHandler,
-        FailureHandler|AuthenticationFailureHandlerInterface $failureHandler,
+        FailureHandler|AuthenticationFailureHandlerInterface $failureHandler
     ): AssertionRequestController {
         return new AssertionRequestController(
             $this->serializer,
@@ -66,6 +66,7 @@ final class AssertionControllerFactory
         OptionsStorage $optionStorage,
         SuccessHandler $successHandler,
         FailureHandler|AuthenticationFailureHandlerInterface $failureHandler,
+        array $securedRelyingPartyIds
     ): AssertionResponseController {
         return new AssertionResponseController(
             $this->httpMessageFactory,
@@ -75,6 +76,7 @@ final class AssertionControllerFactory
             $optionStorage,
             $successHandler,
             $failureHandler,
+            $securedRelyingPartyIds
         );
     }
 }

--- a/src/symfony/src/Controller/AssertionControllerFactory.php
+++ b/src/symfony/src/Controller/AssertionControllerFactory.php
@@ -62,6 +62,9 @@ final class AssertionControllerFactory
         );
     }
 
+    /**
+     * @param string[] $securedRelyingPartyIds
+     */
     public function createAssertionResponseController(
         OptionsStorage $optionStorage,
         SuccessHandler $successHandler,

--- a/src/symfony/src/Controller/AssertionResponseController.php
+++ b/src/symfony/src/Controller/AssertionResponseController.php
@@ -23,6 +23,9 @@ use Webauthn\PublicKeyCredentialRequestOptions;
 
 final class AssertionResponseController
 {
+    /**
+     * @param string[] $securedRelyingPartyIds
+     */
     public function __construct(
         private readonly HttpMessageFactoryInterface $httpMessageFactory,
         private readonly PublicKeyCredentialLoader $publicKeyCredentialLoader,

--- a/src/symfony/src/Controller/AssertionResponseController.php
+++ b/src/symfony/src/Controller/AssertionResponseController.php
@@ -31,6 +31,7 @@ final class AssertionResponseController
         private readonly OptionsStorage $optionsStorage,
         private readonly SuccessHandler $successHandler,
         private readonly FailureHandler|AuthenticationFailureHandlerInterface $failureHandler,
+        private readonly array $securedRelyingPartyIds,
     ) {
     }
 
@@ -59,7 +60,8 @@ final class AssertionResponseController
                 $response,
                 $publicKeyCredentialRequestOptions,
                 $psr7Request,
-                $userEntity?->getId()
+                $userEntity?->getId(),
+                $this->securedRelyingPartyIds
             );
 
             return $this->successHandler->onSuccess($request);

--- a/src/symfony/src/DependencyInjection/WebauthnExtension.php
+++ b/src/symfony/src/DependencyInjection/WebauthnExtension.php
@@ -211,6 +211,7 @@ final class WebauthnExtension extends Extension implements PrependExtensionInter
                     new Reference($requestConfig['options_storage']),
                     new Reference($requestConfig['options_handler']),
                     new Reference($requestConfig['failure_handler']),
+                    $requestConfig['secured_rp_ids'],
                 ])
                 ->addTag(DynamicRouteCompilerPass::TAG, [
                     'method' => $requestConfig['options_method'],


### PR DESCRIPTION
Target branch: 
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [X] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Add missing secured_rp_ids from config in assertion response controller