### PR TITLE
getAlternativeDescriptions can return null

### DIFF
--- a/src/metadata-service/src/Statement/MetadataStatement.php
+++ b/src/metadata-service/src/Statement/MetadataStatement.php
@@ -361,7 +361,7 @@ class MetadataStatement implements JsonSerializable
      * @deprecated since 4.7.0. Please use the property directly.
      * @infection-ignore-all
      */
-    public function getAlternativeDescriptions(): AlternativeDescriptions
+    public function getAlternativeDescriptions(): ?AlternativeDescriptions
     {
         return $this->alternativeDescriptions;
     }


### PR DESCRIPTION
Target branch: 5.0.x

The alternativeDescriptions property is optional in the constructor, and alternative descriptions are often not present in the fido metadata. This causes issues during deserialization. Therefore, the return of getAlternativeDescriptions() must be optional.

- [X] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations
