### PR TITLE
Fix pugx.org badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ![Build Status](https://github.com/web-auth/webauthn-framework/workflows/Integrate/badge.svg)
 
-[![Latest Stable Version](https://poser.pugx.org/web-auth/webauthn-framework/v/stable.png)](https://packagist.org/packages/web-auth/webauthn-framework)
-[![Total Downloads](https://poser.pugx.org/web-auth/webauthn-framework/downloads.png)](https://packagist.org/packages/web-auth/webauthn-framework)
-[![Latest Unstable Version](https://poser.pugx.org/web-auth/webauthn-framework/v/unstable.png)](https://packagist.org/packages/web-auth/webauthn-framework)
-[![License](https://poser.pugx.org/web-auth/webauthn-framework/license.png)](https://packagist.org/packages/web-auth/webauthn-framework)
+[![Latest Stable Version](https://poser.pugx.org/web-auth/webauthn-framework/v/stable)](https://packagist.org/packages/web-auth/webauthn-framework)
+[![Total Downloads](https://poser.pugx.org/web-auth/webauthn-framework/downloads)](https://packagist.org/packages/web-auth/webauthn-framework)
+[![Latest Unstable Version](https://poser.pugx.org/web-auth/webauthn-framework/v/unstable)](https://packagist.org/packages/web-auth/webauthn-framework)
+[![License](https://poser.pugx.org/web-auth/webauthn-framework/license)](https://packagist.org/packages/web-auth/webauthn-framework)
 
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/web-auth/webauthn-framework/badge)](https://api.securityscorecards.dev/projects/github.com/web-auth/webauthn-framework)
 


### PR DESCRIPTION
Target branch: 5.1.x

- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

pugx.org removed the `.png` suffix.

![image](https://github.com/user-attachments/assets/ccd6000b-c128-4616-aaa8-190ef1178d1f)
