### PR TITLE
EventDipatcher is not injected in Validators, no events are dispatched

### DIFF
--- a/src/symfony/src/Service/AuthenticatorAssertionResponseValidator.php
+++ b/src/symfony/src/Service/AuthenticatorAssertionResponseValidator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Webauthn\Bundle\Service;
 
 use Cose\Algorithm\Manager;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 use Webauthn\AuthenticationExtensions\ExtensionOutputCheckerHandler;
@@ -23,7 +24,8 @@ final class AuthenticatorAssertionResponseValidator extends BaseAuthenticatorAss
         PublicKeyCredentialSourceRepository $publicKeyCredentialSourceRepository,
         ?TokenBindingHandler $tokenBindingHandler,
         ExtensionOutputCheckerHandler $extensionOutputCheckerHandler,
-        ?Manager $algorithmManager
+        ?Manager $algorithmManager,
+        ?EventDispatcherInterface $eventDispatcher,
     ) {
         trigger_deprecation(
             'web-auth/webauthn-symfony-bundle',
@@ -39,7 +41,8 @@ final class AuthenticatorAssertionResponseValidator extends BaseAuthenticatorAss
             $publicKeyCredentialSourceRepository,
             $tokenBindingHandler,
             $extensionOutputCheckerHandler,
-            $algorithmManager
+            $algorithmManager,
+            $eventDispatcher
         );
     }
 

--- a/src/symfony/src/Service/AuthenticatorAttestationResponseValidator.php
+++ b/src/symfony/src/Service/AuthenticatorAttestationResponseValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\Service;
 
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 use Webauthn\AttestationStatement\AttestationStatementSupportManager;
@@ -23,7 +24,8 @@ final class AuthenticatorAttestationResponseValidator extends BaseAuthenticatorA
         AttestationStatementSupportManager $attestationStatementSupportManager,
         PublicKeyCredentialSourceRepository $publicKeyCredentialSource,
         ?TokenBindingHandler $tokenBindingHandler,
-        ExtensionOutputCheckerHandler $extensionOutputCheckerHandler
+        ExtensionOutputCheckerHandler $extensionOutputCheckerHandler,
+        ?EventDispatcherInterface $eventDispatcher,
     ) {
         trigger_deprecation(
             'web-auth/webauthn-symfony-bundle',
@@ -39,7 +41,8 @@ final class AuthenticatorAttestationResponseValidator extends BaseAuthenticatorA
             $attestationStatementSupportManager,
             $publicKeyCredentialSource,
             $tokenBindingHandler,
-            $extensionOutputCheckerHandler
+            $extensionOutputCheckerHandler,
+            $eventDispatcher,
         );
     }
 

--- a/src/webauthn/src/AuthenticatorAssertionResponseValidator.php
+++ b/src/webauthn/src/AuthenticatorAssertionResponseValidator.php
@@ -38,13 +38,12 @@ class AuthenticatorAssertionResponseValidator
 
     private LoggerInterface $logger;
 
