### PR TITLE
Add feature to hide existing credentials

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -693,6 +693,11 @@ parameters:
 			path: src/symfony/src/Controller/AttestationControllerFactory.php
 
 		-
+			message: "#^Method Webauthn\\\\Bundle\\\\CredentialOptionsBuilder\\\\PublicKeyCredentialCreationOptionsBuilder\\:\\:getFromRequest\\(\\) invoked with 3 parameters, 2 required\\.$#"
+			count: 1
+			path: src/symfony/src/Controller/AttestationRequestController.php
+
+		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Request\\:\\:getContentType\\(\\)\\.$#"
 			count: 1
 			path: src/symfony/src/Controller/AttestationResponseController.php
@@ -804,11 +809,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\$credentialSourceRepository of method Webauthn\\\\Bundle\\\\CredentialOptionsBuilder\\\\ProfileBasedRequestOptionsBuilder\\:\\:__construct\\(\\) has typehint with deprecated interface Webauthn\\\\PublicKeyCredentialSourceRepository\\.$#"
-			count: 1
-			path: src/symfony/src/CredentialOptionsBuilder/ProfileBasedRequestOptionsBuilder.php
-
-		-
-			message: "#^Should not use function \"dump\", please change the code\\.$#"
 			count: 1
 			path: src/symfony/src/CredentialOptionsBuilder/ProfileBasedRequestOptionsBuilder.php
 
@@ -1059,6 +1059,11 @@ parameters:
 		-
 			message: "#^Cannot access offset 'failure_handler' on mixed\\.$#"
 			count: 4
+			path: src/symfony/src/DependencyInjection/WebauthnExtension.php
+
+		-
+			message: "#^Cannot access offset 'hide_existing…' on mixed\\.$#"
+			count: 1
 			path: src/symfony/src/DependencyInjection/WebauthnExtension.php
 
 		-

--- a/src/symfony/src/Controller/AttestationControllerFactory.php
+++ b/src/symfony/src/Controller/AttestationControllerFactory.php
@@ -72,13 +72,15 @@ final class AttestationControllerFactory
         OptionsStorage $optionStorage,
         CreationOptionsHandler $creationOptionsHandler,
         FailureHandler|AuthenticationFailureHandlerInterface $failureHandler,
+        bool $hideExistingExcludedCredentials = false
     ): AttestationRequestController {
         return new AttestationRequestController(
             $optionsBuilder,
             $userEntityGuesser,
             $optionStorage,
             $creationOptionsHandler,
-            $failureHandler
+            $failureHandler,
+            $hideExistingExcludedCredentials
         );
     }
 

--- a/src/symfony/src/Controller/AttestationRequestController.php
+++ b/src/symfony/src/Controller/AttestationRequestController.php
@@ -24,6 +24,7 @@ final class AttestationRequestController
         private readonly OptionsStorage $optionsStorage,
         private readonly CreationOptionsHandler $creationOptionsHandler,
         private readonly FailureHandler|AuthenticationFailureHandlerInterface $failureHandler,
+        private readonly bool $hideExistingExcludedCredentials = false,
     ) {
     }
 
