### PR TITLE
Fix property access for rpId

### DIFF
--- a/src/webauthn/src/CeremonyStep/CheckOrigin.php
+++ b/src/webauthn/src/CeremonyStep/CheckOrigin.php
@@ -34,7 +34,7 @@ final class CheckOrigin implements CeremonyStep
     ): void {
         $authData = $authenticatorResponse instanceof AuthenticatorAssertionResponse ? $authenticatorResponse->authenticatorData : $authenticatorResponse->attestationObject->authData;
         $C = $authenticatorResponse->clientDataJSON;
-        $rpId = $publicKeyCredentialOptions->rpId ?? $host;
+        $rpId = ($publicKeyCredentialOptions instanceof PublicKeyCredentialRequestOptions ? $publicKeyCredentialOptions->rpId : $publicKeyCredentialOptions->rp->id) ?? $host;
         $facetId = $this->getFacetId($rpId, $publicKeyCredentialOptions->extensions, $authData->extensions);
         $parsedRelyingPartyId = parse_url($C->origin);
         is_array($parsedRelyingPartyId) || throw AuthenticatorResponseVerificationException::create(

--- a/src/webauthn/src/CeremonyStep/CheckOrigin.php
+++ b/src/webauthn/src/CeremonyStep/CheckOrigin.php
@@ -34,7 +34,7 @@ final class CheckOrigin implements CeremonyStep
     ): void {
         $authData = $authenticatorResponse instanceof AuthenticatorAssertionResponse ? $authenticatorResponse->authenticatorData : $authenticatorResponse->attestationObject->authData;
         $C = $authenticatorResponse->clientDataJSON;
-        $rpId = ($publicKeyCredentialOptions instanceof PublicKeyCredentialRequestOptions ? $publicKeyCredentialOptions->rpId : $publicKeyCredentialOptions->rp->id) ?? $host;
+        $rpId = $publicKeyCredentialOptions->rpId ?? $publicKeyCredentialOptions->rp->id ?? $host;
         $facetId = $this->getFacetId($rpId, $publicKeyCredentialOptions->extensions, $authData->extensions);
         $parsedRelyingPartyId = parse_url($C->origin);
         is_array($parsedRelyingPartyId) || throw AuthenticatorResponseVerificationException::create(

--- a/src/webauthn/src/CeremonyStep/CheckRelyingPartyIdIdHash.php
+++ b/src/webauthn/src/CeremonyStep/CheckRelyingPartyIdIdHash.php
@@ -31,7 +31,7 @@ final class CheckRelyingPartyIdIdHash implements CeremonyStep
             'No public key available.'
         );
         $isU2F = U2FPublicKey::isU2FKey($credentialPublicKey);
-        $rpId = ($publicKeyCredentialOptions instanceof PublicKeyCredentialRequestOptions ? $publicKeyCredentialOptions->rpId : $publicKeyCredentialOptions->rp->id) ?? $host;
+        $rpId = $publicKeyCredentialOptions->rpId ?? $publicKeyCredentialOptions->rp->id ?? $host;
         $facetId = $this->getFacetId($rpId, $publicKeyCredentialOptions->extensions, $authData ->extensions);
         $rpIdHash = hash('sha256', $isU2F ? $C->origin : $facetId, true);
         hash_equals(

--- a/src/webauthn/src/CeremonyStep/CheckRelyingPartyIdIdHash.php
+++ b/src/webauthn/src/CeremonyStep/CheckRelyingPartyIdIdHash.php
@@ -31,7 +31,7 @@ final class CheckRelyingPartyIdIdHash implements CeremonyStep
             'No public key available.'
         );
         $isU2F = U2FPublicKey::isU2FKey($credentialPublicKey);
-        $rpId = $publicKeyCredentialOptions->rpId ?? $host;
+        $rpId = ($publicKeyCredentialOptions instanceof PublicKeyCredentialRequestOptions ? $publicKeyCredentialOptions->rpId : $publicKeyCredentialOptions->rp->id) ?? $host;
         $facetId = $this->getFacetId($rpId, $publicKeyCredentialOptions->extensions, $authData ->extensions);
         $rpIdHash = hash('sha256', $isU2F ? $C->origin : $facetId, true);
         hash_equals(


### PR DESCRIPTION
The instance of `PublicKeyCredentialCreationOptions` does not have the `rpId` property. I think it is correct to refer to `rp->id` instead.

In particular, it does not work well when the RP ID is a top-level domain such as `example.com` and the host using WebAuthn is a subdomain such as `account.example.com`.

Target branch: 4.8.x
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->


