### PR TITLE
Add normalization support to denormalizers

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2438,7 +2438,22 @@ parameters:
 			path: src/webauthn/src/Denormalizer/AuthenticationExtensionsDenormalizer.php
 
 		-
+			message: "#^Method Webauthn\\\\Denormalizer\\\\AuthenticationExtensionsDenormalizer\\:\\:normalize\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/webauthn/src/Denormalizer/AuthenticationExtensionsDenormalizer.php
+
+		-
+			message: "#^Method Webauthn\\\\Denormalizer\\\\AuthenticationExtensionsDenormalizer\\:\\:normalize\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/webauthn/src/Denormalizer/AuthenticationExtensionsDenormalizer.php
+
+		-
 			message: "#^Method Webauthn\\\\Denormalizer\\\\AuthenticationExtensionsDenormalizer\\:\\:supportsDenormalization\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/webauthn/src/Denormalizer/AuthenticationExtensionsDenormalizer.php
+
+		-
+			message: "#^Method Webauthn\\\\Denormalizer\\\\AuthenticationExtensionsDenormalizer\\:\\:supportsNormalization\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/webauthn/src/Denormalizer/AuthenticationExtensionsDenormalizer.php
 
@@ -2753,7 +2768,22 @@ parameters:
 			path: src/webauthn/src/Denormalizer/PublicKeyCredentialOptionsDenormalizer.php
 
 		-
+			message: "#^Method Webauthn\\\\Denormalizer\\\\PublicKeyCredentialOptionsDenormalizer\\:\\:normalize\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/webauthn/src/Denormalizer/PublicKeyCredentialOptionsDenormalizer.php
+
+		-
+			message: "#^Method Webauthn\\\\Denormalizer\\\\PublicKeyCredentialOptionsDenormalizer\\:\\:normalize\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/webauthn/src/Denormalizer/PublicKeyCredentialOptionsDenormalizer.php
+
+		-
 			message: "#^Method Webauthn\\\\Denormalizer\\\\PublicKeyCredentialOptionsDenormalizer\\:\\:supportsDenormalization\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/webauthn/src/Denormalizer/PublicKeyCredentialOptionsDenormalizer.php
+
+		-
+			message: "#^Method Webauthn\\\\Denormalizer\\\\PublicKeyCredentialOptionsDenormalizer\\:\\:supportsNormalization\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/webauthn/src/Denormalizer/PublicKeyCredentialOptionsDenormalizer.php
 
@@ -3013,7 +3043,22 @@ parameters:
 			path: src/webauthn/src/Denormalizer/PublicKeyCredentialUserEntityDenormalizer.php
 
 		-
+			message: "#^Method Webauthn\\\\Denormalizer\\\\PublicKeyCredentialUserEntityDenormalizer\\:\\:normalize\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/webauthn/src/Denormalizer/PublicKeyCredentialUserEntityDenormalizer.php
+
+		-
+			message: "#^Method Webauthn\\\\Denormalizer\\\\PublicKeyCredentialUserEntityDenormalizer\\:\\:normalize\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/webauthn/src/Denormalizer/PublicKeyCredentialUserEntityDenormalizer.php
+
+		-
 			message: "#^Method Webauthn\\\\Denormalizer\\\\PublicKeyCredentialUserEntityDenormalizer\\:\\:supportsDenormalization\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/webauthn/src/Denormalizer/PublicKeyCredentialUserEntityDenormalizer.php
+
+		-
+			message: "#^Method Webauthn\\\\Denormalizer\\\\PublicKeyCredentialUserEntityDenormalizer\\:\\:supportsNormalization\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/webauthn/src/Denormalizer/PublicKeyCredentialUserEntityDenormalizer.php
 
@@ -3041,7 +3086,22 @@ parameters:
 			path: src/webauthn/src/Denormalizer/TrustPathDenormalizer.php
 
 		-
+			message: "#^Method Webauthn\\\\Denormalizer\\\\TrustPathDenormalizer\\:\\:normalize\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/webauthn/src/Denormalizer/TrustPathDenormalizer.php
+
+		-
+			message: "#^Method Webauthn\\\\Denormalizer\\\\TrustPathDenormalizer\\:\\:normalize\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/webauthn/src/Denormalizer/TrustPathDenormalizer.php
+
+		-
 			message: "#^Method Webauthn\\\\Denormalizer\\\\TrustPathDenormalizer\\:\\:supportsDenormalization\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/webauthn/src/Denormalizer/TrustPathDenormalizer.php
+
+		-
+			message: "#^Method Webauthn\\\\Denormalizer\\\\TrustPathDenormalizer\\:\\:supportsNormalization\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/webauthn/src/Denormalizer/TrustPathDenormalizer.php
 

--- a/src/webauthn/src/Denormalizer/AuthenticationExtensionsDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/AuthenticationExtensionsDenormalizer.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Webauthn\Denormalizer;
 
-use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
-use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Webauthn\AuthenticationExtensions\AuthenticationExtension;
 use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
 use Webauthn\AuthenticationExtensions\AuthenticationExtensionsClientInputs;
