### PR TITLE
Merge release 4.5.1 into 4.6.x

### DIFF
--- a/.github/workflows/tweet.yml
+++ b/.github/workflows/tweet.yml
@@ -2,7 +2,7 @@ name: tweet
 on:
   push:
     tags:
-      - '*'
+      - '[0-9]+\.[0-9]+\.0'
   release:
     types: [ published ]
 

--- a/src/symfony/src/CredentialOptionsBuilder/ProfileBasedCreationOptionsBuilder.php
+++ b/src/symfony/src/CredentialOptionsBuilder/ProfileBasedCreationOptionsBuilder.php
@@ -97,9 +97,6 @@ final class ProfileBasedCreationOptionsBuilder implements PublicKeyCredentialCre
         string $content
     ): PublicKeyCredentialCreationOptionsRequest {
         $data = $this->serializer->deserialize($content, PublicKeyCredentialCreationOptionsRequest::class, 'json');
-        $data instanceof PublicKeyCredentialCreationOptionsRequest || throw new BadRequestHttpException(
-            'Invalid data'
-        );
         $errors = $this->validator->validate($data);
         if (count($errors) > 0) {
             $messages = [];

--- a/src/symfony/src/CredentialOptionsBuilder/ProfileBasedRequestOptionsBuilder.php
+++ b/src/symfony/src/CredentialOptionsBuilder/ProfileBasedRequestOptionsBuilder.php
@@ -82,9 +82,6 @@ final class ProfileBasedRequestOptionsBuilder implements PublicKeyCredentialRequ
                 AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT => true,
             ]
         );
-        $data instanceof ServerPublicKeyCredentialRequestOptionsRequest || throw new BadRequestHttpException(
-            'Invalid data'
-        );
         $errors = $this->validator->validate($data);
         if (count($errors) > 0) {
             $messages = [];

--- a/src/webauthn/src/AttestationStatement/TPMAttestationStatementSupport.php
+++ b/src/webauthn/src/AttestationStatement/TPMAttestationStatementSupport.php
@@ -63,7 +63,7 @@ final class TPMAttestationStatementSupport implements AttestationStatementSuppor
         $this->dispatcher = $eventDispatcher;
     }
 
-    public static function create(?Clock $clock = null): self
+    public static function create(null|Clock|ClockInterface $clock = null): self
     {
         return new self($clock);
     }

--- a/src/webauthn/src/AuthenticatorAssertionResponseValidator.php
+++ b/src/webauthn/src/AuthenticatorAssertionResponseValidator.php
@@ -106,7 +106,8 @@ class AuthenticatorAssertionResponseValidator implements CanLogData, CanDispatch
                 'web-auth/webauthn-lib',
                 '4.5.0',
                 sprintf(
-                    'The class "%s" is deprecated since 4.5.0 and will be removed in 5.0.0. Please inject the host as a string instead.',
+                    'Passing a %s to the method `check` of the class "%s" is deprecated since 4.5.0 and will be removed in 5.0.0. Please inject the host as a string instead.',
+                    ServerRequestInterface::class,
                     self::class
                 )
             );
@@ -323,7 +324,8 @@ class AuthenticatorAssertionResponseValidator implements CanLogData, CanDispatch
                 'web-auth/webauthn-lib',
                 '4.5.0',
                 sprintf(
-                    'The class "%s" is deprecated since 4.5.0 and will be removed in 5.0.0. Please inject the host as a string instead.',
+                    'Passing a %s to the method `createAuthenticatorAssertionResponseValidationSucceededEvent` of the class "%s" is deprecated since 4.5.0 and will be removed in 5.0.0. Please inject the host as a string instead.',
+                    ServerRequestInterface::class,
                     self::class
                 )
             );
@@ -351,7 +353,8 @@ class AuthenticatorAssertionResponseValidator implements CanLogData, CanDispatch
                 'web-auth/webauthn-lib',
                 '4.5.0',
                 sprintf(
-                    'The class "%s" is deprecated since 4.5.0 and will be removed in 5.0.0. Please inject the host as a string instead.',
+                    'Passing a %s to the method `createAuthenticatorAssertionResponseValidationFailedEvent` of the class "%s" is deprecated since 4.5.0 and will be removed in 5.0.0. Please inject the host as a string instead.',
+                    ServerRequestInterface::class,
                     self::class
                 )
             );

--- a/src/webauthn/src/AuthenticatorAttestationResponseValidator.php
+++ b/src/webauthn/src/AuthenticatorAttestationResponseValidator.php
@@ -134,7 +134,8 @@ class AuthenticatorAttestationResponseValidator implements CanLogData, CanDispat
                 'web-auth/webauthn-lib',
                 '4.5.0',
                 sprintf(
-                    'The class "%s" is deprecated since 4.5.0 and will be removed in 5.0.0. Please inject the host as a string instead.',
+                    'Passing a %s to the method `check` of the class "%s" is deprecated since 4.5.0 and will be removed in 5.0.0. Please inject the host as a string instead.',
+                    ServerRequestInterface::class,
                     self::class
                 )
             );
@@ -295,7 +296,8 @@ class AuthenticatorAttestationResponseValidator implements CanLogData, CanDispat
                 'web-auth/webauthn-lib',
                 '4.5.0',
                 sprintf(
-                    'The class "%s" is deprecated since 4.5.0 and will be removed in 5.0.0. Please inject the host as a string instead.',
+                    'Passing a %s to the method `createAuthenticatorAttestationResponseValidationSucceededEvent` of the class "%s" is deprecated since 4.5.0 and will be removed in 5.0.0. Please inject the host as a string instead.',
+                    ServerRequestInterface::class,
                     self::class
                 )
             );
