### PR TITLE
Add VerificationMethodANDCombinationsDenormalizer and trigger depreca…

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -46,6 +46,56 @@ parameters:
 			path: src/metadata-service/src/Denormalizer/ExtensionDescriptorDenormalizer.php
 
 		-
+			message: "#^Method Webauthn\\\\MetadataService\\\\Denormalizer\\\\VerificationMethodANDCombinationsDenormalizer\\:\\:normalize\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/metadata-service/src/Denormalizer/VerificationMethodANDCombinationsDenormalizer.php
+
+		-
+			message: "#^Method Webauthn\\\\MetadataService\\\\Denormalizer\\\\VerificationMethodANDCombinationsDenormalizer\\:\\:normalize\\(\\) never returns ArrayObject so it can be removed from the return type\\.$#"
+			count: 1
+			path: src/metadata-service/src/Denormalizer/VerificationMethodANDCombinationsDenormalizer.php
+
+		-
+			message: "#^Method Webauthn\\\\MetadataService\\\\Denormalizer\\\\VerificationMethodANDCombinationsDenormalizer\\:\\:normalize\\(\\) never returns bool so it can be removed from the return type\\.$#"
+			count: 1
+			path: src/metadata-service/src/Denormalizer/VerificationMethodANDCombinationsDenormalizer.php
+
+		-
+			message: "#^Method Webauthn\\\\MetadataService\\\\Denormalizer\\\\VerificationMethodANDCombinationsDenormalizer\\:\\:normalize\\(\\) never returns float so it can be removed from the return type\\.$#"
+			count: 1
+			path: src/metadata-service/src/Denormalizer/VerificationMethodANDCombinationsDenormalizer.php
+
+		-
+			message: "#^Method Webauthn\\\\MetadataService\\\\Denormalizer\\\\VerificationMethodANDCombinationsDenormalizer\\:\\:normalize\\(\\) never returns int so it can be removed from the return type\\.$#"
+			count: 1
+			path: src/metadata-service/src/Denormalizer/VerificationMethodANDCombinationsDenormalizer.php
+
+		-
+			message: "#^Method Webauthn\\\\MetadataService\\\\Denormalizer\\\\VerificationMethodANDCombinationsDenormalizer\\:\\:normalize\\(\\) never returns null so it can be removed from the return type\\.$#"
+			count: 1
+			path: src/metadata-service/src/Denormalizer/VerificationMethodANDCombinationsDenormalizer.php
+
+		-
+			message: "#^Method Webauthn\\\\MetadataService\\\\Denormalizer\\\\VerificationMethodANDCombinationsDenormalizer\\:\\:normalize\\(\\) never returns string so it can be removed from the return type\\.$#"
+			count: 1
+			path: src/metadata-service/src/Denormalizer/VerificationMethodANDCombinationsDenormalizer.php
+
+		-
+			message: "#^Method Webauthn\\\\MetadataService\\\\Denormalizer\\\\VerificationMethodANDCombinationsDenormalizer\\:\\:normalize\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/metadata-service/src/Denormalizer/VerificationMethodANDCombinationsDenormalizer.php
+
+		-
+			message: "#^Method Webauthn\\\\MetadataService\\\\Denormalizer\\\\VerificationMethodANDCombinationsDenormalizer\\:\\:normalize\\(\\) return type with generic class ArrayObject does not specify its types\\: TKey, TValue$#"
+			count: 1
+			path: src/metadata-service/src/Denormalizer/VerificationMethodANDCombinationsDenormalizer.php
+
+		-
+			message: "#^Method Webauthn\\\\MetadataService\\\\Denormalizer\\\\VerificationMethodANDCombinationsDenormalizer\\:\\:supportsNormalization\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/metadata-service/src/Denormalizer/VerificationMethodANDCombinationsDenormalizer.php
+
+		-
 			message: "#^Method Webauthn\\\\MetadataService\\\\Psr18HttpClient\\:\\:request\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/metadata-service/src/Psr18HttpClient.php

