### PR TITLE
Refactor authenticator response identification logic

### DIFF
--- a/src/webauthn/src/Denormalizer/AuthenticatorResponseDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/AuthenticatorResponseDenormalizer.php
@@ -20,14 +20,8 @@ final class AuthenticatorResponseDenormalizer implements DenormalizerInterface, 
     public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
     {
         $realType = match (true) {
-            array_key_exists('attestationObject', $data) && ! array_key_exists(
-                'signature',
-                $data
-            ) => AuthenticatorAttestationResponse::class,
-            array_key_exists('authenticatorData', $data) && array_key_exists(
-                'signature',
-                $data
-            ) => AuthenticatorAssertionResponse::class,
+            array_key_exists('attestationObject', $data) => AuthenticatorAttestationResponse::class,
+            array_key_exists('signature', $data) => AuthenticatorAssertionResponse::class,
             default => throw InvalidDataException::create($data, 'Unable to create the response object'),
         };
 

--- a/src/webauthn/src/PublicKeyCredentialLoader.php
+++ b/src/webauthn/src/PublicKeyCredentialLoader.php
@@ -153,15 +153,15 @@ class PublicKeyCredentialLoader implements CanLogData
             return $this->serializer->deserialize($response, AuthenticatorResponse::class, 'json');
         }
         switch (true) {
-            case ! array_key_exists('authenticatorData', $response) && ! array_key_exists('signature', $response):
+            case array_key_exists('attestationObject', $response):
                 $attestationObject = $this->attestationObjectLoader->load($response['attestationObject']);
 
                 return AuthenticatorAttestationResponse::create(CollectedClientData::createFormJson(
                     $response['clientDataJSON']
                 ), $attestationObject, $transports);
-            case array_key_exists('authenticatorData', $response) && array_key_exists('signature', $response):
+            case array_key_exists('signature', $response):
                 $authDataLoader = AuthenticatorDataLoader::create();
-                $authData = Base64UrlSafe::decodeNoPadding($response['authenticatorData']);
+                $authData = Base64UrlSafe::decodeNoPadding($response['authenticatorData'] ?? '');
                 $authenticatorData = $authDataLoader->load($authData);
 
                 try {


### PR DESCRIPTION
The logic for identifying the type of Authenticator Response has been simplified. Instead of checking for multiple array keys in a data object, we now simply check for the presence of either 'attestationObject' or 'signature'. This refactoring leads to cleaner and more maintainable code.

Target branch: 4.8.x
Resolves issue #583 

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
