### PR TITLE
fix: Support 4.7.x publickey data in PublicKeyCredentialSource::createFromArray

### DIFF
--- a/src/webauthn/src/PublicKeyCredentialSource.php
+++ b/src/webauthn/src/PublicKeyCredentialSource.php
@@ -208,7 +208,7 @@ class PublicKeyCredentialSource implements JsonSerializable
     {
         $keys = array_keys(get_class_vars(self::class));
         foreach ($keys as $key) {
-            if ($key === 'otherUI') {
+            if (in_array($key, ['otherUI', 'backupEligible', 'backupStatus', 'uvInitialized'], true)) {
                 continue;
             }
             array_key_exists($key, $data) || throw InvalidDataException::create($data, sprintf(


### PR DESCRIPTION
Target branch: 4.8.x
Resolves issue #563

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

With #513 `backupEligible`, `backupStatus` and `uvInitialized` became mandatatory public key attributes, while webauthn-lib versions prior to 4.8.0 did not generated this public key attributes, which means a public key generated with 4.7.x must not be reported as invalid.