@@ -319,7 +321,8 @@ class AuthenticatorAttestationResponseValidator implements CanLogData, CanDispat
                 'web-auth/webauthn-lib',
                 '4.5.0',
                 sprintf(
-                    'The class "%s" is deprecated since 4.5.0 and will be removed in 5.0.0. Please inject the host as a string instead.',
+                    'Passing a %s to the method `createAuthenticatorAttestationResponseValidationFailedEvent` of the class "%s" is deprecated since 4.5.0 and will be removed in 5.0.0. Please inject the host as a string instead.',
+                    ServerRequestInterface::class,
                     self::class
                 )
             );

--- a/src/webauthn/src/AuthenticatorSelectionCriteria.php
+++ b/src/webauthn/src/AuthenticatorSelectionCriteria.php
@@ -46,7 +46,7 @@ class AuthenticatorSelectionCriteria implements JsonSerializable
 
     private string $userVerification = self::USER_VERIFICATION_REQUIREMENT_PREFERRED;
 
-    private string $residentKey = self::RESIDENT_KEY_REQUIREMENT_PREFERRED;
+    private null|string $residentKey = self::RESIDENT_KEY_REQUIREMENT_PREFERRED;
 
     public static function create(): self
     {
@@ -78,7 +78,7 @@ class AuthenticatorSelectionCriteria implements JsonSerializable
         return $this;
     }
 
-    public function setResidentKey(string $residentKey): self
+    public function setResidentKey(null|string $residentKey): self
     {
         $this->residentKey = $residentKey;
         //$this->requireResidentKey = $residentKey === self::RESIDENT_KEY_REQUIREMENT_REQUIRED;
@@ -104,7 +104,7 @@ class AuthenticatorSelectionCriteria implements JsonSerializable
         return $this->userVerification;
     }
 
-    public function getResidentKey(): string
+    public function getResidentKey(): null|string
     {
         return $this->residentKey;
     }

--- a/src/webauthn/src/Event/AuthenticatorAssertionResponseValidationFailedEvent.php
+++ b/src/webauthn/src/Event/AuthenticatorAssertionResponseValidationFailedEvent.php
@@ -24,7 +24,8 @@ class AuthenticatorAssertionResponseValidationFailedEvent
                 'web-auth/webauthn-lib',
                 '4.5.0',
                 sprintf(
-                    'The class "%s" is deprecated since 4.5.0 and will be removed in 5.0.0. Please inject the host as a string instead.',
+                    'Passing a %s to the class "%s" is deprecated since 4.5.0 and will be removed in 5.0.0. Please inject the host as a string instead.',
+                    ServerRequestInterface::class,
                     self::class
                 )
             );

--- a/src/webauthn/src/Event/AuthenticatorAssertionResponseValidationSucceededEvent.php
+++ b/src/webauthn/src/Event/AuthenticatorAssertionResponseValidationSucceededEvent.php
@@ -24,7 +24,8 @@ class AuthenticatorAssertionResponseValidationSucceededEvent
                 'web-auth/webauthn-lib',
                 '4.5.0',
                 sprintf(
-                    'The class "%s" is deprecated since 4.5.0 and will be removed in 5.0.0. Please inject the host as a string instead.',
+                    'Passing a %s to the class "%s" is deprecated since 4.5.0 and will be removed in 5.0.0. Please inject the host as a string instead.',
+                    ServerRequestInterface::class,
                     self::class
                 )
             );

--- a/src/webauthn/src/Event/AuthenticatorAttestationResponseValidationFailedEvent.php
+++ b/src/webauthn/src/Event/AuthenticatorAttestationResponseValidationFailedEvent.php
@@ -22,7 +22,8 @@ class AuthenticatorAttestationResponseValidationFailedEvent
                 'web-auth/webauthn-lib',
                 '4.5.0',
                 sprintf(
-                    'The class "%s" is deprecated since 4.5.0 and will be removed in 5.0.0. Please inject the host as a string instead.',
+                    'Passing a %s to the class "%s" is deprecated since 4.5.0 and will be removed in 5.0.0. Please inject the host as a string instead.',
+                    ServerRequestInterface::class,
                     self::class
                 )
             );

--- a/src/webauthn/src/Event/AuthenticatorAttestationResponseValidationSucceededEvent.php
+++ b/src/webauthn/src/Event/AuthenticatorAttestationResponseValidationSucceededEvent.php
@@ -22,7 +22,8 @@ class AuthenticatorAttestationResponseValidationSucceededEvent
                 'web-auth/webauthn-lib',
                 '4.5.0',
                 sprintf(
-                    'The class "%s" is deprecated since 4.5.0 and will be removed in 5.0.0. Please inject the host as a string instead.',
+                    'Passing a %s to the class "%s" is deprecated since 4.5.0 and will be removed in 5.0.0. Please inject the host as a string instead.',
+                    ServerRequestInterface::class,
                     self::class
                 )
             );


### PR DESCRIPTION
### Release Notes for [4.5.1](https://github.com/web-auth/webauthn-framework/milestone/35)



### 4.5.1

- Total issues resolved: **1**
- Total pull requests resolved: **3**
- Total contributors: **2**

#### bug

 - [377: Allow resident key to be `null`](https://github.com/web-auth/webauthn-framework/pull/377) thanks to @Spomky
 - [367: The TPMAttestationStatementSupport::create method should allow PSR-20&hellip;](https://github.com/web-auth/webauthn-framework/pull/367) thanks to @Spomky

DX
--

 - [371: Improves deprecation messages](https://github.com/web-auth/webauthn-framework/pull/371) thanks to @Spomky and @TimWolla
