### PR TITLE
Fixed error handling in Stimulus controller

### DIFF
--- a/src/stimulus/assets/src/controller.ts
+++ b/src/stimulus/assets/src/controller.ts
@@ -54,7 +54,7 @@ export default class extends Controller {
         const data = this._getData();
 
         this._dispatchEvent('webauthn:request:options', {data});
-        
+
         try {
             const resp = await this.fetch('POST', this.requestOptionsUrlValue, JSON.stringify(data));
             const respJson = await resp.response;

--- a/src/stimulus/assets/src/controller.ts
+++ b/src/stimulus/assets/src/controller.ts
@@ -54,22 +54,26 @@ export default class extends Controller {
         const data = this._getData();
 
         this._dispatchEvent('webauthn:request:options', {data});
+        
+        try {
+            const resp = await this.fetch('POST', this.requestOptionsUrlValue, JSON.stringify(data));
+            const respJson = await resp.response;
+            const asseResp = await startAuthentication(respJson, this.useBrowserAutofillValue);
 
-        const resp = await this.fetch('POST', this.requestOptionsUrlValue, JSON.stringify(data));
-        const respJson = await resp.response;
-        const asseResp = await startAuthentication(respJson, this.useBrowserAutofillValue);
+            const verificationResp = await this.fetch('POST', this.requestResultUrlValue, JSON.stringify(asseResp));
+            const verificationJSON = await verificationResp.response;
+            this._dispatchEvent('webauthn:request:response', {response: asseResp});
 
-        const verificationResp = await this.fetch('POST', this.requestResultUrlValue, JSON.stringify(asseResp));
-        const verificationJSON = await verificationResp.response;
-        this._dispatchEvent('webauthn:request:response', {response: asseResp});
-
-        if (verificationJSON && verificationJSON.errorMessage === '') {
-            this._dispatchEvent('webauthn:request:success', verificationJSON);
-            if (this.requestSuccessRedirectUriValue) {
-                window.location.replace(this.requestSuccessRedirectUriValue);
+            if (verificationJSON && verificationJSON.errorMessage === '') {
+                this._dispatchEvent('webauthn:request:success', verificationJSON);
+                if (this.requestSuccessRedirectUriValue) {
+                    window.location.replace(this.requestSuccessRedirectUriValue);
+                }
+            } else {
+                this._dispatchEvent('webauthn:request:failure', verificationJSON.errorMessage);
             }
-        } else {
-            this._dispatchEvent('webauthn:request:failure', verificationJSON.errorMessage);
+        } catch (e) {
+            this._dispatchEvent('webauthn:request:failure', e);
         }
     }
 
@@ -77,24 +81,29 @@ export default class extends Controller {
         event.preventDefault();
         const data = this._getData();
         this._dispatchEvent('webauthn:creation:options', {data});
-        const resp = await this.fetch('POST', this.creationOptionsUrlValue, JSON.stringify(data));
 
-        const respJson = await resp.response;
-        if (respJson.excludeCredentials === undefined) {
-            respJson.excludeCredentials = [];
-        }
-        const attResp = await startRegistration(respJson);
-        this._dispatchEvent('webauthn:creation:response', {response: attResp});
-        const verificationResp = await this.fetch('POST', this.creationResultUrlValue, JSON.stringify(attResp));
+        try {
+            const resp = await this.fetch('POST', this.creationOptionsUrlValue, JSON.stringify(data));
 
-        const verificationJSON = await verificationResp.response;
-        if (verificationJSON && verificationJSON.errorMessage === '') {
-            this._dispatchEvent('webauthn:creation:success', verificationJSON);
-            if (this.creationSuccessRedirectUriValue) {
-                window.location.replace(this.creationSuccessRedirectUriValue);
+            const respJson = await resp.response;
+            if (respJson.excludeCredentials === undefined) {
+                respJson.excludeCredentials = [];
             }
-        } else {
-            this._dispatchEvent('webauthn:creation:failure', verificationJSON.errorMessage);
+            const attResp = await startRegistration(respJson);
+            this._dispatchEvent('webauthn:creation:response', {response: attResp});
+            const verificationResp = await this.fetch('POST', this.creationResultUrlValue, JSON.stringify(attResp));
+
+            const verificationJSON = await verificationResp.response;
+            if (verificationJSON && verificationJSON.errorMessage === '') {
+                this._dispatchEvent('webauthn:creation:success', verificationJSON);
+                if (this.creationSuccessRedirectUriValue) {
+                    window.location.replace(this.creationSuccessRedirectUriValue);
+                }
+            } else {
+                this._dispatchEvent('webauthn:creation:failure', verificationJSON.errorMessage);
+            }
+        } catch (e) {
+            this._dispatchEvent('webauthn:request:failure', e);
         }
     }
 
@@ -109,7 +118,7 @@ export default class extends Controller {
             xhr.responseType = "json";
             xhr.setRequestHeader('Content-Type', 'application/json')
             xhr.onload = function () {
-                if (xhr.status >= 200 && xhr.status < 300) {
+                if ((xhr.status >= 200 && xhr.status < 300) || xhr.status == 401) {
                     resolve(xhr);
                 } else {
                     reject({


### PR DESCRIPTION
Target branch: 4.6.x

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Fixed error handling in Stimulus controller.
- added http status code "401 - Unauthorized" - to correctly evaluate the invalid key from JSON errorMessage.
- the whole code block with URL fetching is now in try catch block - because combination of await and reject promise throw an uncaught error.