### PR TITLE
Fixed configuration for authenticator selection criteria

### DIFF
--- a/src/symfony/src/DependencyInjection/Configuration.php
+++ b/src/symfony/src/DependencyInjection/Configuration.php
@@ -160,8 +160,31 @@ final class Configuration implements ConfigurationInterface
             ->end()
             ->arrayNode('authenticator_selection_criteria')
             ->addDefaultsIfNotSet()
+            ->beforeNormalization()
+            ->ifArray()
+            ->then(function (array $v): array {
+                if (isset($v['attachment_mode'])) {
+                    $v['authenticator_attachment'] = $v['attachment_mode'];
+                    unset($v['attachment_mode']);
+                }
+
+                return $v;
+            })
+            ->end()
             ->children()
             ->scalarNode('attachment_mode')
+            ->setDeprecated('web-auth/webauthn-symfony-bundle', '4.7.0', 'Use "authenticator_attachment" instead')
+            ->defaultValue(AuthenticatorSelectionCriteria::AUTHENTICATOR_ATTACHMENT_NO_PREFERENCE)
+            ->validate()
+            ->ifNotInArray([
+                AuthenticatorSelectionCriteria::AUTHENTICATOR_ATTACHMENT_NO_PREFERENCE,
+                AuthenticatorSelectionCriteria::AUTHENTICATOR_ATTACHMENT_PLATFORM,
+                AuthenticatorSelectionCriteria::AUTHENTICATOR_ATTACHMENT_CROSS_PLATFORM,
+            ])
+            ->thenInvalid($errorTemplate)
+            ->end()
+            ->end()
+            ->scalarNode('authenticator_attachment')
             ->defaultValue(AuthenticatorSelectionCriteria::AUTHENTICATOR_ATTACHMENT_NO_PREFERENCE)
             ->validate()
             ->ifNotInArray([

--- a/tests/symfony/config/config.yml
+++ b/tests/symfony/config/config.yml
@@ -164,7 +164,7 @@ webauthn:
         icon: null
       challenge_length: 32
       authenticator_selection_criteria:
-        attachment_mode: !php/const Webauthn\AuthenticatorSelectionCriteria::AUTHENTICATOR_ATTACHMENT_NO_PREFERENCE
+        authenticator_attachment: !php/const Webauthn\AuthenticatorSelectionCriteria::AUTHENTICATOR_ATTACHMENT_NO_PREFERENCE
         require_resident_key: false
         user_verification: !php/const Webauthn\AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_PREFERRED
         resident_key: !php/const Webauthn\AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_REQUIRED


### PR DESCRIPTION
Target branch: 4.7.x

- [X] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Fixed configuration authenticator selection criteria:

- Renamed attachment_mode into authenticator_attachment.

