### PR TITLE
Fix wrong key name in PublicKeyCredentialCreationOptionsFactory.php, rename authenticator_attachment to attachment_mode

### DIFF
--- a/src/symfony/src/Service/PublicKeyCredentialCreationOptionsFactory.php
+++ b/src/symfony/src/Service/PublicKeyCredentialCreationOptionsFactory.php
@@ -106,7 +106,7 @@ final class PublicKeyCredentialCreationOptionsFactory implements CanDispatchEven
     private function createAuthenticatorSelectionCriteria(array $profile): AuthenticatorSelectionCriteria
     {
         return AuthenticatorSelectionCriteria::create(
-            $profile['authenticator_selection_criteria']['authenticator_attachment'],
+            $profile['authenticator_selection_criteria']['attachment_mode'],
             $profile['authenticator_selection_criteria']['user_verification'],
             $profile['authenticator_selection_criteria']['resident_key'],
             $profile['authenticator_selection_criteria']['require_resident_key'],


### PR DESCRIPTION
Target branch: 4.7

<!-- replace space with "x" in square brackets: [x] -->
- [X] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

No idea if this is the correct way to fix this, but when I was upgrading to the latest 4.7 version, I was encountering this issue:
```
{"status":"error","errorMessage":"Warning: Undefined array key \u0022authenticator_attachment\u0022"}
```