### PR TITLE
Remove debug dump in ProfileBasedRequestOptionsBuilder

### DIFF
--- a/src/symfony/src/CredentialOptionsBuilder/ProfileBasedRequestOptionsBuilder.php
+++ b/src/symfony/src/CredentialOptionsBuilder/ProfileBasedRequestOptionsBuilder.php
@@ -73,7 +73,7 @@ final class ProfileBasedRequestOptionsBuilder implements PublicKeyCredentialRequ
         $userEntity = $optionsRequest->username === null ? null : $this->userEntityRepository->findOneByUsername(
             $optionsRequest->username
         );
-        dump($this->fakeCredentialGenerator?->generate($request, $optionsRequest->username ?? ''));
+
         $allowedCredentials = match (true) {
             $userEntity === null && $optionsRequest->username === null, $userEntity === null && $optionsRequest->username !== null && $this->fakeCredentialGenerator === null => [],
             $userEntity === null && $optionsRequest->username !== null && $this->fakeCredentialGenerator !== null => $this->fakeCredentialGenerator->generate(


### PR DESCRIPTION
The update removes a debug dump in the ProfileBasedRequestOptionsBuilder. This dump was outputting the results of the fake credential generator if it's defined in cases when a

Target branch: 
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
