### PR TITLE
Add missing tag to inject configured event dispatcher

### DIFF
--- a/src/symfony/src/DependencyInjection/Factory/Security/WebauthnServicesFactory.php
+++ b/src/symfony/src/DependencyInjection/Factory/Security/WebauthnServicesFactory.php
@@ -10,6 +10,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Webauthn\AuthenticatorAssertionResponseValidator;
 use Webauthn\AuthenticatorAttestationResponseValidator;
+use Webauthn\Bundle\DependencyInjection\Compiler\EventDispatcherSetterCompilerPass;
 use Webauthn\CeremonyStep\CeremonyStepManager;
 use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
 
@@ -56,7 +57,8 @@ class WebauthnServicesFactory
                 $authenticatorAssertionResponseValidatorId,
                 new Definition(AuthenticatorAssertionResponseValidator::class)
             )
-            ->setArguments([null, null, null, null, null, new Reference($ceremonyStepManagerId)]);
+            ->setArguments([null, null, null, null, null, new Reference($ceremonyStepManagerId)])
+            ->addTag(EventDispatcherSetterCompilerPass::TAG);
 
         return $authenticatorAssertionResponseValidatorId;
     }
@@ -82,7 +84,8 @@ class WebauthnServicesFactory
                 $authenticatorAttestationResponseValidatorId,
                 new Definition(AuthenticatorAttestationResponseValidator::class)
             )
-            ->setArguments([null, null, null, null, null, new Reference($ceremonyStepManagerId)]);
+            ->setArguments([null, null, null, null, null, new Reference($ceremonyStepManagerId)])
+            ->addTag(EventDispatcherSetterCompilerPass::TAG);
 
         return $authenticatorAttestationResponseValidatorId;
     }

--- a/src/symfony/src/DependencyInjection/WebauthnExtension.php
+++ b/src/symfony/src/DependencyInjection/WebauthnExtension.php
@@ -244,6 +244,7 @@ final class WebauthnExtension extends Extension implements PrependExtensionInter
                 null,
                 new Reference($creationCeremonyStepManagerId),
             ]);
+            $attestationResponseValidator->addTag(EventDispatcherSetterCompilerPass::TAG);
             $container->setDefinition($attestationResponseValidatorId, $attestationResponseValidator);
 
             $attestationResponseControllerId = sprintf('webauthn.controller.creation.response.%s', $name);
@@ -330,6 +331,7 @@ final class WebauthnExtension extends Extension implements PrependExtensionInter
                 null,
                 new Reference($requestCeremonyStepManagerId),
             ]);
+            $assertionResponseValidator->addTag(EventDispatcherSetterCompilerPass::TAG);
             $container->setDefinition($assertionResponseValidatorId, $assertionResponseValidator);
 
             $assertionResponseControllerId = sprintf('webauthn.controller.request.response.%s', $name);


### PR DESCRIPTION
Target branch: 4.8.x
Resolves issue #

<!-- replace space with "x" in square brackets: [x] -->
- [X] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Add missing tags in dynamic attestation and assertion validator services.

IMHO, those multiple services should be removed to have only one declared by class, instead of one by configuration. 
