### PR TITLE
Make DoctrineCredentialSourceRepository extends ServiceEntityRepository

### DIFF
--- a/src/symfony/src/Repository/DoctrineCredentialSourceRepository.php
+++ b/src/symfony/src/Repository/DoctrineCredentialSourceRepository.php
@@ -6,12 +6,17 @@ namespace Webauthn\Bundle\Repository;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
 use RuntimeException;
 use Webauthn\PublicKeyCredentialSource;
 use Webauthn\PublicKeyCredentialUserEntity;
 
-class DoctrineCredentialSourceRepository implements PublicKeyCredentialSourceRepositoryInterface, CanSaveCredentialSource, ServiceEntityRepositoryInterface
+/**
+ * @extends EntityRepository<PublicKeyCredentialSource>
+ */
+class DoctrineCredentialSourceRepository extends EntityRepository implements PublicKeyCredentialSourceRepositoryInterface, CanSaveCredentialSource, ServiceEntityRepositoryInterface
 {
     private readonly EntityManagerInterface $manager;
 
@@ -30,6 +35,10 @@ class DoctrineCredentialSourceRepository implements PublicKeyCredentialSourceRep
         ));
         $this->class = $class;
         $this->manager = $manager;
+
+        /** @var ClassMetadata<PublicKeyCredentialSource> $classMetadata */
+        $classMetadata = $manager->getClassMetadata($class);
+        parent::__construct($manager, $classMetadata);
     }
 
     public function saveCredentialSource(PublicKeyCredentialSource $publicKeyCredentialSource): void


### PR DESCRIPTION
Target branch: 4.6.x

- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

With basic implementation of `PublicKeyCredentialSourceRepository` from [documentation](https://webauthn-doc.spomky-labs.com/symfony-bundle/entities-with-doctrine#the-repository), when run PHPStan on level 6 it complains about inconsistency of interface.

Before:

```
41cd02ece24c:/app$ php bin/phpstan analyse --error-format=raw
Note: Using configuration file /app/phpstan.neon.
 1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

/app/src/Entity/PublicKeyCredentialSource.php:17:Parameter $repositoryClass of attribute class Doctrine\ORM\Mapping\Entity constructor expects class-string<Doctrine\ORM\EntityRepository<T of object>>|null, 'App\\Repository\\PublicKeyCredentialSourceRepository' given.
```

After:
```
41cd02ece24c:/app$ php bin/phpstan analyse --error-format=raw
Note: Using configuration file /app/phpstan.neon.
 1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

```

Why `ServiceEntityRepositoryInterface` doesn't solve the problem? It's because doctrine orm implementation there's requirement for `EntityRepository` concerete implementation instead of interface :/ 

ref: https://github.com/doctrine/orm/blob/2.15.x/lib/Doctrine/ORM/Mapping/Entity.php#L33


<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
