### PR TITLE
Refactor code for deprecation of "id" property

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2349,6 +2349,14 @@ parameters:
 			path: src/webauthn/src/CollectedClientData.php
 
 		-
+			message: """
+				#^Access to deprecated property \\$id of class Webauthn\\\\Credential\\:
+				since 4\\.9\\.0\\. Please use the property rawId instead\\.$#
+			"""
+			count: 1
+			path: src/webauthn/src/Credential.php
+
+		-
 			message: "#^Cannot access offset 'authData' on mixed\\.$#"
 			count: 1
 			path: src/webauthn/src/Denormalizer/AttestationObjectDenormalizer.php

--- a/src/webauthn/src/Credential.php
+++ b/src/webauthn/src/Credential.php
@@ -4,15 +4,39 @@ declare(strict_types=1);
 
 namespace Webauthn;
 
+use InvalidArgumentException;
+
 /**
  * @see https://w3c.github.io/webappsec-credential-management/#credential
  */
 abstract class Credential
 {
+    /**
+     * @deprecated since 4.9.0. Please use the property rawId instead.
+     */
+    public readonly string $id;
+
+    public readonly string $rawId;
+
     public function __construct(
-        public readonly string $id,
-        public readonly string $type
+        null|string $id,
+        public readonly string $type,
+        null|string $rawId = null,
     ) {
+        if ($id === null && $rawId === null) {
+            throw new InvalidArgumentException('You must provide a valid raw ID');
+        }
+        if ($id !== null) {
+            trigger_deprecation(
+                'web-auth/webauthn-lib',
+                '4.9.0',
+                'The property "$id" is deprecated and will be removed in 5.0.0. Please set null use "rawId" instead.'
+            );
+        } else {
+            $id = base64_encode($rawId);
+        }
+        $this->id = $id;
+        $this->rawId = $rawId ?? base64_encode($id);
     }
 
     /**

--- a/src/webauthn/src/Denormalizer/PublicKeyCredentialDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/PublicKeyCredentialDenormalizer.php
@@ -29,7 +29,7 @@ final class PublicKeyCredentialDenormalizer implements DenormalizerInterface, De
         $data['rawId'] = $rawId;
 
         return PublicKeyCredential::create(
-            $data['id'],
+            null,
             $data['type'],
             $data['rawId'],
             $this->denormalizer->denormalize($data['response'], AuthenticatorResponse::class, $format, $context),

--- a/src/webauthn/src/PublicKeyCredential.php
+++ b/src/webauthn/src/PublicKeyCredential.php
@@ -14,12 +14,12 @@ use const JSON_THROW_ON_ERROR;
 class PublicKeyCredential extends Credential implements Stringable
 {
     public function __construct(
-        string $id,
+        null|string $id,
         string $type,
-        public readonly string $rawId,
+        string $rawId,
         public readonly AuthenticatorResponse $response
     ) {
-        parent::__construct($id, $type);
+        parent::__construct($id, $type, $rawId);
     }
 
     /**
@@ -31,7 +31,7 @@ class PublicKeyCredential extends Credential implements Stringable
         return json_encode($this->getPublicKeyCredentialDescriptor(), JSON_THROW_ON_ERROR);
     }
 
-    public static function create(string $id, string $type, string $rawId, AuthenticatorResponse $response): self
+    public static function create(null|string $id, string $type, string $rawId, AuthenticatorResponse $response): self
     {
         return new self($id, $type, $rawId, $response);
     }

--- a/src/webauthn/src/PublicKeyCredentialLoader.php
+++ b/src/webauthn/src/PublicKeyCredentialLoader.php
@@ -86,7 +86,7 @@ class PublicKeyCredentialLoader implements CanLogData
             hash_equals($id, $rawId) || throw InvalidDataException::create($json, 'Invalid ID');
 
             $publicKeyCredential = PublicKeyCredential::create(
-                $json['id'],
+                null,
                 $json['type'],
                 $rawId,
                 $this->createResponse($json['response'])

--- a/tests/library/Functional/AppleAttestationStatementTest.php
+++ b/tests/library/Functional/AppleAttestationStatementTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Webauthn\Tests\Functional;
 
 use DateTimeImmutable;
-use ParagonIE\ConstantTime\Base64UrlSafe;
 use PHPUnit\Framework\Attributes\Test;
 use Webauthn\AttestationStatement\AttestationStatement;
 use Webauthn\AttestedCredentialData;
@@ -55,10 +54,7 @@ final class AppleAttestationStatementTest extends AbstractTestCase
         $this->getAuthenticatorAttestationResponseValidator()
             ->check($publicKeyCredential->response, $publicKeyCredentialCreationOptions, 'dev.dontneeda.pw');
         $publicKeyCredentialDescriptor = $publicKeyCredential->getPublicKeyCredentialDescriptor();
-        static::assertSame(
-            base64_decode('J4lAqPXhefDrUD7oh5LQMbBH5TE', true),
-            Base64UrlSafe::decode($publicKeyCredential->id)
-        );
+        static::assertSame(base64_decode('J4lAqPXhefDrUD7oh5LQMbBH5TE', true), $publicKeyCredential->rawId);
         static::assertSame(base64_decode('J4lAqPXhefDrUD7oh5LQMbBH5TE', true), $publicKeyCredentialDescriptor->id);
         static::assertSame(
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,

--- a/tests/library/Functional/AttestationStatementWithTokenBindingTest.php
+++ b/tests/library/Functional/AttestationStatementWithTokenBindingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Webauthn\Tests\Functional;
 
 use Cose\Algorithms;
-use ParagonIE\ConstantTime\Base64UrlSafe;
 use PHPUnit\Framework\Attributes\Test;
 use Webauthn\AttestedCredentialData;
 use Webauthn\AuthenticatorAttestationResponse;
@@ -55,7 +54,7 @@ final class AttestationStatementWithTokenBindingTest extends AbstractTestCase
                 '+uZVS9+4JgjAYI49YhdzTgHmbn638+ZNSvC0UtHkWTVS+CtTjnaSbqtzdzijByOAvEAsh+TaQJAr43FRj+dYag==',
                 true
             ),
-            Base64UrlSafe::decode($publicKeyCredential->id)
+            $publicKeyCredential->rawId
         );
         static::assertSame(
             base64_decode(

--- a/tests/library/Functional/AttestationTest.php
+++ b/tests/library/Functional/AttestationTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Webauthn\Tests\Functional;
 
-use ParagonIE\ConstantTime\Base64UrlSafe;
 use PHPUnit\Framework\Attributes\Test;
 use RangeException;
 use Webauthn\AttestedCredentialData;
@@ -56,7 +55,7 @@ final class AttestationTest extends AbstractTestCase
         $publicKeyCredentialDescriptor = $publicKeyCredential->getPublicKeyCredentialDescriptor();
         static::assertSame(
             hex2bin('4787c0563f68b2055564bef21dfb4f7953a68e89b7c70e192caec3b7ff26cce3'),
-            Base64UrlSafe::decode($publicKeyCredential->id)
+            $publicKeyCredential->rawId
         );
         static::assertSame(
             hex2bin('4787c0563f68b2055564bef21dfb4f7953a68e89b7c70e192caec3b7ff26cce3'),

--- a/tests/library/Functional/PackedAttestationStatementTest.php
+++ b/tests/library/Functional/PackedAttestationStatementTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Webauthn\Tests\Functional;
 
-use ParagonIE\ConstantTime\Base64UrlSafe;
 use PHPUnit\Framework\Attributes\Test;
 use Webauthn\AttestedCredentialData;
 use Webauthn\AuthenticatorAttestationResponse;
@@ -52,7 +51,7 @@ final class PackedAttestationStatementTest extends AbstractTestCase
                 'xYw3gEj0LVL83JXz7oKL14XQjh9W1NMFrTALWI+lqXl7ndKW+n8JFYsBCuKbZA3zRAUxAZDHG/tXHsAi6TbO0Q==',
                 true
             ),
-            Base64UrlSafe::decode($publicKeyCredential->id)
+            $publicKeyCredential->rawId
         );
         static::assertSame(
             base64_decode(
@@ -114,7 +113,7 @@ final class PackedAttestationStatementTest extends AbstractTestCase
                 'AFkzwaxVuCUz4qFPaNAgnYgoZKKTtvGIAaIASAbnlHGy8UktdI/jN0CetpIkiw9++R0AF9a6OJnHD+G4aIWur+Pxj+sI9xDE+AVeQKve',
                 true
             ),
-            Base64UrlSafe::decode($publicKeyCredential->id)
+            $publicKeyCredential->rawId
         );
         static::assertSame(
             base64_decode(
@@ -171,7 +170,7 @@ final class PackedAttestationStatementTest extends AbstractTestCase
         $publicKeyCredentialDescriptor = $publicKeyCredential->getPublicKeyCredentialDescriptor();
         static::assertSame(
             base64_decode('RSRHHrZblfX23SKbu09qBzVp8Y1W1c9GI1EtHZ9gDzY=', true),
-            Base64UrlSafe::decode($publicKeyCredential->id)
+            $publicKeyCredential->rawId
         );
         static::assertSame(
             base64_decode('RSRHHrZblfX23SKbu09qBzVp8Y1W1c9GI1EtHZ9gDzY=', true),

--- a/tests/library/Functional/W10Test.php
+++ b/tests/library/Functional/W10Test.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Webauthn\Tests\Functional;
 
-use ParagonIE\ConstantTime\Base64UrlSafe;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Uid\Uuid;
@@ -46,7 +45,7 @@ final class W10Test extends AbstractTestCase
         $publicKeyCredentialSource = $this->getAuthenticatorAttestationResponseValidator()
             ->check($publicKeyCredential->response, $publicKeyCredentialCreationOptions, $host);
         $publicKeyCredentialDescriptor = $publicKeyCredential->getPublicKeyCredentialDescriptor();
-        static::assertSame($credentialId, Base64UrlSafe::decode($publicKeyCredential->id));
+        static::assertSame($credentialId, $publicKeyCredential->rawId);
         static::assertSame($credentialId, $publicKeyCredentialDescriptor->id);
         static::assertSame(
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,


### PR DESCRIPTION
The "id" property in the PublicKeyCredential is deprecated. This commit refactors the relevant code, specifically in the "PublicKeyCredential" class and several test classes, to replace the use of "Base64UrlSafe::decode($publicKeyCredential->id)" with "$publicKeyCredential->rawId". The changes are made such that the functionality is maintained but future compatibility is ensured.

Target branch: 4.9.x
Resolves issue #581

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
