### PR TITLE
Update return type in getAlternativeDescriptions method

### DIFF
--- a/src/metadata-service/src/Statement/MetadataStatement.php
+++ b/src/metadata-service/src/Statement/MetadataStatement.php
@@ -361,7 +361,7 @@ class MetadataStatement implements JsonSerializable
      * @deprecated since 4.7.0. Please use the property directly.
      * @infection-ignore-all
      */
-    public function getAlternativeDescriptions(): AlternativeDescriptions
+    public function getAlternativeDescriptions(): null|AlternativeDescriptions
     {
         return $this->alternativeDescriptions;
     }

--- a/tests/symfony/config/config.yml
+++ b/tests/symfony/config/config.yml
@@ -111,6 +111,8 @@ doctrine:
     auto_generate_proxy_classes: true
     naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
     auto_mapping: true
+    controller_resolver:
+      auto_mapping: false
     mappings:
       App:
         is_bundle: false


### PR DESCRIPTION
The method getAlternativeDescriptions in MetadataStatement.php has been updated to allow it to return null. This change provides more flexibility when no alternative descriptions are available for any given metadata statement.

Target branch: 4.8.x
Resolves issue #595

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
