### PR TITLE
Token binding handlers shall be nullable (#347)

### DIFF
--- a/src/webauthn/src/AuthenticatorAssertionResponseValidator.php
+++ b/src/webauthn/src/AuthenticatorAssertionResponseValidator.php
@@ -59,7 +59,7 @@ class AuthenticatorAssertionResponseValidator
 
     public static function create(
         PublicKeyCredentialSourceRepository $publicKeyCredentialSourceRepository,
-        TokenBindingHandler $tokenBindingHandler,
+        ?TokenBindingHandler $tokenBindingHandler,
         ExtensionOutputCheckerHandler $extensionOutputCheckerHandler,
         ?Manager $algorithmManager,
         EventDispatcherInterface $eventDispatcher = null,

--- a/src/webauthn/src/AuthenticatorAttestationResponseValidator.php
+++ b/src/webauthn/src/AuthenticatorAttestationResponseValidator.php
@@ -64,7 +64,7 @@ class AuthenticatorAttestationResponseValidator
     public static function create(
         AttestationStatementSupportManager $attestationStatementSupportManager,
         PublicKeyCredentialSourceRepository $publicKeyCredentialSource,
-        TokenBindingHandler $tokenBindingHandler,
+        ?TokenBindingHandler $tokenBindingHandler,
         ExtensionOutputCheckerHandler $extensionOutputCheckerHandler,
         EventDispatcherInterface $eventDispatcher = null,
     ): self {


### PR DESCRIPTION
If not nullable, we always trigger a deprecation warning when we call the constructor of AuthenticatorAssertionResponseValidator and AuthenticatorAttestationResponseValidator.

Signed-off-by: Emmanuel Deloget <logout@free.fr>

Target branch: 4.5.x, 4.4.x
Resolves issue #347

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations
