### PR TITLE
Allow symfony/uid version 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "symfony/security-core": "^6.1",
         "symfony/security-http": "^6.1",
         "symfony/serializer": "^6.1",
-        "symfony/uid": "^6.1",
+        "symfony/uid": "^6.1 || ^7.0",
         "symfony/validator": "^6.1",
         "web-auth/cose-lib": "^4.2.3",
         "web-token/jwt-signature": "^3.1"

--- a/src/webauthn/composer.json
+++ b/src/webauthn/composer.json
@@ -30,7 +30,7 @@
         "psr/http-factory": "^1.0",
         "psr/log": "^1.0|^2.0|^3.0",
         "spomky-labs/cbor-php": "^3.0",
-        "symfony/uid": "^6.1",
+        "symfony/uid": "^6.1 || ^7.0",
         "web-auth/cose-lib": "^4.2.3",
         "web-auth/metadata-service": "self.version"
     },


### PR DESCRIPTION
Target branch: 4.8.x

- [ ] It is a Bug fix
- [ x ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

I'm not using your symfony bundle because I usually don't like to wait for third parties to update their bundle so I can upgrade my applications "immediatly" and therefor use webauthn/webauthn-lib directly.
Unfortunately this has a hard dependency on symfony/uid 6. This can easily be changed to allow version 7 without any code changes and would allow me to upgrade to symfony 7.

I hope the PR is correct like that, I don't really work with monorepos. Tests have passed locally for me.