### PR TITLE
Add FakeCredentialGenerator for preventing username enumeration

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -187,12 +187,6 @@ jobs:
         run: |
           vendor/bin/deptrac analyse --fail-on-uncovered --no-cache
 
-      - name: "SonarCloud Scan"
-        uses: "sonarsource/sonarcloud-github-action@master"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
   rector_checkstyle:
     name: "6️⃣ Rector Checkstyle"
     needs:

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -798,7 +798,17 @@ parameters:
 			path: src/symfony/src/CredentialOptionsBuilder/ProfileBasedRequestOptionsBuilder.php
 
 		-
+			message: "#^Parameter \\#1 \\$userEntity of method Webauthn\\\\Bundle\\\\CredentialOptionsBuilder\\\\ProfileBasedRequestOptionsBuilder\\:\\:getCredentials\\(\\) expects Webauthn\\\\PublicKeyCredentialUserEntity, Webauthn\\\\PublicKeyCredentialUserEntity\\|null given\\.$#"
+			count: 1
+			path: src/symfony/src/CredentialOptionsBuilder/ProfileBasedRequestOptionsBuilder.php
+
+		-
 			message: "#^Parameter \\$credentialSourceRepository of method Webauthn\\\\Bundle\\\\CredentialOptionsBuilder\\\\ProfileBasedRequestOptionsBuilder\\:\\:__construct\\(\\) has typehint with deprecated interface Webauthn\\\\PublicKeyCredentialSourceRepository\\.$#"
+			count: 1
+			path: src/symfony/src/CredentialOptionsBuilder/ProfileBasedRequestOptionsBuilder.php
+
+		-
+			message: "#^Should not use function \"dump\", please change the code\\.$#"
 			count: 1
 			path: src/symfony/src/CredentialOptionsBuilder/ProfileBasedRequestOptionsBuilder.php
 
@@ -3169,6 +3179,11 @@ parameters:
 			message: "#^Parameter \\#9 \\$counter of static method Webauthn\\\\PublicKeyCredentialSource\\:\\:create\\(\\) expects int, mixed given\\.$#"
 			count: 1
 			path: src/webauthn/src/PublicKeyCredentialSource.php
+
+		-
+			message: "#^Method Webauthn\\\\SimpleFakeCredentialGenerator\\:\\:generate\\(\\) should return array\\<Webauthn\\\\PublicKeyCredentialDescriptor\\> but returns mixed\\.$#"
+			count: 1
+			path: src/webauthn/src/SimpleFakeCredentialGenerator.php
 
 		-
 			message: "#^Method Webauthn\\\\StringStream\\:\\:read\\(\\) should return string but returns string\\|false\\.$#"

--- a/src/symfony/src/Controller/AssertionControllerFactory.php
+++ b/src/symfony/src/Controller/AssertionControllerFactory.php
@@ -19,6 +19,7 @@ use Webauthn\Bundle\Security\Handler\RequestOptionsHandler;
 use Webauthn\Bundle\Security\Handler\SuccessHandler;
 use Webauthn\Bundle\Security\Storage\OptionsStorage;
 use Webauthn\Bundle\Service\PublicKeyCredentialRequestOptionsFactory;
+use Webauthn\FakeCredentialGenerator;
 use Webauthn\MetadataService\CanLogData;
 use Webauthn\PublicKeyCredentialLoader;
 use Webauthn\PublicKeyCredentialSourceRepository;
@@ -34,7 +35,8 @@ final class AssertionControllerFactory implements CanLogData
         private readonly null|PublicKeyCredentialLoader $publicKeyCredentialLoader,
         private readonly AuthenticatorAssertionResponseValidator $authenticatorAssertionResponseValidator,
         private readonly PublicKeyCredentialUserEntityRepositoryInterface $publicKeyCredentialUserEntityRepository,
-        private readonly PublicKeyCredentialSourceRepository|PublicKeyCredentialSourceRepositoryInterface $publicKeyCredentialSourceRepository
+        private readonly PublicKeyCredentialSourceRepository|PublicKeyCredentialSourceRepositoryInterface $publicKeyCredentialSourceRepository,
+        private readonly null|FakeCredentialGenerator $fakeCredentialGenerator = null,
     ) {
         if ($this->publicKeyCredentialLoader !== null) {
             trigger_deprecation(
@@ -68,6 +70,7 @@ final class AssertionControllerFactory implements CanLogData
             $this->publicKeyCredentialSourceRepository,
             $this->publicKeyCredentialRequestOptionsFactory,
             $profile,
+            $this->fakeCredentialGenerator,
         );
 
         return $this->createRequestController($optionsBuilder, $optionStorage, $optionsHandler, $failureHandler);
@@ -84,7 +87,7 @@ final class AssertionControllerFactory implements CanLogData
             $optionStorage,
             $optionsHandler,
             $failureHandler,
-            $this->logger
+            $this->logger,
         );
     }
 

