### PR TITLE
Add Credential entity and related tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,6 +22,7 @@
         <server name="SYMFONY_PHPUNIT_VERSION" value="10.1"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
         <env name="APP_DEBUG" value="true"/>
+        <env name="DATABASE_URL" value="sqlite:///%kernel.project_dir%/var/data.db"/>
         <server name="KERNEL_CLASS" value="Webauthn\Tests\Bundle\Functional\AppKernel"/>
         <ini name="memory_limit" value="-1"/>
     </php>

--- a/tests/symfony/config/config.yml
+++ b/tests/symfony/config/config.yml
@@ -1,6 +1,3 @@
-parameters:
-  env(DATABASE_URL): ''
-
 framework:
   test: true
   secret: 'test'
@@ -98,13 +95,6 @@ services:
 
 doctrine:
   dbal:
-    driver: 'pdo_mysql'
-    server_version: '5.7'
-    charset: utf8mb4
-    default_table_options:
-      charset: utf8mb4
-      collate: utf8mb4_unicode_ci
-
     url: '%env(resolve:DATABASE_URL)%'
   orm:
     enable_lazy_ghost_objects: true

--- a/tests/symfony/functional/Entity/Credential.php
+++ b/tests/symfony/functional/Entity/Credential.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Bundle\Functional\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Webauthn\PublicKeyCredentialSource;
+
+#[ORM\Entity]
+#[Orm\Table(name: 'credentials')]
+class Credential extends PublicKeyCredentialSource
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::STRING, length: 10)]
+    #[ORM\GeneratedValue(strategy: 'NONE')]
+    public string $id;
+}

--- a/tests/symfony/functional/Entity/EntityTest.php
+++ b/tests/symfony/functional/Entity/EntityTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Bundle\Functional\Entity;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * @internal
+ */
+final class EntityTest extends KernelTestCase
+{
+    #[Test]
+    #[DataProvider('expectedFields')]
+    public function theSchemaIsValid(string $name, string $type, null|bool $nullable): void
+    {
+        //Given
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+
+        //When
+        $classMetadata = $entityManager->getClassMetadata(Credential::class);
+        $fields = $classMetadata->fieldMappings;
+
+        //Then
+        static::assertArrayHasKey($name, $fields);
+        $field = $fields[$name];
+        static::assertSame($type, $field['type']);
+        static::assertSame($nullable, $field['nullable']);
+
+    }
+
+    public static function expectedFields(): iterable
+    {
+        yield [
+            'name' => 'publicKeyCredentialId',
+            'type' => 'base64',
+            'nullable' => null,
+        ];
+        yield [
+            'name' => 'type',
+            'type' => 'string',
+            'nullable' => null,
+        ];
+        yield [
+            'name' => 'transports',
+            'type' => 'array',
+            'nullable' => null,
+        ];
+        yield [
+            'name' => 'attestationType',
+            'type' => 'string',
+            'nullable' => null,
+        ];
+        yield [
+            'name' => 'trustPath',
+            'type' => 'trust_path',
+            'nullable' => null,
+        ];
+        yield [
+            'name' => 'aaguid',
+            'type' => 'aaguid',
+            'nullable' => null,
+        ];
+        yield [
+            'name' => 'credentialPublicKey',
+            'type' => 'base64',
+            'nullable' => null,
+        ];
+        yield [
+            'name' => 'userHandle',
+            'type' => 'string',
+            'nullable' => null,
+        ];
+        yield [
+            'name' => 'counter',
+            'type' => 'integer',
+            'nullable' => null,
+        ];
+        yield [
+            'name' => 'otherUI',
+            'type' => 'array',
+            'nullable' => true,
+        ];
+        yield [
+            'name' => 'backupEligible',
+            'type' => 'boolean',
+            'nullable' => true,
+        ];
+        yield [
+            'name' => 'backupStatus',
+            'type' => 'boolean',
+            'nullable' => true,
+        ];
+        yield [
+            'name' => 'uvInitialized',
+            'type' => 'boolean',
+            'nullable' => true,
+        ];
+    }
+}


### PR DESCRIPTION
This update introduces the Credential entity in the Symfony functional tests. Along with the entity, a new test suite for this entity is added, ensuring that the schema for the entity is valid. Additionally, the DATABASE_URL environment variable is introduced in the phpunit configuration to facilitate testing.

Target branch: 4.9.x
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
