### PR TITLE
Add exception to event payload

### DIFF
--- a/src/stimulus/assets/dist/controller.js
+++ b/src/stimulus/assets/dist/controller.js
@@ -47,7 +47,7 @@ class default_1 extends Controller {
             }
         }
         catch (e) {
-            this._dispatchEvent('webauthn:assertion:failure', {});
+            this._dispatchEvent('webauthn:assertion:failure', {exception: e});
             return;
         }
     }
@@ -70,7 +70,7 @@ class default_1 extends Controller {
             }
         }
         catch (e) {
-            this._dispatchEvent('webauthn:attestation:failure', {});
+            this._dispatchEvent('webauthn:attestation:failure', {exception: e});
             return;
         }
     }

--- a/src/stimulus/assets/src/controller.ts
+++ b/src/stimulus/assets/src/controller.ts
@@ -91,7 +91,7 @@ export default class extends Controller {
                 window.location.replace(this.requestSuccessRedirectUriValue);
             }
         } catch (e) {
-            this._dispatchEvent('webauthn:assertion:failure', {});
+            this._dispatchEvent('webauthn:assertion:failure', {exception: e});
             return;
         }
     }
@@ -117,7 +117,7 @@ export default class extends Controller {
                 window.location.replace(this.creationSuccessRedirectUriValue);
             }
         } catch (e) {
-            this._dispatchEvent('webauthn:attestation:failure', {});
+            this._dispatchEvent('webauthn:attestation:failure', {exception: e});
             return;
         }
     }


### PR DESCRIPTION
Target branch: 5.1.x

- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

I think it would make sense to add the exception to the payload of the `webauthn:assertion:failure` and `webauthn:attestation:failure` custom event. This way you could display the error message somewhere, when reacting to the event, if you want to.