### PR TITLE
Fix to encode/decode credential id as base64url

### DIFF
--- a/src/webauthn/src/Credential.php
+++ b/src/webauthn/src/Credential.php
@@ -37,7 +37,7 @@ abstract class Credential
             $id = Base64UrlSafe::encodeUnpadded($rawId);
         }
         $this->id = $id;
-        $this->rawId = $rawId ?? Base64UrlSafe::decodeUnpadded($id);
+        $this->rawId = $rawId ?? Base64UrlSafe::decodeNoPadding($id);
     }
 
     /**

--- a/src/webauthn/src/Credential.php
+++ b/src/webauthn/src/Credential.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Webauthn;
 
 use InvalidArgumentException;
+use ParagonIE\ConstantTime\Base64UrlSafe;
 
 /**
  * @see https://w3c.github.io/webappsec-credential-management/#credential
@@ -33,10 +34,10 @@ abstract class Credential
                 'The property "$id" is deprecated and will be removed in 5.0.0. Please set null use "rawId" instead.'
             );
         } else {
-            $id = base64_encode($rawId);
+            $id = Base64UrlSafe::encodeUnpadded($rawId);
         }
         $this->id = $id;
-        $this->rawId = $rawId ?? base64_encode($id);
+        $this->rawId = $rawId ?? Base64UrlSafe::decodeUnpadded($id);
     }
 
     /**


### PR DESCRIPTION
Target branch: 4.9.x
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->

Previously, the `id` of the PublicKeyCredential obtained by the PublicKeyCredentialDenormalizer was a raw base64url encoded string sent by the browser. However, with change #589, it is now converted to a base64-encoded string. This pull request reverts this behavior back to the previous one.

Also, I think it is correct to decode if only `$id` is passed when creating an instance, so I fixed this as well.
