### PR TITLE
Deprecate Android SafetyNet support

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -861,6 +861,14 @@ parameters:
 			path: src/symfony/src/DependencyInjection/Configuration.php
 
 		-
+			message: """
+				#^Call to deprecated method addAndroidSafetynetConfig\\(\\) of class Webauthn\\\\Bundle\\\\DependencyInjection\\\\Configuration\\:
+				since 4\\.9\\.0 and will be removed in 5\\.0\\.0\\. Android SafetyNet is now deprecated\\.$#
+			"""
+			count: 1
+			path: src/symfony/src/DependencyInjection/Configuration.php
+
+		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\:\\:scalarNode\\(\\)\\.$#"
 			count: 1
 			path: src/symfony/src/DependencyInjection/Factory/Security/WebauthnFactory.php
@@ -1029,6 +1037,14 @@ parameters:
 			message: "#^Parameter \\#9 \\$failureHandlerId of method Webauthn\\\\Bundle\\\\DependencyInjection\\\\Factory\\\\Security\\\\WebauthnFactory\\:\\:createAttestationRequestControllerAndRoute\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/symfony/src/DependencyInjection/Factory/Security/WebauthnFactory.php
+
+		-
+			message: """
+				#^Call to deprecated method loadAndroidSafetyNet\\(\\) of class Webauthn\\\\Bundle\\\\DependencyInjection\\\\WebauthnExtension\\:
+				since 4\\.9\\.0 and will be removed in 5\\.0\\.0\\. Android SafetyNet is now deprecated\\.$#
+			"""
+			count: 1
+			path: src/symfony/src/DependencyInjection/WebauthnExtension.php
 
 		-
 			message: "#^Cannot access offset 'failure_handler' on mixed\\.$#"
@@ -1240,6 +1256,14 @@ parameters:
 			message: "#^Class Webauthn\\\\Bundle\\\\Repository\\\\PublicKeyCredentialSourceRepository extends generic class Webauthn\\\\Bundle\\\\Repository\\\\DoctrineCredentialSourceRepository but does not specify its types\\: T$#"
 			count: 1
 			path: src/symfony/src/Repository/PublicKeyCredentialSourceRepository.php