-    private ?EventDispatcherInterface $eventDispatcher = null;
-
     public function __construct(
         private readonly PublicKeyCredentialSourceRepository $publicKeyCredentialSourceRepository,
         private readonly ?TokenBindingHandler $tokenBindingHandler,
         private readonly ExtensionOutputCheckerHandler $extensionOutputCheckerHandler,
         private readonly ?Manager $algorithmManager,
+        private ?EventDispatcherInterface $eventDispatcher = null,
     ) {
         if ($this->tokenBindingHandler !== null) {
             trigger_deprecation(
@@ -63,12 +62,14 @@ class AuthenticatorAssertionResponseValidator
         TokenBindingHandler $tokenBindingHandler,
         ExtensionOutputCheckerHandler $extensionOutputCheckerHandler,
         ?Manager $algorithmManager,
+        EventDispatcherInterface $eventDispatcher = null,
     ): self {
         return new self(
             $publicKeyCredentialSourceRepository,
             $tokenBindingHandler,
             $extensionOutputCheckerHandler,
-            $algorithmManager
+            $algorithmManager,
+            $eventDispatcher,
         );
     }
 
@@ -292,6 +293,13 @@ class AuthenticatorAssertionResponseValidator
 
     public function setEventDispatcher(EventDispatcherInterface $eventDispatcher): self
     {
+        trigger_deprecation(
+            'web-auth/webauthn-symfony-bundle',
+            '4.4.2',
+            'The method "setEventDispatcher" is deprecated since 4.4.2 and will be removed in 5.0.0. Please use "$eventDispatcher" parameter in __construct method instead.'
+        );
+
+
         $this->eventDispatcher = $eventDispatcher;
 
         return $this;

--- a/src/webauthn/src/AuthenticatorAssertionResponseValidator.php
+++ b/src/webauthn/src/AuthenticatorAssertionResponseValidator.php
@@ -299,7 +299,6 @@ class AuthenticatorAssertionResponseValidator
             'The method "setEventDispatcher" is deprecated since 4.4.2 and will be removed in 5.0.0. Please use "$eventDispatcher" parameter in __construct method instead.'
         );
 
-
         $this->eventDispatcher = $eventDispatcher;
 
         return $this;

--- a/src/webauthn/src/AuthenticatorAttestationResponseValidator.php
+++ b/src/webauthn/src/AuthenticatorAttestationResponseValidator.php
@@ -44,13 +44,12 @@ class AuthenticatorAttestationResponseValidator
 
     private ?CertificateChainValidator $certificateChainValidator = null;
 
-    private ?EventDispatcherInterface $eventDispatcher = null;
-
     public function __construct(
         private readonly AttestationStatementSupportManager $attestationStatementSupportManager,
         private readonly PublicKeyCredentialSourceRepository $publicKeyCredentialSource,
         private readonly ?TokenBindingHandler $tokenBindingHandler,
         private readonly ExtensionOutputCheckerHandler $extensionOutputCheckerHandler,
+        private ?EventDispatcherInterface $eventDispatcher = null,
     ) {
         if ($this->tokenBindingHandler !== null) {
             trigger_deprecation(
@@ -66,13 +65,15 @@ class AuthenticatorAttestationResponseValidator
         AttestationStatementSupportManager $attestationStatementSupportManager,
         PublicKeyCredentialSourceRepository $publicKeyCredentialSource,
         TokenBindingHandler $tokenBindingHandler,
-        ExtensionOutputCheckerHandler $extensionOutputCheckerHandler
+        ExtensionOutputCheckerHandler $extensionOutputCheckerHandler,
+        EventDispatcherInterface $eventDispatcher = null,
     ): self {
         return new self(
             $attestationStatementSupportManager,
             $publicKeyCredentialSource,
             $tokenBindingHandler,
             $extensionOutputCheckerHandler,
+            $eventDispatcher,
         );
     }
 
@@ -85,6 +86,12 @@ class AuthenticatorAttestationResponseValidator
 
     public function setEventDispatcher(EventDispatcherInterface $eventDispatcher): self
     {
+        trigger_deprecation(
+            'web-auth/webauthn-symfony-bundle',
+            '4.4.2',
+            'The method "setEventDispatcher" is deprecated since 4.4.2 and will be removed in 5.0.0. Please use "$eventDispatcher" parameter in __construct method instead.'
+        );
+
         $this->eventDispatcher = $eventDispatcher;
 
         return $this;

--- a/tests/library/Functional/AbstractTestCase.php
+++ b/tests/library/Functional/AbstractTestCase.php
@@ -21,6 +21,7 @@ use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Finder\Finder;
 use Webauthn\AttestationStatement\AndroidKeyAttestationStatementSupport;
 use Webauthn\AttestationStatement\AndroidSafetyNetAttestationStatementSupport;
@@ -116,7 +117,8 @@ abstract class AbstractTestCase extends TestCase
                 $credentialRepository,
                 new TokenBindingNotSupportedHandler(),
                 new ExtensionOutputCheckerHandler(),
-                $this->getAlgorithmManager()
+                $this->getAlgorithmManager(),
+                new EventDispatcher()
             );
         }
 

--- a/tests/library/Unit/AttestationStatement/TPMAttestationStatementSupportTest.php
+++ b/tests/library/Unit/AttestationStatement/TPMAttestationStatementSupportTest.php
@@ -8,6 +8,7 @@ use Http\Mock\Client;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\ServerRequest;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Webauthn\AttestationStatement\AttestationObjectLoader;
 use Webauthn\AttestationStatement\AttestationStatementSupportManager;
 use Webauthn\AttestationStatement\NoneAttestationStatementSupport;
@@ -57,6 +58,7 @@ final class TPMAttestationStatementSupportTest extends TestCase
             $pkSourceRepository,
             IgnoreTokenBindingHandler::create(),
             ExtensionOutputCheckerHandler::create(),
+            new EventDispatcher()
         )->enableMetadataStatementSupport(
             $metadataStatementRepository,
             $metadataStatementRepository,


### PR DESCRIPTION
Target branch: 4.4.x

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [X] Includes Deprecations

Fix:
* Inject the EventDispatcher if available in:
  * `Webauthn\AuthenticatorAttestationResponseValidator`
  * `Webauthn\AuthenticatorAssertionResponseValidator`
  * `Webauthn\Bundle\AuthenticatorAttestationResponseValidator`
  * `Webauthn\Bundle\AuthenticatorAssertionResponseValidator`


New deprecated methods:
* `Webauthn\AuthenticatorAssertionResponseValidator::setEventDispatcher` is now deprecated
* `Webauthn\AuthenticatorAttestationResponseValidator::setEventDispatcher` is now deprecated