### PR TITLE
Fix dependency package name to symfony/property-info

### DIFF
--- a/src/metadata-service/src/Denormalizer/MetadataStatementSerializerFactory.php
+++ b/src/metadata-service/src/Denormalizer/MetadataStatementSerializerFactory.php
@@ -16,6 +16,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 
 final class MetadataStatementSerializerFactory
 {
+    private const PACKAGE_SYMFONY_PROPERTY_INFO = 'symfony/property-info';
+
     private const PACKAGE_SYMFONY_SERIALIZER = 'symfony/serializer';
 
     private const PACKAGE_PHPDOCUMENTOR_REFLECTION_DOCBLOCK = 'phpdocumentor/reflection-docblock';
@@ -52,9 +54,9 @@ final class MetadataStatementSerializerFactory
             UidNormalizer::class => self::PACKAGE_SYMFONY_SERIALIZER,
             ArrayDenormalizer::class => self::PACKAGE_SYMFONY_SERIALIZER,
             ObjectNormalizer::class => self::PACKAGE_SYMFONY_SERIALIZER,
-            PropertyInfoExtractor::class => self::PACKAGE_SYMFONY_SERIALIZER,
+            PropertyInfoExtractor::class => self::PACKAGE_SYMFONY_PROPERTY_INFO,
             PhpDocExtractor::class => self::PACKAGE_PHPDOCUMENTOR_REFLECTION_DOCBLOCK,
-            ReflectionExtractor::class => self::PACKAGE_SYMFONY_SERIALIZER,
+            ReflectionExtractor::class => self::PACKAGE_SYMFONY_PROPERTY_INFO,
             JsonEncoder::class => self::PACKAGE_SYMFONY_SERIALIZER,
             Serializer::class => self::PACKAGE_SYMFONY_SERIALIZER,
         ];

--- a/src/webauthn/src/Denormalizer/WebauthnSerializerFactory.php
+++ b/src/webauthn/src/Denormalizer/WebauthnSerializerFactory.php
@@ -18,6 +18,8 @@ use Webauthn\AttestationStatement\AttestationStatementSupportManager;
 
 final class WebauthnSerializerFactory
 {
+    private const PACKAGE_SYMFONY_PROPERTY_INFO = 'symfony/property-info';
+
     private const PACKAGE_SYMFONY_SERIALIZER = 'symfony/serializer';
 
     private const PACKAGE_PHPDOCUMENTOR_REFLECTION_DOCBLOCK = 'phpdocumentor/reflection-docblock';
@@ -75,9 +77,9 @@ final class WebauthnSerializerFactory
             UidNormalizer::class => self::PACKAGE_SYMFONY_SERIALIZER,
             ArrayDenormalizer::class => self::PACKAGE_SYMFONY_SERIALIZER,
             ObjectNormalizer::class => self::PACKAGE_SYMFONY_SERIALIZER,
-            PropertyInfoExtractor::class => self::PACKAGE_SYMFONY_SERIALIZER,
+            PropertyInfoExtractor::class => self::PACKAGE_SYMFONY_PROPERTY_INFO,
             PhpDocExtractor::class => self::PACKAGE_PHPDOCUMENTOR_REFLECTION_DOCBLOCK,
-            ReflectionExtractor::class => self::PACKAGE_SYMFONY_SERIALIZER,
+            ReflectionExtractor::class => self::PACKAGE_SYMFONY_PROPERTY_INFO,
             JsonEncoder::class => self::PACKAGE_SYMFONY_SERIALIZER,
             Serializer::class => self::PACKAGE_SYMFONY_SERIALIZER,
         ];


### PR DESCRIPTION
Target branch: 4.8.x
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->

The `PropertyInfoExtractor` and `ReflectionExtractor` are included in `symfony/property-info`.
The `symfony/property-info` is included in `require-dev` of `symfony/serializer`, but not in `require`. Therefore, if the packages are installed with the `--no-dev` option, the classes will not be found and an error requiring the installation of the incorrect package will be displayed.
