### PR TITLE
Prevent PublicKeyCredentialLoader::load from throwing \JsonException

### DIFF
--- a/src/webauthn/src/PublicKeyCredentialLoader.php
+++ b/src/webauthn/src/PublicKeyCredentialLoader.php
@@ -119,7 +119,7 @@ class PublicKeyCredentialLoader implements CanLogData
             $this->logger->error('An error occurred', [
                 'exception' => $throwable,
             ]);
-            throw $throwable;
+            throw InvalidDataException::create($data, 'Unable to load the data', $throwable);
         }
     }
 

--- a/tests/library/Functional/AttestationTest.php
+++ b/tests/library/Functional/AttestationTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Webauthn\Tests\Functional;
 
 use ParagonIE\ConstantTime\Base64UrlSafe;
-use RangeException;
 use Webauthn\AttestedCredentialData;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\AuthenticatorData;
+use Webauthn\Exception\InvalidDataException;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialDescriptor;
 use Webauthn\Tests\MemoryPublicKeyCredentialSourceRepository;
@@ -23,8 +23,8 @@ final class AttestationTest extends AbstractTestCase
      */
     public function aResponseCannotBeLoaded(): void
     {
-        static::expectException(RangeException::class);
-        static::expectExceptionMessage('Incorrect padding');
+        static::expectException(InvalidDataException::class);
+        static::expectExceptionMessage('Unable to load the data');
         $response = '{"id":"wHU13DaUWRqIQq94SAfCG8jqUZGdW0N95hnchI3rG7s===","rawId":"wHU13DaUWRqIQq94SAfCG8jqUZGdW0N95hnchI3rG7s","response":{"authenticatorData":"lgTqgoJOmKStoUtEYtDXOo7EaRMNqRsZMHRZIp90o1kBAAAAag","signature":"MEYCIQD4faYQG08_xpmAxFwp33OObSPavG7iUCJimHhH2QwyVAIhAMVRovz5DR_itNGYzTpKgO2urLgx5F2mZf3U4INTRR74","userHandle":"MDFHN0VEWUMxQ1QxSjBUUVBIWEY3QVlGNUs","clientDataJSON":"eyJvcmlnaW4iOiJodHRwczovL3dlYmF1dGhuLnNwb21reS1sYWJzLmNvbSIsImNoYWxsZW5nZSI6IkhaaktrWURKTEgtVnF6bFgtaXpCcUc3Q1pvN0FVRmtobG12TnRHM1VKSjQiLCJ0eXBlIjoid2ViYXV0aG4uZ2V0In0"},"getClientExtensionResults":{},"type":"public-key"}';
         $this->getPublicKeyCredentialLoader()
             ->load($response);


### PR DESCRIPTION
… Use of library exception instead

Target branch: 4.5.x
Resolves issue #346 

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [x] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