--- a/src/symfony/src/DependencyInjection/Configuration.php
+++ b/src/symfony/src/DependencyInjection/Configuration.php
@@ -21,6 +21,7 @@ use Webauthn\Bundle\Service\DefaultSuccessHandler;
 use Webauthn\Counter\ThrowExceptionIfInvalid;
 use Webauthn\MetadataService\CertificateChain\PhpCertificateChainValidator;
 use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\SimpleFakeCredentialGenerator;
 
 final class Configuration implements ConfigurationInterface
 {
@@ -61,6 +62,13 @@ final class Configuration implements ConfigurationInterface
                 )
                 ->defaultNull()
                 ->info('Creates PSR-7 HTTP Request and Response instances from Symfony ones.')
+            ->end()
+            ->scalarNode('fake_credential_generator')
+                ->defaultValue(SimpleFakeCredentialGenerator::class)
+                ->cannotBeEmpty()
+                ->info(
+                    'A service that implements the FakeCredentialGenerator to generate fake credentials for preventing username enumeration.'
+                )
             ->end()
             ->scalarNode('clock')
                 ->defaultValue('webauthn.clock.default')

--- a/src/symfony/src/DependencyInjection/Factory/Security/WebauthnFactory.php
+++ b/src/symfony/src/DependencyInjection/Factory/Security/WebauthnFactory.php
@@ -10,6 +10,7 @@ use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\ParentNodeDefinitionInterface;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpFoundation\Request;
@@ -35,6 +36,7 @@ use Webauthn\Bundle\Security\Storage\SessionStorage;
 use Webauthn\Bundle\Service\PublicKeyCredentialCreationOptionsFactory;
 use Webauthn\Bundle\Service\PublicKeyCredentialRequestOptionsFactory;
 use Webauthn\Denormalizer\WebauthnSerializerFactory;
+use Webauthn\FakeCredentialGenerator;
 use function array_key_exists;
 use function assert;
 
@@ -490,7 +492,7 @@ final class WebauthnFactory implements FirewallListenerFactoryInterface, Authent
                 new Reference(PublicKeyCredentialSourceRepositoryInterface::class),
                 new Reference(PublicKeyCredentialRequestOptionsFactory::class),
                 $config['profile'],
-                new Reference(WebauthnSerializerFactory::class),
+                new Reference(FakeCredentialGenerator::class, ContainerInterface::NULL_ON_INVALID_REFERENCE),
             ]);
         $container->setDefinition($optionsBuilderId, $optionsBuilder);
 

--- a/src/symfony/src/DependencyInjection/WebauthnExtension.php
+++ b/src/symfony/src/DependencyInjection/WebauthnExtension.php
@@ -10,6 +10,7 @@ use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\FileLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -45,6 +46,7 @@ use Webauthn\CeremonyStep\CeremonyStepManager;
 use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
 use Webauthn\CeremonyStep\TopOriginValidator;
 use Webauthn\Counter\CounterChecker;
+use Webauthn\FakeCredentialGenerator;
 use Webauthn\MetadataService\CanLogData;
 use Webauthn\MetadataService\CertificateChain\CertificateChainValidator;
 use Webauthn\MetadataService\Event\CanDispatchEvents;
@@ -100,6 +102,7 @@ final class WebauthnExtension extends Extension implements PrependExtensionInter
         $container->setAlias('webauthn.http_client', $config['http_client']);
         $container->setAlias('webauthn.logger', $config['logger']);
 
+        $container->setAlias(FakeCredentialGenerator::class, $config['fake_credential_generator']);
         $container->setAlias(PublicKeyCredentialSourceRepository::class, $config['credential_repository']);
         $container->setAlias(PublicKeyCredentialSourceRepositoryInterface::class, $config['credential_repository']);
         $container->setAlias(PublicKeyCredentialUserEntityRepository::class, $config['user_repository']);
@@ -287,6 +290,7 @@ final class WebauthnExtension extends Extension implements PrependExtensionInter
                         new Reference(PublicKeyCredentialSourceRepositoryInterface::class),
                         new Reference(PublicKeyCredentialRequestOptionsFactory::class),
                         $requestConfig['profile'],
+                        new Reference(FakeCredentialGenerator::class, ContainerInterface::NULL_ON_INVALID_REFERENCE),
                     ]);
                 $container->setDefinition($assertionOptionsBuilderId, $assertionOptionsBuilder);
             }

