### PR TITLE
fix: detect realType AuthenticatorAttestationResponse

### DIFF
--- a/src/webauthn/src/Denormalizer/AuthenticatorResponseDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/AuthenticatorResponseDenormalizer.php
@@ -25,7 +25,7 @@ final class AuthenticatorResponseDenormalizer implements DenormalizerInterface, 
         }
 
         $realType = match (true) {
-            ! array_key_exists('authenticatorData', $data) && ! array_key_exists(
+            array_key_exists('attestationObject', $data) && ! array_key_exists(
                 'signature',
                 $data
             ) => AuthenticatorAttestationResponse::class,


### PR DESCRIPTION
Target branch: 4.8.0
Resolves issue: #558

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

I think this is a better check to determine if the response is an `AuthenticatorAttestationResponse`.