--- a/src/metadata-service/src/Denormalizer/MetadataStatementSerializerFactory.php
+++ b/src/metadata-service/src/Denormalizer/MetadataStatementSerializerFactory.php
@@ -31,6 +31,7 @@ final class MetadataStatementSerializerFactory
         }
 
         $denormalizers = [
+            new VerificationMethodANDCombinationsDenormalizer(),
             new ExtensionDescriptorDenormalizer(),
             new UidNormalizer(),
             new ArrayDenormalizer(),

--- a/src/metadata-service/src/Denormalizer/VerificationMethodANDCombinationsDenormalizer.php
+++ b/src/metadata-service/src/Denormalizer/VerificationMethodANDCombinationsDenormalizer.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\MetadataService\Denormalizer;
+
+use ArrayObject;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Webauthn\MetadataService\Statement\VerificationMethodANDCombinations;
+use function assert;
+
+final class VerificationMethodANDCombinationsDenormalizer implements NormalizerInterface, NormalizerAwareInterface
+{
+    use NormalizerAwareTrait;
+
+    /**
+     * @return array<class-string, bool>
+     */
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            VerificationMethodANDCombinations::class => true,
+        ];
+    }
+
+    public function normalize(
+        mixed $object,
+        ?string $format = null,
+        array $context = []
+    ): array|string|int|float|bool|ArrayObject|null {
+        assert($object instanceof VerificationMethodANDCombinations);
+
+        return array_map(
+            fn ($verificationMethod) => $this->normalizer->normalize($verificationMethod, $format, $context),
+            $object->verificationMethods
+        );
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof VerificationMethodANDCombinations;
+    }
+}

--- a/src/metadata-service/src/Service/MetadataBLOBPayload.php
+++ b/src/metadata-service/src/Service/MetadataBLOBPayload.php
@@ -116,6 +116,18 @@ class MetadataBLOBPayload implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        trigger_deprecation(
+            'web-auth/webauthn-bundle',
+            '4.9.0',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
+            __METHOD__
+        );
+        trigger_deprecation(
+            'web-auth/webauthn-bundle',
+            '4.9.0',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
+            __METHOD__
+        );
         $data = [
             'legalHeader' => $this->legalHeader,
             'nextUpdate' => $this->nextUpdate,

--- a/src/metadata-service/src/Service/MetadataBLOBPayloadEntry.php
+++ b/src/metadata-service/src/Service/MetadataBLOBPayloadEntry.php
@@ -210,6 +210,12 @@ class MetadataBLOBPayloadEntry implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        trigger_deprecation(
+            'web-auth/webauthn-bundle',
+            '4.9.0',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
+            __METHOD__
+        );
         $data = [
             'aaid' => $this->aaid,
             'aaguid' => $this->aaguid,

--- a/src/metadata-service/src/Statement/AlternativeDescriptions.php
+++ b/src/metadata-service/src/Statement/AlternativeDescriptions.php
@@ -50,6 +50,12 @@ class AlternativeDescriptions implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        trigger_deprecation(
+            'web-auth/webauthn-bundle',
+            '4.9.0',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
+            __METHOD__
+        );
         return $this->descriptions;
     }
 }

--- a/src/metadata-service/src/Statement/AuthenticatorGetInfo.php
+++ b/src/metadata-service/src/Statement/AuthenticatorGetInfo.php
@@ -40,6 +40,12 @@ class AuthenticatorGetInfo implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        trigger_deprecation(
+            'web-auth/webauthn-bundle',
+            '4.9.0',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
+            __METHOD__
+        );
         return $this->info;
     }
 }