@@ -31,7 +32,11 @@ final class AttestationRequestController
     {
         try {
             $userEntity = $this->userEntityGuesser->findUserEntity($request);
-            $publicKeyCredentialCreationOptions = $this->extractor->getFromRequest($request, $userEntity);
+            $publicKeyCredentialCreationOptions = $this->extractor->getFromRequest(
+                $request,
+                $userEntity,
+                $this->hideExistingExcludedCredentials
+            );
 
             $response = $this->creationOptionsHandler->onCreationOptions(
                 $publicKeyCredentialCreationOptions,

--- a/src/symfony/src/CredentialOptionsBuilder/ProfileBasedCreationOptionsBuilder.php
+++ b/src/symfony/src/CredentialOptionsBuilder/ProfileBasedCreationOptionsBuilder.php
@@ -48,7 +48,8 @@ final class ProfileBasedCreationOptionsBuilder implements PublicKeyCredentialCre
 
     public function getFromRequest(
         Request $request,
-        PublicKeyCredentialUserEntity $userEntity
+        PublicKeyCredentialUserEntity $userEntity,
+        bool $hideExistingExcludedCredentials = false
     ): PublicKeyCredentialCreationOptions {
         $format = method_exists(
             $request,
@@ -57,7 +58,7 @@ final class ProfileBasedCreationOptionsBuilder implements PublicKeyCredentialCre
         $format === 'json' || throw new BadRequestHttpException('Only JSON content type allowed');
         $content = $request->getContent();
 
-        $excludedCredentials = $this->getCredentials($userEntity);
+        $excludedCredentials = $hideExistingExcludedCredentials === true ? [] : $this->getCredentials($userEntity);
         $optionsRequest = $this->getServerPublicKeyCredentialCreationOptionsRequest($content);
         $authenticatorSelectionData = $optionsRequest->authenticatorSelection;
         $authenticatorSelection = null;

--- a/src/symfony/src/CredentialOptionsBuilder/PublicKeyCredentialCreationOptionsBuilder.php
+++ b/src/symfony/src/CredentialOptionsBuilder/PublicKeyCredentialCreationOptionsBuilder.php
@@ -12,6 +12,7 @@ interface PublicKeyCredentialCreationOptionsBuilder
 {
     public function getFromRequest(
         Request $request,
-        PublicKeyCredentialUserEntity $userEntity
+        PublicKeyCredentialUserEntity $userEntity,
+        /*bool $hideExistingExcludedCredentials = false*/
     ): PublicKeyCredentialCreationOptions;
 }

--- a/src/symfony/src/DependencyInjection/Configuration.php
+++ b/src/symfony/src/DependencyInjection/Configuration.php
@@ -354,6 +354,12 @@ final class Configuration implements ConfigurationInterface
             ->scalarNode('user_entity_guesser')
             ->isRequired()
             ->end()
+            ->scalarNode('hide_existing_credentials')
+                ->info(
+                    'In order to prevent username enumeration, the existing credentials can be hidden. This is highly recommended when the attestation ceremony is performed by anonymous users.'
+                )
+                ->defaultFalse()
+            ->end()
             ->scalarNode('options_storage')
             ->defaultValue(SessionStorage::class)
             ->info('Service responsible of the options/user entity storage during the ceremony')

--- a/src/symfony/src/DependencyInjection/Factory/Security/WebauthnFactory.php
+++ b/src/symfony/src/DependencyInjection/Factory/Security/WebauthnFactory.php
@@ -415,6 +415,7 @@ final class WebauthnFactory implements FirewallListenerFactoryInterface, Authent
                 new Reference($optionsStorageId),
                 new Reference($optionsHandlerId),
                 new Reference($failureHandlerId),
+                true,
             ]);
         $this->createControllerAndRoute(
             $container,

--- a/src/symfony/src/DependencyInjection/WebauthnExtension.php
+++ b/src/symfony/src/DependencyInjection/WebauthnExtension.php
@@ -215,6 +215,7 @@ final class WebauthnExtension extends Extension implements PrependExtensionInter
                     new Reference($creationConfig['options_storage']),
                     new Reference($creationConfig['options_handler']),
                     new Reference($creationConfig['failure_handler']),
+                    $creationConfig['hide_existing_credentials'] ?? false,
                 ])
                 ->addTag(DynamicRouteCompilerPass::TAG, [
                     'method' => $creationConfig['options_method'],

--- a/tests/symfony/config/config.yml
+++ b/tests/symfony/config/config.yml
@@ -131,6 +131,7 @@ webauthn:
     enabled: true
     creation:
       test:
+        hide_existing_credentials: true
         options_path: '/devices/add/options'
         result_path: '/devices/add'
         #host: null

--- a/tests/symfony/functional/Attestation/AdditionalAuthenticatorTest.php
+++ b/tests/symfony/functional/Attestation/AdditionalAuthenticatorTest.php
@@ -64,6 +64,7 @@ final class AdditionalAuthenticatorTest extends WebTestCase
             static::assertArrayHasKey($expectedKey, $data);
         }
         static::assertSame('ok', $data['status']);
+        static::assertArrayNotHasKey('excludeCredentials', $data); // username enumeration prevention is enabled
     }
 
     #[Test]

--- a/tests/symfony/functional/PublicKeyCredentialSourceRepository.php
+++ b/tests/symfony/functional/PublicKeyCredentialSourceRepository.php
@@ -38,6 +38,24 @@ final class PublicKeyCredentialSourceRepository implements PublicKeyCredentialSo
             100
         );
         $this->saveCredentialSource($publicKeyCredentialSource1);
+        $publicKeyCredentialSource2 = PublicKeyCredentialSource::create(
+            base64_decode(
+                'Ac8zKrpVWv9UCwxY1FyMqkESz2lV4CNwTk2+Hp19LgKbvh5uQ2/i6AMbTbTz1zcNapCEeiLJPlAAVM4L7AIow6I=',
+                true
+            ),
+            PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
+            [],
+            AttestationStatement::TYPE_NONE,
+            EmptyTrustPath::create(),
+            Uuid::fromBinary(base64_decode('AAAAAAAAAAAAAAAAAAAAAA==', true)),
+            base64_decode(
+                'pQECAyYgASFYIJV56vRrFusoDf9hm3iDmllcxxXzzKyO9WruKw4kWx7zIlgg/nq63l8IMJcIdKDJcXRh9hoz0L+nVwP1Oxil3/oNQYs=',
+                true
+            ),
+            '929fba2f-2361-4bc6-a917-bb76aa14c7f9',
+            100
+        );
+        $this->saveCredentialSource($publicKeyCredentialSource2);
     }
 
     public function findOneByCredentialId(string $publicKeyCredentialId): ?PublicKeyCredentialSource


### PR DESCRIPTION
The code changes enable suppressing the existing user credential details to enhance security. This feature introduces a preventive measure against username enumeration exploits by concealing the previously existing credentials. The flag 'hide_existing_credentials' has been added to facilitate this change, defaulted to false. This change is particularly important during the attestation ceremony performed by anonymous users.

Target branch: 4.9.x
Resolves issue # none

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