+
+		-
+			message: """
+				#^Fetching class constant class of deprecated class Webauthn\\\\AttestationStatement\\\\AndroidSafetyNetAttestationStatementSupport\\:
+				since 4\\.9\\.0 and will be removed in 5\\.0\\.0\\. Android SafetyNet is now deprecated\\.$#
+			"""
+			count: 1
+			path: src/symfony/src/Resources/config/android_safetynet.php
 
 		-
 			message: """
@@ -1767,6 +1791,14 @@ parameters:
 			message: "#^Parameter \\#3 \\.\\.\\.\\$arrays of function array_map expects array, mixed given\\.$#"
 			count: 1
 			path: src/symfony/src/Service/PublicKeyCredentialRequestOptionsFactory.php
+
+		-
+			message: """
+				#^Instantiation of deprecated class Webauthn\\\\Bundle\\\\DependencyInjection\\\\Compiler\\\\EnforcedSafetyNetApiKeyVerificationCompilerPass\\:
+				since 4\\.9\\.0 and will be removed in 5\\.0\\.0\\. Android SafetyNet is now deprecated\\.$#
+			"""
+			count: 1
+			path: src/symfony/src/WebauthnBundle.php
 
 		-
 			message: "#^Method Webauthn\\\\Bundle\\\\WebauthnBundle\\:\\:getContainerExtension\\(\\) never returns null so it can be removed from the return type\\.$#"

--- a/src/symfony/src/DependencyInjection/Compiler/EnforcedSafetyNetApiKeyVerificationCompilerPass.php
+++ b/src/symfony/src/DependencyInjection/Compiler/EnforcedSafetyNetApiKeyVerificationCompilerPass.php
@@ -9,6 +9,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Webauthn\AttestationStatement\AndroidSafetyNetAttestationStatementSupport;
 
+/**
+ * @deprecated since 4.9.0 and will be removed in 5.0.0. Android SafetyNet is now deprecated.
+ */
 final class EnforcedSafetyNetApiKeyVerificationCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void

--- a/src/symfony/src/DependencyInjection/Configuration.php
+++ b/src/symfony/src/DependencyInjection/Configuration.php
@@ -456,10 +456,14 @@ final class Configuration implements ConfigurationInterface
             ->end();
     }
 
+    /**
+     * @deprecated since 4.9.0 and will be removed in 5.0.0. Android SafetyNet is now deprecated.
+     */
     private function addAndroidSafetynetConfig(ArrayNodeDefinition $rootNode): void
     {
         $rootNode->children()
             ->arrayNode('android_safetynet')
+                ->setDeprecated('web-auth/webauthn-symfony-bundle', '4.9.0', 'Android SafetyNet is now deprecated.')
                 ->addDefaultsIfNotSet()
                 ->info('Additional configuration options for the Android SafetyNet attestation.')
                 ->children()

--- a/src/symfony/src/DependencyInjection/WebauthnExtension.php
+++ b/src/symfony/src/DependencyInjection/WebauthnExtension.php
@@ -357,6 +357,7 @@ final class WebauthnExtension extends Extension implements PrependExtensionInter
     }
 
     /**
+     * @deprecated since 4.9.0 and will be removed in 5.0.0. Android SafetyNet is now deprecated.
      * @param mixed[] $config
      */
     private function loadAndroidSafetyNet(ContainerBuilder $container, FileLoader $loader, array $config): void

--- a/src/symfony/src/Resources/config/android_safetynet.php
+++ b/src/symfony/src/Resources/config/android_safetynet.php
@@ -20,7 +20,11 @@ return static function (ContainerConfigurator $container): void {
     if (class_exists(JWKFactory::class) && class_exists(RS256::class)) {
         $container
             ->set(AndroidSafetyNetAttestationStatementSupport::class)
-            ->deprecate('web-auth/webauthn-symfony-bundle','4.9.0', 'The "%service_id%" service is deprecated and will be removed in version 5.0.0. Android SafetyNet is now deprecated.')
+            ->deprecate(
+                'web-auth/webauthn-symfony-bundle',
+                '4.9.0',
+                'The "%service_id%" service is deprecated and will be removed in version 5.0.0. Android SafetyNet is now deprecated.'
+            )
             ->args([service(ClockInterface::class)->nullOnInvalid()])
             ->call('setMaxAge', [param('webauthn.android_safetynet.max_age')])
             ->call('setLeeway', [param('webauthn.android_safetynet.leeway')]);

--- a/src/symfony/src/Resources/config/android_safetynet.php
+++ b/src/symfony/src/Resources/config/android_safetynet.php
@@ -10,6 +10,7 @@ use Webauthn\AttestationStatement\AndroidSafetyNetAttestationStatementSupport;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
+//TODO >=5.0.0: Remove this file
 return static function (ContainerConfigurator $container): void {
     $container = $container->services()
         ->defaults()
@@ -19,6 +20,7 @@ return static function (ContainerConfigurator $container): void {
     if (class_exists(JWKFactory::class) && class_exists(RS256::class)) {
         $container
             ->set(AndroidSafetyNetAttestationStatementSupport::class)
+            ->deprecate('web-auth/webauthn-symfony-bundle','4.9.0', 'The "%service_id%" service is deprecated and will be removed in version 5.0.0. Android SafetyNet is now deprecated.')
             ->args([service(ClockInterface::class)->nullOnInvalid()])
             ->call('setMaxAge', [param('webauthn.android_safetynet.max_age')])
             ->call('setLeeway', [param('webauthn.android_safetynet.leeway')]);

--- a/src/webauthn/composer.json
+++ b/src/webauthn/composer.json
@@ -51,7 +51,6 @@
         "symfony/property-info": "As of 4.5.x, the symfony/serializer component will become mandatory for converting objects such as the Metadata Statement",
         "phpdocumentor/reflection-docblock": "As of 4.5.x, the phpdocumentor/reflection-docblock component will become mandatory for converting objects such as the Metadata Statement",
         "psr/log-implementation": "Recommended to receive logs from the library",
-        "web-token/jwt-library": "Mandatory for the AndroidSafetyNet Attestation Statement support",
         "symfony/event-dispatcher": "Recommended to use dispatched events"
     }
 }

--- a/src/webauthn/src/AttestationStatement/AndroidSafetyNetAttestationStatementSupport.php
+++ b/src/webauthn/src/AttestationStatement/AndroidSafetyNetAttestationStatementSupport.php
@@ -43,6 +43,9 @@ use function is_int;
 use function is_string;
 use const JSON_THROW_ON_ERROR;
 
+/**
+ * @deprecated since 4.9.0 and will be removed in 5.0.0. Android SafetyNet is now deprecated.
+ */
 final class AndroidSafetyNetAttestationStatementSupport implements AttestationStatementSupport, CanDispatchEvents
 {
     private ?string $apiKey = null;


### PR DESCRIPTION
The Android SafetyNet support is marked as deprecated starting from version 4.9.0 and will be completely removed in version 5.0.0. This includes key verification classes, configuration options, and dependencies. This decision arises from updates in the latest symfony and webauthn environments.

Target branch: 4.9.x
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [x] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
