### PR TITLE
Add status revoked to isCompromised

### DIFF
--- a/src/webauthn/src/MetadataService/Statement/StatusReport.php
+++ b/src/webauthn/src/MetadataService/Statement/StatusReport.php
@@ -63,6 +63,7 @@ class StatusReport implements JsonSerializable
             AuthenticatorStatus::USER_KEY_PHYSICAL_COMPROMISE,
             AuthenticatorStatus::USER_KEY_REMOTE_COMPROMISE,
             AuthenticatorStatus::USER_VERIFICATION_BYPASS,
+            AuthenticatorStatus::REVOKED,
         ], true);
     }
 


### PR DESCRIPTION
Target branch:  4.9.x

<!-- replace space with "x" in square brackets: [x] -->
- [X] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

According to the [FIDO specifications](https://fidoalliance.org/specs/mds/fido-metadata-service-v3.0-ps-20210518.html#dom-authenticatorstatus-revoked), any authenticator marked as "removed" should not be utilized. If an authenticator is flagged as a "fraudulent product," it should be considered compromised, thus rendering it untrustworthy. Consequently, the server should reject any interactions involving such an authenticator to maintain a secure environment.