### PR TITLE
Add new fields to PublicKeyCredentialSource mapping

### DIFF
--- a/src/symfony/src/Resources/config/doctrine-mapping/PublicKeyCredentialSource.orm.xml
+++ b/src/symfony/src/Resources/config/doctrine-mapping/PublicKeyCredentialSource.orm.xml
@@ -15,5 +15,8 @@
         <field name="userHandle"/>
         <field name="counter" type="integer"/>
         <field name="otherUI" type="array" nullable="true"/>
+        <field name="backupEligible" type="boolean" nullable="true"/>
+        <field name="backupStatus" type="boolean" nullable="true"/>
+        <field name="uvInitialized" type="boolean" nullable="true"/>
     </mapped-superclass>
 </doctrine-mapping>


### PR DESCRIPTION
Three new fields have been added to the PublicKeyCredentialSource mapping defined in XML. These boolean fields include "backupEligible", "backupStatus", and "uvInitialized". Each can be nullable, allowing for more flexible data management.

Target branch: 
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