--- a/src/metadata-service/src/Statement/BiometricAccuracyDescriptor.php
+++ b/src/metadata-service/src/Statement/BiometricAccuracyDescriptor.php
@@ -74,6 +74,12 @@ class BiometricAccuracyDescriptor extends AbstractDescriptor
      */
     public function jsonSerialize(): array
     {
+        trigger_deprecation(
+            'web-auth/webauthn-bundle',
+            '4.9.0',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
+            __METHOD__
+        );
         $data = [
             'selfAttestedFRR' => $this->selfAttestedFRR,
             'selfAttestedFAR' => $this->selfAttestedFAR,

--- a/src/metadata-service/src/Statement/BiometricStatusReport.php
+++ b/src/metadata-service/src/Statement/BiometricStatusReport.php
@@ -125,6 +125,12 @@ class BiometricStatusReport implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        trigger_deprecation(
+            'web-auth/webauthn-bundle',
+            '4.9.0',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
+            __METHOD__
+        );
         $data = [
             'certLevel' => $this->certLevel,
             'modality' => $this->modality,

--- a/src/metadata-service/src/Statement/CodeAccuracyDescriptor.php
+++ b/src/metadata-service/src/Statement/CodeAccuracyDescriptor.php
@@ -77,6 +77,12 @@ class CodeAccuracyDescriptor extends AbstractDescriptor
      */
     public function jsonSerialize(): array
     {
+        trigger_deprecation(
+            'web-auth/webauthn-bundle',
+            '4.9.0',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
+            __METHOD__
+        );
         $data = [
             'base' => $this->base,
             'minLength' => $this->minLength,

--- a/src/metadata-service/src/Statement/DisplayPNGCharacteristicsDescriptor.php
+++ b/src/metadata-service/src/Statement/DisplayPNGCharacteristicsDescriptor.php
@@ -184,6 +184,12 @@ class DisplayPNGCharacteristicsDescriptor implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        trigger_deprecation(
+            'web-auth/webauthn-bundle',
+            '4.9.0',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
+            __METHOD__
+        );
         $data = [
             'width' => $this->width,
             'height' => $this->height,

--- a/src/metadata-service/src/Statement/EcdaaTrustAnchor.php
+++ b/src/metadata-service/src/Statement/EcdaaTrustAnchor.php
@@ -87,6 +87,12 @@ class EcdaaTrustAnchor implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        trigger_deprecation(
+            'web-auth/webauthn-bundle',
+            '4.9.0',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
+            __METHOD__
+        );
         $data = [
             'X' => Base64UrlSafe::encodeUnpadded($this->X),
             'Y' => Base64UrlSafe::encodeUnpadded($this->Y),

--- a/src/metadata-service/src/Statement/ExtensionDescriptor.php
+++ b/src/metadata-service/src/Statement/ExtensionDescriptor.php
@@ -94,6 +94,12 @@ class ExtensionDescriptor implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        trigger_deprecation(
+            'web-auth/webauthn-bundle',
+            '4.9.0',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
+            __METHOD__
+        );
         $result = [
             'id' => $this->id,
             'tag' => $this->tag,

--- a/src/metadata-service/src/Statement/MetadataStatement.php
+++ b/src/metadata-service/src/Statement/MetadataStatement.php
@@ -658,6 +658,12 @@ class MetadataStatement implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        trigger_deprecation(
+            'web-auth/webauthn-bundle',
+            '4.9.0',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
+            __METHOD__
+        );
         $data = [
             'legalHeader' => $this->legalHeader,
             'aaid' => $this->aaid,

--- a/src/metadata-service/src/Statement/PatternAccuracyDescriptor.php
+++ b/src/metadata-service/src/Statement/PatternAccuracyDescriptor.php
@@ -65,6 +65,12 @@ class PatternAccuracyDescriptor extends AbstractDescriptor
      */
     public function jsonSerialize(): array
     {
+        trigger_deprecation(
+            'web-auth/webauthn-bundle',
+            '4.9.0',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
+            __METHOD__
+        );
         $data = [
             'minComplexity' => $this->minComplexity,
             'maxRetries' => $this->maxRetries,

--- a/src/metadata-service/src/Statement/RgbPaletteEntry.php
+++ b/src/metadata-service/src/Statement/RgbPaletteEntry.php
@@ -78,6 +78,12 @@ class RgbPaletteEntry implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        trigger_deprecation(
+            'web-auth/webauthn-bundle',
+            '4.9.0',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
+            __METHOD__
+        );
         return [
             'r' => $this->r,
             'g' => $this->g,

--- a/src/metadata-service/src/Statement/RogueListEntry.php
+++ b/src/metadata-service/src/Statement/RogueListEntry.php
@@ -62,6 +62,12 @@ class RogueListEntry implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        trigger_deprecation(
+            'web-auth/webauthn-bundle',
+            '4.9.0',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
+            __METHOD__
+        );
         return [
             'sk' => $this->sk,
             'date' => $this->date,

--- a/src/metadata-service/src/Statement/StatusReport.php
+++ b/src/metadata-service/src/Statement/StatusReport.php
@@ -183,6 +183,12 @@ class StatusReport implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        trigger_deprecation(
+            'web-auth/webauthn-bundle',
+            '4.9.0',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
+            __METHOD__
+        );
         $data = [
             'status' => $this->status,
             'effectiveDate' => $this->effectiveDate,

--- a/src/metadata-service/src/Statement/VerificationMethodANDCombinations.php
+++ b/src/metadata-service/src/Statement/VerificationMethodANDCombinations.php
@@ -68,6 +68,12 @@ class VerificationMethodANDCombinations implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        trigger_deprecation(
+            'web-auth/webauthn-bundle',
+            '4.9.0',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
+            __METHOD__
+        );
         return $this->verificationMethods;
     }
 }

--- a/src/metadata-service/src/Statement/VerificationMethodDescriptor.php
+++ b/src/metadata-service/src/Statement/VerificationMethodDescriptor.php
@@ -255,6 +255,12 @@ class VerificationMethodDescriptor implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        trigger_deprecation(
+            'web-auth/webauthn-bundle',
+            '4.9.0',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
+            __METHOD__
+        );
         $data = [
             'userVerificationMethod' => $this->userVerificationMethod,
             'caDesc' => $this->caDesc,

--- a/src/metadata-service/src/Statement/Version.php
+++ b/src/metadata-service/src/Statement/Version.php
@@ -72,6 +72,12 @@ class Version implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        trigger_deprecation(
+            'web-auth/webauthn-bundle',
+            '4.9.0',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
+            __METHOD__
+        );
         $data = [
             'major' => $this->major,
             'minor' => $this->minor,

--- a/src/symfony/src/Resources/config/services.php
+++ b/src/symfony/src/Resources/config/services.php
@@ -49,6 +49,7 @@ use Webauthn\Denormalizer\WebauthnSerializerFactory;
 use Webauthn\FakeCredentialGenerator;
 use Webauthn\MetadataService\Denormalizer\ExtensionDescriptorDenormalizer;
 use Webauthn\MetadataService\Denormalizer\MetadataStatementSerializerFactory;
+use Webauthn\MetadataService\Denormalizer\VerificationMethodANDCombinationsDenormalizer;
 use Webauthn\PublicKeyCredentialLoader;
 use Webauthn\PublicKeyCredentialSourceRepository;
 use Webauthn\SimpleFakeCredentialGenerator;
@@ -196,6 +197,11 @@ return static function (ContainerConfigurator $container): void {
     $container
         ->alias('webauthn.request_factory.default', RequestFactoryInterface::class);
 
+    $container
+        ->set(VerificationMethodANDCombinationsDenormalizer::class)
+        ->tag('serializer.normalizer', [
+            'priority' => 1024,
+        ]);
     $container
         ->set(ExtensionDescriptorDenormalizer::class)
         ->tag('serializer.normalizer', [

--- a/src/webauthn/src/AttestationStatement/AttestationStatement.php
+++ b/src/webauthn/src/AttestationStatement/AttestationStatement.php
@@ -177,7 +177,7 @@ class AttestationStatement implements JsonSerializable
         trigger_deprecation(
             'web-auth/webauthn-bundle',
             '4.9.0',
-            'The "%s" method is deprecated and will be removed in 5.0. The serializer instead.',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
             __METHOD__
         );
         return [

--- a/src/webauthn/src/AttestedCredentialData.php
+++ b/src/webauthn/src/AttestedCredentialData.php
@@ -111,7 +111,7 @@ class AttestedCredentialData implements JsonSerializable
         trigger_deprecation(
             'web-auth/webauthn-bundle',
             '4.9.0',
-            'The "%s" method is deprecated and will be removed in 5.0. The serializer instead.',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
             __METHOD__
         );
         $result = [

--- a/src/webauthn/src/AuthenticationExtensions/AuthenticationExtension.php
+++ b/src/webauthn/src/AuthenticationExtensions/AuthenticationExtension.php
@@ -42,7 +42,7 @@ class AuthenticationExtension implements JsonSerializable
         trigger_deprecation(
             'web-auth/webauthn-bundle',
             '4.9.0',
-            'The "%s" method is deprecated and will be removed in 5.0. The serializer instead.',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
             __METHOD__
         );
         return $this->value;

--- a/src/webauthn/src/AuthenticationExtensions/AuthenticationExtensions.php
+++ b/src/webauthn/src/AuthenticationExtensions/AuthenticationExtensions.php
@@ -112,7 +112,7 @@ class AuthenticationExtensions implements JsonSerializable, Countable, IteratorA
         trigger_deprecation(
             'web-auth/webauthn-bundle',
             '4.9.0',
-            'The "%s" method is deprecated and will be removed in 5.0. The serializer instead.',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
             __METHOD__
         );
         return $this->extensions;

--- a/src/webauthn/src/AuthenticatorSelectionCriteria.php
+++ b/src/webauthn/src/AuthenticatorSelectionCriteria.php
@@ -232,7 +232,7 @@ class AuthenticatorSelectionCriteria implements JsonSerializable
         trigger_deprecation(
             'web-auth/webauthn-bundle',
             '4.9.0',
-            'The "%s" method is deprecated and will be removed in 5.0. The serializer instead.',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
             __METHOD__
         );
         $json = [

--- a/src/webauthn/src/PublicKeyCredentialCreationOptions.php
+++ b/src/webauthn/src/PublicKeyCredentialCreationOptions.php
@@ -316,7 +316,7 @@ final class PublicKeyCredentialCreationOptions extends PublicKeyCredentialOption
         trigger_deprecation(
             'web-auth/webauthn-bundle',
             '4.9.0',
-            'The "%s" method is deprecated and will be removed in 5.0. The serializer instead.',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
             __METHOD__
         );
         $json = [

--- a/src/webauthn/src/PublicKeyCredentialDescriptor.php
+++ b/src/webauthn/src/PublicKeyCredentialDescriptor.php
@@ -110,7 +110,7 @@ class PublicKeyCredentialDescriptor implements JsonSerializable
         trigger_deprecation(
             'web-auth/webauthn-bundle',
             '4.9.0',
-            'The "%s" method is deprecated and will be removed in 5.0. The serializer instead.',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
             __METHOD__
         );
         $json = [

--- a/src/webauthn/src/PublicKeyCredentialParameters.php
+++ b/src/webauthn/src/PublicKeyCredentialParameters.php
@@ -86,7 +86,7 @@ class PublicKeyCredentialParameters implements JsonSerializable
         trigger_deprecation(
             'web-auth/webauthn-bundle',
             '4.9.0',
-            'The "%s" method is deprecated and will be removed in 5.0. The serializer instead.',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
             __METHOD__
         );
         return [

--- a/src/webauthn/src/PublicKeyCredentialRequestOptions.php
+++ b/src/webauthn/src/PublicKeyCredentialRequestOptions.php
@@ -207,7 +207,7 @@ final class PublicKeyCredentialRequestOptions extends PublicKeyCredentialOptions
         trigger_deprecation(
             'web-auth/webauthn-bundle',
             '4.9.0',
-            'The "%s" method is deprecated and will be removed in 5.0. The serializer instead.',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
             __METHOD__
         );
         $json = [

--- a/src/webauthn/src/PublicKeyCredentialRpEntity.php
+++ b/src/webauthn/src/PublicKeyCredentialRpEntity.php
@@ -54,7 +54,7 @@ class PublicKeyCredentialRpEntity extends PublicKeyCredentialEntity
         trigger_deprecation(
             'web-auth/webauthn-bundle',
             '4.9.0',
-            'The "%s" method is deprecated and will be removed in 5.0. The serializer instead.',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
             __METHOD__
         );
         $json = parent::jsonSerialize();

--- a/src/webauthn/src/PublicKeyCredentialSource.php
+++ b/src/webauthn/src/PublicKeyCredentialSource.php
@@ -251,7 +251,7 @@ class PublicKeyCredentialSource implements JsonSerializable
         trigger_deprecation(
             'web-auth/webauthn-bundle',
             '4.9.0',
-            'The "%s" method is deprecated and will be removed in 5.0. The serializer instead.',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
             __METHOD__
         );
         $result = [

--- a/src/webauthn/src/PublicKeyCredentialUserEntity.php
+++ b/src/webauthn/src/PublicKeyCredentialUserEntity.php
@@ -90,7 +90,7 @@ class PublicKeyCredentialUserEntity extends PublicKeyCredentialEntity
         trigger_deprecation(
             'web-auth/webauthn-bundle',
             '4.9.0',
-            'The "%s" method is deprecated and will be removed in 5.0. The serializer instead.',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
             __METHOD__
         );
         $json = parent::jsonSerialize();

--- a/src/webauthn/src/TrustPath/CertificateTrustPath.php
+++ b/src/webauthn/src/TrustPath/CertificateTrustPath.php
@@ -59,7 +59,7 @@ final class CertificateTrustPath implements TrustPath
         trigger_deprecation(
             'web-auth/webauthn-bundle',
             '4.9.0',
-            'The "%s" method is deprecated and will be removed in 5.0. The serializer instead.',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
             __METHOD__
         );
         return [

--- a/src/webauthn/src/TrustPath/EmptyTrustPath.php
+++ b/src/webauthn/src/TrustPath/EmptyTrustPath.php
@@ -19,7 +19,7 @@ final class EmptyTrustPath implements TrustPath
         trigger_deprecation(
             'web-auth/webauthn-bundle',
             '4.9.0',
-            'The "%s" method is deprecated and will be removed in 5.0. The serializer instead.',
+            'The "%s" method is deprecated and will be removed in 5.0. Please use the serializer instead.',
             __METHOD__
         );
         return [

--- a/tests/MDS/Unit/BiometricAccuracyDescriptorObjectTest.php
+++ b/tests/MDS/Unit/BiometricAccuracyDescriptorObjectTest.php
@@ -6,15 +6,14 @@ namespace Webauthn\Tests\MetadataService\Unit;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Webauthn\MetadataService\Statement\BiometricAccuracyDescriptor;
-use const JSON_THROW_ON_ERROR;
-use const JSON_UNESCAPED_SLASHES;
 
 /**
  * @internal
  */
-final class BiometricAccuracyDescriptorObjectTest extends TestCase
+final class BiometricAccuracyDescriptorObjectTest extends MdsTestCase
 {
     #[Test]
     #[DataProvider('validObjectData')]
@@ -32,7 +31,9 @@ final class BiometricAccuracyDescriptorObjectTest extends TestCase
         static::assertSame($maxTemplates, $object->maxTemplates);
         static::assertSame($maxRetries, $object->maxRetries);
         static::assertSame($blockSlowdown, $object->blockSlowdown);
-        static::assertSame($expectedJson, json_encode($object, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES));
+        static::assertSame($expectedJson, $this->getSerializer()->serialize($object, JsonEncoder::FORMAT, [
+            AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+        ]));
     }
 
     public static function validObjectData(): iterable

--- a/tests/MDS/Unit/CodeAccuracyDescriptorObjectTest.php
+++ b/tests/MDS/Unit/CodeAccuracyDescriptorObjectTest.php
@@ -6,15 +6,15 @@ namespace Webauthn\Tests\MetadataService\Unit;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Webauthn\MetadataService\Exception\MetadataStatementLoadingException;
 use Webauthn\MetadataService\Statement\CodeAccuracyDescriptor;
-use const JSON_UNESCAPED_SLASHES;
 
 /**
  * @internal
  */
-final class CodeAccuracyDescriptorObjectTest extends TestCase
+final class CodeAccuracyDescriptorObjectTest extends MdsTestCase
 {
     #[Test]
     #[DataProvider('validObjectData')]
@@ -30,7 +30,9 @@ final class CodeAccuracyDescriptorObjectTest extends TestCase
         static::assertSame($minLength, $object->minLength);
         static::assertSame($maxRetries, $object->maxRetries);
         static::assertSame($blockSlowdown, $object->blockSlowdown);
-        static::assertSame($expectedJson, json_encode($object, JSON_UNESCAPED_SLASHES));
+        static::assertSame($expectedJson, $this->getSerializer()->serialize($object, JsonEncoder::FORMAT, [
+            AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+        ]));
     }
 
     public static function validObjectData(): iterable

--- a/tests/MDS/Unit/DisplayPNGCharacteristicsDescriptorTest.php
+++ b/tests/MDS/Unit/DisplayPNGCharacteristicsDescriptorTest.php
@@ -6,14 +6,13 @@ namespace Webauthn\Tests\MetadataService\Unit;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
 use Webauthn\MetadataService\Exception\MetadataStatementLoadingException;
 use Webauthn\MetadataService\Statement\DisplayPNGCharacteristicsDescriptor;
 
 /**
  * @internal
  */
-final class DisplayPNGCharacteristicsDescriptorTest extends TestCase
+final class DisplayPNGCharacteristicsDescriptorTest extends MdsTestCase
 {
     #[Test]
     #[DataProvider('getInvalidValues')]

--- a/tests/MDS/Unit/MdsTestCase.php
+++ b/tests/MDS/Unit/MdsTestCase.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\MetadataService\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\SerializerInterface;
+use Webauthn\MetadataService\Denormalizer\MetadataStatementSerializerFactory;
+
+/**
+ * @internal
+ */
+abstract class MdsTestCase extends TestCase
+{
+    protected function getSerializer(): SerializerInterface
+    {
+        return MetadataStatementSerializerFactory::create();
+    }
+}

--- a/tests/MDS/Unit/PatternAccuracyDescriptorObjectTest.php
+++ b/tests/MDS/Unit/PatternAccuracyDescriptorObjectTest.php
@@ -6,15 +6,15 @@ namespace Webauthn\Tests\MetadataService\Unit;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Webauthn\MetadataService\Exception\MetadataStatementLoadingException;
 use Webauthn\MetadataService\Statement\PatternAccuracyDescriptor;
-use const JSON_UNESCAPED_SLASHES;
 
 /**
  * @internal
  */
-final class PatternAccuracyDescriptorObjectTest extends TestCase
+final class PatternAccuracyDescriptorObjectTest extends MdsTestCase
 {
     #[Test]
     #[DataProvider('validObjectData')]
@@ -28,7 +28,9 @@ final class PatternAccuracyDescriptorObjectTest extends TestCase
         static::assertSame($minComplexity, $object->minComplexity);
         static::assertSame($maxRetries, $object->maxRetries);
         static::assertSame($blockSlowdown, $object->blockSlowdown);
-        static::assertSame($expectedJson, json_encode($object, JSON_UNESCAPED_SLASHES));
+        static::assertSame($expectedJson, $this->getSerializer()->serialize($object, JsonEncoder::FORMAT, [
+            AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+        ]));
     }
 
     public static function validObjectData(): iterable

--- a/tests/MDS/Unit/VerificationMethodANDCombinationsObjectTest.php
+++ b/tests/MDS/Unit/VerificationMethodANDCombinationsObjectTest.php
@@ -6,25 +6,26 @@ namespace Webauthn\Tests\MetadataService\Unit;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Webauthn\MetadataService\Statement\BiometricAccuracyDescriptor;
 use Webauthn\MetadataService\Statement\CodeAccuracyDescriptor;
 use Webauthn\MetadataService\Statement\PatternAccuracyDescriptor;
 use Webauthn\MetadataService\Statement\VerificationMethodANDCombinations;
 use Webauthn\MetadataService\Statement\VerificationMethodDescriptor;
-use const JSON_THROW_ON_ERROR;
-use const JSON_UNESCAPED_SLASHES;
 
 /**
  * @internal
  */
-final class VerificationMethodANDCombinationsObjectTest extends TestCase
+final class VerificationMethodANDCombinationsObjectTest extends MdsTestCase
 {
     #[Test]
     #[DataProvider('validObjectData')]
     public function validObject(VerificationMethodANDCombinations $object, string $expectedJson): void
     {
-        static::assertSame($expectedJson, json_encode($object, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES));
+        static::assertSame($expectedJson, $this->getSerializer()->serialize($object, JsonEncoder::FORMAT, [
+            AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+        ]));
     }
 
     public static function validObjectData(): iterable

--- a/tests/MDS/Unit/VerificationMethodDescriptorObjectTest.php
+++ b/tests/MDS/Unit/VerificationMethodDescriptorObjectTest.php
@@ -6,24 +6,25 @@ namespace Webauthn\Tests\MetadataService\Unit;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Webauthn\MetadataService\Statement\BiometricAccuracyDescriptor;
 use Webauthn\MetadataService\Statement\CodeAccuracyDescriptor;
 use Webauthn\MetadataService\Statement\PatternAccuracyDescriptor;
 use Webauthn\MetadataService\Statement\VerificationMethodDescriptor;
-use const JSON_THROW_ON_ERROR;
-use const JSON_UNESCAPED_SLASHES;
 
 /**
  * @internal
  */
-final class VerificationMethodDescriptorObjectTest extends TestCase
+final class VerificationMethodDescriptorObjectTest extends MdsTestCase
 {
     #[Test]
     #[DataProvider('validObjectData')]
     public function validObject(VerificationMethodDescriptor $object, string $expectedJson): void
     {
-        static::assertSame($expectedJson, json_encode($object, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES));
+        static::assertSame($expectedJson, $this->getSerializer()->serialize($object, JsonEncoder::FORMAT, [
+            AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+        ]));
     }
 
     public static function validObjectData(): iterable

--- a/tests/MDS/Unit/VersionObjectTest.php
+++ b/tests/MDS/Unit/VersionObjectTest.php
@@ -6,16 +6,15 @@ namespace Webauthn\Tests\MetadataService\Unit;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Webauthn\MetadataService\Exception\MetadataStatementLoadingException;
 use Webauthn\MetadataService\Statement\Version;
-use const JSON_THROW_ON_ERROR;
-use const JSON_UNESCAPED_SLASHES;
 
 /**
  * @internal
  */
-final class VersionObjectTest extends TestCase
+final class VersionObjectTest extends MdsTestCase
 {
     #[Test]
     #[DataProvider('validObjectData')]
@@ -23,7 +22,9 @@ final class VersionObjectTest extends TestCase
     {
         static::assertSame($major, $object->major);
         static::assertSame($minor, $object->minor);
-        static::assertSame($expectedJson, json_encode($object, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES));
+        static::assertSame($expectedJson, $this->getSerializer()->serialize($object, JsonEncoder::FORMAT, [
+            AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+        ]));
     }
 
     public static function validObjectData(): iterable


### PR DESCRIPTION
…tion messages

Added `VerificationMethodANDCombinationsDenormalizer` and included in serializer configuration. Also, implemented trigger_deprecation in jsonSerialize methods marking them as deprecated and suggesting the use of the serializer instead. Further method and class modifications are reflected in the phpstan-baseline.neon file.

Target branch: 4.9.x
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [x] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
