### PR TITLE
Changed ble to internal transport

### DIFF
--- a/src/webauthn/src/SimpleFakeCredentialGenerator.php
+++ b/src/webauthn/src/SimpleFakeCredentialGenerator.php
@@ -46,7 +46,7 @@ final class SimpleFakeCredentialGenerator implements FakeCredentialGenerator
         $transports = [
             PublicKeyCredentialDescriptor::AUTHENTICATOR_TRANSPORT_USB,
             PublicKeyCredentialDescriptor::AUTHENTICATOR_TRANSPORT_NFC,
-            PublicKeyCredentialDescriptor::AUTHENTICATOR_TRANSPORT_BLE,
+            PublicKeyCredentialDescriptor::AUTHENTICATOR_TRANSPORT_INTERNAL,
         ];
         $credentials = [];
         for ($i = 0; $i < random_int(1, 3); $i++) {


### PR DESCRIPTION
Bluetooth Low Energy are rare authenticators. Using internal (Passkeys) is way more unpredictable then ble.