### PR TITLE
Enable XSD validation for Doctrine ORM 3.0 compat

### DIFF
--- a/src/symfony/src/WebauthnBundle.php
+++ b/src/symfony/src/WebauthnBundle.php
@@ -94,7 +94,7 @@ final class WebauthnBundle extends Bundle
         ];
         if (class_exists(DoctrineOrmMappingsPass::class)) {
             $container->addCompilerPass(
-                DoctrineOrmMappingsPass::createXmlMappingDriver($mappings, []),
+                DoctrineOrmMappingsPass::createXmlMappingDriver($mappings, [], false, [], true),
                 PassConfig::TYPE_BEFORE_OPTIMIZATION,
                 0
             );


### PR DESCRIPTION
Applied to 4.7.x.
See #522 