### PR TITLE
Fix typos

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.gitsplit.yml export-ignore
+/.typos.toml export-ignore
 /babel.config.js export-ignore
 /CODE_OF_CONDUCT.md export-ignore
 /deptrac.yaml export-ignore

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,21 @@
+[files]
+extend-exclude = [
+    "tests/metadataServices/",
+    "tests/blob.jwt"
+]
+[default]
+extend-ignore-re = [
+    "'\\{\"id\":\".+\\}';",
+    "'\\[\\{\".+\"\\}\\]';",
+    "'\\{\".+\"\\}';",
+    "'\\{\".+\\}'",
+    "'eHouz_Zi7-BmByHjJ_[A-Za-z0-9_-]+'",
+    "\"attestationObject\": \"[A-Za-z0-9_-]+\",",
+    "'mMihuIx9Luks[A-Za-z0-9_-]+'",
+    "\"Exemple FIDO2 authenticator de FIDO Alliance\""
+]
+[default.extend-words]
+cose = "cose"
+[default.extend-identifiers]
+"baDesc" = "baDesc"
+"getBaDesc" = "getBaDesc"

--- a/src/symfony/src/Resources/config/cose.php
+++ b/src/symfony/src/Resources/config/cose.php
@@ -30,48 +30,170 @@ return static function (ContainerConfigurator $container): void {
         ->class(Manager::class);
 
     $container
-        ->set('webauthn.cose.algoritm.RS1')
+        ->set('webauthn.cose.algorithm.RS1')
         ->class(RS1::class);
     $container
-        ->set('webauthn.cose.algoritm.RS256')
+        ->alias('webauthn.cose.algoritm.RS1', 'webauthn.cose.algorithm.RS1')
+        ->deprecate(
+            'web-auth/webauthn-symfony-bundle',
+            '4.7.0',
+            'The "%alias_id%" service alias is deprecated, use "%service_id%" instead.'
+        )
+    ;
+
+    $container
+        ->set('webauthn.cose.algorithm.RS256')
         ->class(RS256::class);
     $container
-        ->set('webauthn.cose.algoritm.RS384')
+        ->alias('webauthn.cose.algoritm.RS256', 'webauthn.cose.algorithm.RS256')
+        ->deprecate(
+            'web-auth/webauthn-symfony-bundle',
+            '4.7.0',
+            'The "%alias_id%" service alias is deprecated, use "%service_id%" instead.'
+        )
+    ;
+
+    $container
+        ->set('webauthn.cose.algorithm.RS384')
         ->class(RS384::class);
     $container
-        ->set('webauthn.cose.algoritm.RS512')
-        ->class(RS512::class);
+        ->alias('webauthn.cose.algoritm.RS384', 'webauthn.cose.algorithm.RS384')
+        ->deprecate(
+            'web-auth/webauthn-symfony-bundle',
+            '4.7.0',
+            'The "%alias_id%" service alias is deprecated, use "%service_id%" instead.'
+        )
+    ;
 
     $container
-        ->set('webauthn.cose.algoritm.PS256')
+        ->set('webauthn.cose.algorithm.RS512')
+        ->class(RS512::class);
+    $container
+        ->alias('webauthn.cose.algoritm.RS512', 'webauthn.cose.algorithm.RS512')
+        ->deprecate(
+            'web-auth/webauthn-symfony-bundle',
+            '4.7.0',
+            'The "%alias_id%" service alias is deprecated, use "%service_id%" instead.'
+        )
+    ;
+
+    $container
+        ->set('webauthn.cose.algorithm.PS256')
         ->class(PS256::class);
     $container
-        ->set('webauthn.cose.algoritm.PS384')
+        ->alias('webauthn.cose.algoritm.PS256', 'webauthn.cose.algorithm.PS256')
+        ->deprecate(
+            'web-auth/webauthn-symfony-bundle',
+            '4.7.0',
+            'The "%alias_id%" service alias is deprecated, use "%service_id%" instead.'
+        )
+    ;
+
+    $container
+        ->set('webauthn.cose.algorithm.PS384')
         ->class(PS384::class);
     $container
-        ->set('webauthn.cose.algoritm.PS512')
-        ->class(PS512::class);
+        ->alias('webauthn.cose.algoritm.PS384', 'webauthn.cose.algorithm.PS384')
+        ->deprecate(
+            'web-auth/webauthn-symfony-bundle',
+            '4.7.0',
+            'The "%alias_id%" service alias is deprecated, use "%service_id%" instead.'
+        )
+    ;
 
     $container
-        ->set('webauthn.cose.algoritm.ES256K')
+        ->set('webauthn.cose.algorithm.PS512')
+        ->class(PS512::class);
+    $container
+        ->alias('webauthn.cose.algoritm.PS512', 'webauthn.cose.algorithm.PS512')
+        ->deprecate(
+            'web-auth/webauthn-symfony-bundle',
+            '4.7.0',
+            'The "%alias_id%" service alias is deprecated, use "%service_id%" instead.'
+        )
+    ;
+
+    $container
+        ->set('webauthn.cose.algorithm.ES256K')
         ->class(ES256K::class);
     $container
-        ->set('webauthn.cose.algoritm.ES256')
-        ->class(ES256::class);
-    $container
-        ->set('webauthn.cose.algoritm.ES384')
-        ->class(ES384::class);
-    $container
-        ->set('webauthn.cose.algoritm.ES512')
-        ->class(ES512::class);
+        ->alias('webauthn.cose.algoritm.ES256K', 'webauthn.cose.algorithm.ES256K')
+        ->deprecate(
+            'web-auth/webauthn-symfony-bundle',
+            '4.7.0',
+            'The "%alias_id%" service alias is deprecated, use "%service_id%" instead.'
+        )
+    ;
 
     $container
-        ->set('webauthn.cose.algoritm.ED256')
+        ->set('webauthn.cose.algorithm.ES256')
+        ->class(ES256::class);
+    $container
+        ->alias('webauthn.cose.algoritm.ES256', 'webauthn.cose.algorithm.ES256')
+        ->deprecate(
+            'web-auth/webauthn-symfony-bundle',
+            '4.7.0',
+            'The "%alias_id%" service alias is deprecated, use "%service_id%" instead.'
+        )
+    ;
+
+    $container
+        ->set('webauthn.cose.algorithm.ES384')
+        ->class(ES384::class);
+    $container
+        ->alias('webauthn.cose.algoritm.ES384', 'webauthn.cose.algorithm.ES384')
+        ->deprecate(
+            'web-auth/webauthn-symfony-bundle',
+            '4.7.0',
+            'The "%alias_id%" service alias is deprecated, use "%service_id%" instead.'
+        )
+    ;
+
+    $container
+        ->set('webauthn.cose.algorithm.ES512')
+        ->class(ES512::class);
+    $container
+        ->alias('webauthn.cose.algoritm.ES512', 'webauthn.cose.algorithm.ES512')
+        ->deprecate(
+            'web-auth/webauthn-symfony-bundle',
+            '4.7.0',
+            'The "%alias_id%" service alias is deprecated, use "%service_id%" instead.'
+        )
+    ;
+
+    $container
+        ->set('webauthn.cose.algorithm.ED256')
         ->class(Ed256::class);
     $container
-        ->set('webauthn.cose.algoritm.ED512')
+        ->alias('webauthn.cose.algoritm.ED256', 'webauthn.cose.algorithm.ED256')
+        ->deprecate(
+            'web-auth/webauthn-symfony-bundle',
+            '4.7.0',
+            'The "%alias_id%" service alias is deprecated, use "%service_id%" instead.'
+        )
+    ;
+
+    $container
+        ->set('webauthn.cose.algorithm.ED512')
         ->class(Ed512::class);
     $container
-        ->set('webauthn.cose.algoritm.Ed25519ph')
+        ->alias('webauthn.cose.algoritm.ED512', 'webauthn.cose.algorithm.ED512')
+        ->deprecate(
+            'web-auth/webauthn-symfony-bundle',
+            '4.7.0',
+            'The "%alias_id%" service alias is deprecated, use "%service_id%" instead.'
+        )
+    ;
+
+    $container
+        ->set('webauthn.cose.algorithm.Ed25519ph')
         ->class(Ed25519::class);
+    $container
+        ->alias('webauthn.cose.algoritm.Ed25519ph', 'webauthn.cose.algorithm.Ed25519ph')
+        ->deprecate(
+            'web-auth/webauthn-symfony-bundle',
+            '4.7.0',
+            'The "%alias_id%" service alias is deprecated, use "%service_id%" instead.'
+        )
+    ;
 };


### PR DESCRIPTION
Target branch: 4.7.x

- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

This files starts with `->set('webauthn.cose.algorithm.manager')` (note the "h")
@Spomky What effect does it have?