@@ -16,10 +15,8 @@ use function in_array;
 use function is_array;
 use function is_string;
 
-final class AuthenticationExtensionsDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface
+final class AuthenticationExtensionsDenormalizer implements DenormalizerInterface, NormalizerInterface
 {
-    use DenormalizerAwareTrait;
-
     public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
     {
         if ($data instanceof AuthenticationExtensions) {
@@ -59,5 +56,21 @@ final class AuthenticationExtensionsDenormalizer implements DenormalizerInterfac
             AuthenticationExtensionsClientInputs::class => true,
             AuthenticationExtensionsClientOutputs::class => true,
         ];
+    }
+
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
+    {
+        assert($data instanceof AuthenticationExtensions);
+        $extensions = [];
+        foreach ($data->extensions as $extension) {
+            $extensions[$extension->name] = $extension->value;
+        }
+
+        return $extensions;
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof AuthenticationExtensions;
     }
 }

--- a/src/webauthn/src/Denormalizer/PublicKeyCredentialOptionsDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/PublicKeyCredentialOptionsDenormalizer.php
@@ -9,6 +9,9 @@ use Symfony\Component\Serializer\Exception\BadMethodCallException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
 use Webauthn\AuthenticatorSelectionCriteria;
 use Webauthn\PublicKeyCredentialCreationOptions;
@@ -18,11 +21,13 @@ use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialRpEntity;
 use Webauthn\PublicKeyCredentialUserEntity;
 use function array_key_exists;
+use function assert;
 use function in_array;
 
-final class PublicKeyCredentialOptionsDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface
+final class PublicKeyCredentialOptionsDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface, NormalizerInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
 
     public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
     {
@@ -107,6 +112,11 @@ final class PublicKeyCredentialOptionsDenormalizer implements DenormalizerInterf
         );
     }
 
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof PublicKeyCredentialCreationOptions || $data instanceof PublicKeyCredentialRequestOptions;
+    }
+
     /**
      * @return array<class-string, bool>
      */
@@ -116,5 +126,55 @@ final class PublicKeyCredentialOptionsDenormalizer implements DenormalizerInterf
             PublicKeyCredentialCreationOptions::class => true,
             PublicKeyCredentialRequestOptions::class => true,
         ];
+    }
+
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
+    {
+        assert(
+            $data instanceof PublicKeyCredentialCreationOptions || $data instanceof PublicKeyCredentialRequestOptions
+        );
+        $json = [
+            'challenge' => Base64UrlSafe::encodeUnpadded($data->challenge),
+            'timeout' => $data->timeout,
+            'extensions' => $this->normalizer->normalize($data->extensions, $format, $context),
+        ];
+
+        if ($data instanceof PublicKeyCredentialCreationOptions) {
+            $json = [
+                ...$json,
+                'rp' => $this->normalizer->normalize($data->rp, PublicKeyCredentialRpEntity::class, $context),
+                'user' => $this->normalizer->normalize($data->user, PublicKeyCredentialUserEntity::class, $context),
+                'pubKeyCredParams' => $this->normalizer->normalize(
+                    $data->pubKeyCredParams,
+                    PublicKeyCredentialParameters::class . '[]',
+                    $context
+                ),
+                'authenticatorSelection' => $data->authenticatorSelection === null ? null : $this->normalizer->normalize(
+                    $data->authenticatorSelection,
+                    AuthenticatorSelectionCriteria::class,
+                    $context
+                ),
+                'attestation' => $data->attestation,
+                'excludeCredentials' => $this->normalizer->normalize(
+                    $data->excludeCredentials,
+                    PublicKeyCredentialDescriptor::class . '[]',
+                    $context
+                ),
+            ];
+        }
+        if ($data instanceof PublicKeyCredentialRequestOptions) {
+            $json = [
+                ...$json,
+                'rpId' => $data->rpId,
+                'allowCredentials' => $this->normalizer->normalize(
+                    $data->allowCredentials,
+                    PublicKeyCredentialDescriptor::class . '[]',
+                    $context
+                ),
+                'userVerification' => $data->userVerification,
+            ];
+        }
+
+        return array_filter($json, static fn ($value) => $value !== null && $value !== []);
     }
 }

--- a/src/webauthn/src/Denormalizer/PublicKeyCredentialUserEntityDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/PublicKeyCredentialUserEntityDenormalizer.php
@@ -4,17 +4,16 @@ declare(strict_types=1);
 
 namespace Webauthn\Denormalizer;
 
-use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
-use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use ParagonIE\ConstantTime\Base64UrlSafe;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Webauthn\PublicKeyCredentialUserEntity;
 use Webauthn\Util\Base64;
 use function array_key_exists;
+use function assert;
 
-final class PublicKeyCredentialUserEntityDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface
+final class PublicKeyCredentialUserEntityDenormalizer implements DenormalizerInterface, NormalizerInterface
 {
-    use DenormalizerAwareTrait;
-
     public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
     {
         if (! array_key_exists('id', $data)) {
@@ -43,5 +42,23 @@ final class PublicKeyCredentialUserEntityDenormalizer implements DenormalizerInt
         return [
             PublicKeyCredentialUserEntity::class => true,
         ];
+    }
+
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
+    {
+        assert($data instanceof PublicKeyCredentialUserEntity);
+        $normalized = [
+            'id' => Base64UrlSafe::encodeUnpadded($data->id),
+            'name' => $data->name,
+            'displayName' => $data->displayName,
+            'icon' => $data->icon,
+        ];
+
+        return array_filter($normalized, fn ($value) => $value !== null);
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof PublicKeyCredentialUserEntity;
     }
 }

--- a/src/webauthn/src/Denormalizer/TrustPathDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/TrustPathDenormalizer.php
@@ -5,14 +5,16 @@ declare(strict_types=1);
 namespace Webauthn\Denormalizer;
 
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Webauthn\Exception\InvalidTrustPathException;
 use Webauthn\TrustPath\CertificateTrustPath;
 use Webauthn\TrustPath\EcdaaKeyIdTrustPath;
 use Webauthn\TrustPath\EmptyTrustPath;
 use Webauthn\TrustPath\TrustPath;
 use function array_key_exists;
+use function assert;
 
-final class TrustPathDenormalizer implements DenormalizerInterface
+final class TrustPathDenormalizer implements DenormalizerInterface, NormalizerInterface
 {
     public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
     {
@@ -37,5 +39,25 @@ final class TrustPathDenormalizer implements DenormalizerInterface
         return [
             TrustPath::class => true,
         ];
+    }
+
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
+    {
+        assert($data instanceof TrustPath);
+        return match (true) {
+            $data instanceof EcdaaKeyIdTrustPath => [
+                'ecdaaKeyId' => $data->getEcdaaKeyId(),
+            ],
+            $data instanceof CertificateTrustPath => [
+                'x5c' => $data->certificates,
+            ],
+            $data instanceof EmptyTrustPath => [],
+            default => throw new InvalidTrustPathException('Unsupported trust path type'),
+        };
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof TrustPath;
     }
 }

--- a/tests/library/Unit/SerializerTest.php
+++ b/tests/library/Unit/SerializerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Serializer\Encoder\JsonEncode;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+use Webauthn\AuthenticatorSelectionCriteria;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialParameters;
+use Webauthn\PublicKeyCredentialRpEntity;
+use Webauthn\PublicKeyCredentialUserEntity;
+use Webauthn\Tests\AbstractTestCase;
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * @internal
+ */
+final class SerializerTest extends AbstractTestCase
+{
+    #[Test]
+    public function theCredentialCanBeDeserialized(): void
+    {
+        //Given
+        $publicKeyCredentialCreationOptions = PublicKeyCredentialCreationOptions::create(
+            PublicKeyCredentialRpEntity::create('Example.com', 'example.com'),
+            PublicKeyCredentialUserEntity::create('john.doe', '0123456789', 'John Doe'),
+            hash('xxh128', 'pk id test', true),
+            [PublicKeyCredentialParameters::createPk(-1), PublicKeyCredentialParameters::createPk(256)],
+            AuthenticatorSelectionCriteria::create(
+                AuthenticatorSelectionCriteria::AUTHENTICATOR_ATTACHMENT_CROSS_PLATFORM,
+                AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_REQUIRED,
+            ),
+            PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
+        );
+
+        //When
+        $json = $this->getSerializer()
+            ->serialize(
+                $publicKeyCredentialCreationOptions,
+                'json',
+                [
+                    JsonEncode::OPTIONS => JSON_THROW_ON_ERROR,
+                    AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+                    AbstractObjectNormalizer::SKIP_UNINITIALIZED_VALUES => true,
+                ],
+            );
+
+        //Then
+        static::assertJsonStringEqualsJsonString(
+            '{
+                "rp": {
+                    "id": "example.com",
+                    "name": "Example.com"
+                },
+                "user": {
+                    "id": "MDEyMzQ1Njc4OQ",
+                    "name": "john.doe",
+                    "displayName": "John Doe"
+                },
+                "challenge": "Q3_A7bKkpBKqDwV0fdS4Ow",
+                "pubKeyCredParams": [
+                    {
+                        "type": "public-key",
+                        "alg": -1
+                    },
+                    {
+                        "type": "public-key",
+                        "alg": 256
+                    }
+                ],
+                "authenticatorSelection": {
+                    "authenticatorAttachment": "cross-platform",
+                    "userVerification": "required"
+                },
+                "attestation": "none"
+            }',
+            $json,
+        );
+    }
+}


### PR DESCRIPTION
This update enhances several denormalizer classes in the WebAuthn package (AuthenticationExtensionsDenormalizer, PublicKeyCredentialOptionsDenormalizer, PublicKeyCredentialUserEntityDenormalizer, TrustPathDenormalizer) to also support normalization. This allows backward conversion from entities back to arrays. A new Serializer unit test has been introduced for validation.

Target branch: 4.9.x
Resolves issue #591

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