--- a/src/symfony/src/Resources/config/services.php
+++ b/src/symfony/src/Resources/config/services.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Lcobucci\Clock\SystemClock;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -42,10 +43,12 @@ use Webauthn\Denormalizer\PublicKeyCredentialOptionsDenormalizer;
 use Webauthn\Denormalizer\PublicKeyCredentialSourceDenormalizer;
 use Webauthn\Denormalizer\PublicKeyCredentialUserEntityDenormalizer;
 use Webauthn\Denormalizer\WebauthnSerializerFactory;
+use Webauthn\FakeCredentialGenerator;
 use Webauthn\MetadataService\Denormalizer\ExtensionDescriptorDenormalizer;
 use Webauthn\MetadataService\Denormalizer\MetadataStatementSerializerFactory;
 use Webauthn\PublicKeyCredentialLoader;
 use Webauthn\PublicKeyCredentialSourceRepository;
+use Webauthn\SimpleFakeCredentialGenerator;
 use Webauthn\TokenBinding\IgnoreTokenBindingHandler;
 use Webauthn\TokenBinding\SecTokenBindingHandler;
 use Webauthn\TokenBinding\TokenBindingNotSupportedHandler;
@@ -78,6 +81,11 @@ return static function (ContainerConfigurator $container): void {
         ->class(CeremonyStepManager::class)
         ->factory([service(CeremonyStepManagerFactory::class), 'creationCeremony'])
         ->args([param('webauthn.secured_relying_party_ids')])
+    ;
+
+    $container
+        ->set(SimpleFakeCredentialGenerator::class)
+        ->args([service(CacheItemPoolInterface::class)->nullOnInvalid()])
     ;
 
     $container
@@ -162,6 +170,7 @@ return static function (ContainerConfigurator $container): void {
             service(AuthenticatorAssertionResponseValidator::class),
             service(PublicKeyCredentialUserEntityRepositoryInterface::class),
             service(PublicKeyCredentialSourceRepository::class)->nullOnInvalid(),
+            service(FakeCredentialGenerator::class)->nullOnInvalid(),
         ]);
 
     $container

--- a/src/webauthn/src/FakeCredentialGenerator.php
+++ b/src/webauthn/src/FakeCredentialGenerator.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn;
+
+use Symfony\Component\HttpFoundation\Request;
+
+interface FakeCredentialGenerator
+{
+    /**
+     * @return PublicKeyCredentialDescriptor[]
+     */
+    public function generate(Request $request, string $username): array;
+}

--- a/src/webauthn/src/SimpleFakeCredentialGenerator.php
+++ b/src/webauthn/src/SimpleFakeCredentialGenerator.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\HttpFoundation\Request;
+use function count;
+use function is_int;
+
+final class SimpleFakeCredentialGenerator implements FakeCredentialGenerator
+{
+    public function __construct(
+        private readonly null|CacheItemPoolInterface $cache = null
+    ) {
+    }
+
+    /**
+     * @return PublicKeyCredentialDescriptor[]
+     */
+    public function generate(Request $request, string $username): array
+    {
+        if ($this->cache === null) {
+            return $this->generateCredentials($username);
+        }
+
+        $cacheKey = 'fake_credentials_' . hash('xxh128', $username);
+        $cacheItem = $this->cache->getItem($cacheKey);
+        if ($cacheItem->isHit()) {
+            return $cacheItem->get();
+        }
+
+        $credentials = $this->generateCredentials($username);
+        $cacheItem->set($credentials);
+        $this->cache->save($cacheItem);
+
+        return $credentials;
+    }
+
+    /**
+     * @return PublicKeyCredentialDescriptor[]
+     */
+    private function generateCredentials(string $username): array
+    {
+        $transports = [
+            PublicKeyCredentialDescriptor::AUTHENTICATOR_TRANSPORT_USB,
+            PublicKeyCredentialDescriptor::AUTHENTICATOR_TRANSPORT_NFC,
+            PublicKeyCredentialDescriptor::AUTHENTICATOR_TRANSPORT_BLE,
+        ];
+        $credentials = [];
+        for ($i = 0; $i < random_int(1, 3); $i++) {
+            $randomTransportKeys = array_rand($transports, random_int(1, count($transports)));
+            if (is_int($randomTransportKeys)) {
+                $randomTransportKeys = [$randomTransportKeys];
+            }
+            $randomTransports = array_values(array_intersect_key($transports, array_flip($randomTransportKeys)));
+            $credentials[] = PublicKeyCredentialDescriptor::create(
+                PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
+                hash('sha256', random_bytes(16) . $username),
+                $randomTransports
+            );
+        }
+
+        return $credentials;
+    }
+}


### PR DESCRIPTION
The update introduces a FakeCredentialGenerator that generates fake credentials. This addition helps in preventing username enumeration. Furthermore, a SimpleFakeCredentialGenerator implementation, which integrates with caching, and related configuration were provided. The changes were propagated through the different parts of the system as necessary.

Target branch: 4.9.x
Resolves issue: none

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
