### PR TITLE
Missing Optional PublicKeyCredentialParameters for creation options

### DIFF
--- a/src/webauthn/src/PublicKeyCredentialCreationOptions.php
+++ b/src/webauthn/src/PublicKeyCredentialCreationOptions.php
@@ -46,7 +46,7 @@ final class PublicKeyCredentialCreationOptions extends PublicKeyCredentialOption
         public readonly PublicKeyCredentialUserEntity $user,
         string $challenge,
         /** @readonly  */
-        public array $pubKeyCredParams,
+        public array $pubKeyCredParams = [],
         /** @readonly  */
         public null|AuthenticatorSelectionCriteria $authenticatorSelection = null,
         /** @readonly  */
@@ -83,7 +83,7 @@ final class PublicKeyCredentialCreationOptions extends PublicKeyCredentialOption
         PublicKeyCredentialRpEntity $rp,
         PublicKeyCredentialUserEntity $user,
         string $challenge,
-        array $pubKeyCredParams,
+        array $pubKeyCredParams = [],
         /** @readonly  */
         null|AuthenticatorSelectionCriteria $authenticatorSelection = null,
         /** @readonly  */


### PR DESCRIPTION
Target branch: 
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
PublicKeyCredentialParameters parameter should allow empty list by default