### PR TITLE
Make nullable parameters explicity nullable for PHP 8.4

### DIFF
--- a/src/symfony/src/Exception/HttpNotImplementedException.php
+++ b/src/symfony/src/Exception/HttpNotImplementedException.php
@@ -12,7 +12,7 @@ class HttpNotImplementedException extends HttpException
     /**
      * @param array<string, mixed> $headers
      */
-    public function __construct(string $message = '', Throwable $previous = null, int $code = 0, array $headers = [])
+    public function __construct(string $message = '', ?Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(501, $message, $previous, $headers, $code);
     }

--- a/src/symfony/src/Routing/Loader.php
+++ b/src/symfony/src/Routing/Loader.php
@@ -31,12 +31,12 @@ class Loader extends SymfonyLoader
     /**
      * @noRector
      */
-    public function load(mixed $resource, string $type = null): RouteCollection
+    public function load(mixed $resource, ?string $type = null): RouteCollection
     {
         return $this->routes;
     }
 
-    public function supports(mixed $resource, string $type = null): bool
+    public function supports(mixed $resource, ?string $type = null): bool
     {
         return $type === 'webauthn';
     }

--- a/src/symfony/src/Security/Handler/DefaultFailureHandler.php
+++ b/src/symfony/src/Security/Handler/DefaultFailureHandler.php
@@ -13,7 +13,7 @@ use Throwable;
 
 final class DefaultFailureHandler implements FailureHandler, AuthenticationFailureHandlerInterface
 {
-    public function onFailure(Request $request, Throwable $exception = null): Response
+    public function onFailure(Request $request, ?Throwable $exception = null): Response
     {
         $data = [
             'status' => 'error',

--- a/src/symfony/src/Security/Handler/FailureHandler.php
+++ b/src/symfony/src/Security/Handler/FailureHandler.php
@@ -10,5 +10,5 @@ use Throwable;
 
 interface FailureHandler
 {
-    public function onFailure(Request $request, Throwable $exception = null): Response;
+    public function onFailure(Request $request, ?Throwable $exception = null): Response;
 }

--- a/src/symfony/src/Service/DefaultFailureHandler.php
+++ b/src/symfony/src/Service/DefaultFailureHandler.php
@@ -12,7 +12,7 @@ use Webauthn\Bundle\Security\Handler\FailureHandler;
 
 final class DefaultFailureHandler implements FailureHandler
 {
-    public function onFailure(Request $request, Throwable $exception = null): Response
+    public function onFailure(Request $request, ?Throwable $exception = null): Response
     {
         $data = [
             'status' => 'error',

--- a/src/webauthn/src/AuthenticationExtensions/ExtensionOutputError.php
+++ b/src/webauthn/src/AuthenticationExtensions/ExtensionOutputError.php
@@ -13,7 +13,7 @@ class ExtensionOutputError extends Exception
         public readonly AuthenticationExtension $authenticationExtension,
         string $message = '',
         int $code = 0,
-        Throwable $previous = null
+        ?Throwable $previous = null
     ) {
         parent::__construct($message, $code, $previous);
     }

--- a/src/webauthn/src/Denormalizer/AttestationObjectDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/AttestationObjectDenormalizer.php
@@ -19,7 +19,7 @@ final class AttestationObjectDenormalizer implements DenormalizerInterface, Deno
 {
     use DenormalizerAwareTrait;
 
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         $stream = new StringStream($data);
         $parsed = Decoder::create()->decode($stream);
@@ -46,7 +46,7 @@ final class AttestationObjectDenormalizer implements DenormalizerInterface, Deno
         );
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return $type === AttestationObject::class;
     }

--- a/src/webauthn/src/Denormalizer/AttestationStatementDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/AttestationStatementDenormalizer.php
@@ -15,14 +15,14 @@ final class AttestationStatementDenormalizer implements DenormalizerInterface
     ) {
     }
 
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         $attestationStatementSupport = $this->attestationStatementSupportManager->get($data['fmt']);
 
         return $attestationStatementSupport->load($data);
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return $type === AttestationStatement::class;
     }

--- a/src/webauthn/src/Denormalizer/AuthenticationExtensionsDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/AuthenticationExtensionsDenormalizer.php
@@ -17,7 +17,7 @@ use function is_string;
 
 final class AuthenticationExtensionsDenormalizer implements DenormalizerInterface, NormalizerInterface
 {
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         if ($data instanceof AuthenticationExtensions) {
             return AuthenticationExtensions::create($data->extensions);
@@ -33,7 +33,7 @@ final class AuthenticationExtensionsDenormalizer implements DenormalizerInterfac
         return AuthenticationExtensions::create($data);
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return in_array(
             $type,

--- a/src/webauthn/src/Denormalizer/AuthenticatorAssertionResponseDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/AuthenticatorAssertionResponseDenormalizer.php
@@ -18,7 +18,7 @@ final class AuthenticatorAssertionResponseDenormalizer implements DenormalizerIn
 {
     use DenormalizerAwareTrait;
 
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         $data['authenticatorData'] = Base64::decode($data['authenticatorData']);
         $data['signature'] = Base64::decode($data['signature']);
@@ -42,7 +42,7 @@ final class AuthenticatorAssertionResponseDenormalizer implements DenormalizerIn
         );
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return $type === AuthenticatorAssertionResponse::class;
     }

--- a/src/webauthn/src/Denormalizer/AuthenticatorAttestationResponseDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/AuthenticatorAttestationResponseDenormalizer.php
@@ -17,7 +17,7 @@ final class AuthenticatorAttestationResponseDenormalizer implements Denormalizer
 {
     use DenormalizerAwareTrait;
 
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         $data['clientDataJSON'] = Base64UrlSafe::decodeNoPadding($data['clientDataJSON']);
         $data['attestationObject'] = Base64::decode($data['attestationObject']);
@@ -42,7 +42,7 @@ final class AuthenticatorAttestationResponseDenormalizer implements Denormalizer
         );
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return $type === AuthenticatorAttestationResponse::class;
     }

--- a/src/webauthn/src/Denormalizer/AuthenticatorDataDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/AuthenticatorDataDenormalizer.php
@@ -35,7 +35,7 @@ final class AuthenticatorDataDenormalizer implements DenormalizerInterface, Deno
         $this->decoder = Decoder::create();
     }
 
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         $authData = $this->fixIncorrectEdDSAKey($data);
         $authDataStream = new StringStream($authData);
@@ -87,7 +87,7 @@ final class AuthenticatorDataDenormalizer implements DenormalizerInterface, Deno
         );
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return $type === AuthenticatorData::class;
     }

--- a/src/webauthn/src/Denormalizer/AuthenticatorResponseDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/AuthenticatorResponseDenormalizer.php
@@ -17,7 +17,7 @@ final class AuthenticatorResponseDenormalizer implements DenormalizerInterface, 
 {
     use DenormalizerAwareTrait;
 
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         $realType = match (true) {
             array_key_exists('attestationObject', $data) => AuthenticatorAttestationResponse::class,
@@ -28,7 +28,7 @@ final class AuthenticatorResponseDenormalizer implements DenormalizerInterface, 
         return $this->denormalizer->denormalize($data, $realType, $format, $context);
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return $type === AuthenticatorResponse::class;
     }

--- a/src/webauthn/src/Denormalizer/CollectedClientDataDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/CollectedClientDataDenormalizer.php
@@ -14,12 +14,12 @@ final class CollectedClientDataDenormalizer implements DenormalizerInterface, De
 {
     use DenormalizerAwareTrait;
 
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         return CollectedClientData::create($data, json_decode($data, true, flags: JSON_THROW_ON_ERROR));
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return $type === CollectedClientData::class;
     }

--- a/src/webauthn/src/Denormalizer/ExtensionDescriptorDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/ExtensionDescriptorDenormalizer.php
@@ -19,7 +19,7 @@ class ExtensionDescriptorDenormalizer implements DenormalizerInterface, Denormal
 
     private const ALREADY_CALLED = 'EXTENSION_DESCRIPTOR_PREPROCESS_ALREADY_CALLED';
 
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         if (array_key_exists('fail_if_unknown', $data)) {
             $data['failIfUnknown'] = $data['fail_if_unknown'];
@@ -31,7 +31,7 @@ class ExtensionDescriptorDenormalizer implements DenormalizerInterface, Denormal
         return $this->denormalizer->denormalize($data, $type, $format, $context);
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         if ($context[self::ALREADY_CALLED] ?? false) {
             return false;

--- a/src/webauthn/src/Denormalizer/PublicKeyCredentialDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/PublicKeyCredentialDenormalizer.php
@@ -18,7 +18,7 @@ final class PublicKeyCredentialDenormalizer implements DenormalizerInterface, De
 {
     use DenormalizerAwareTrait;
 
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         if (! array_key_exists('id', $data)) {
             return $data;
@@ -36,7 +36,7 @@ final class PublicKeyCredentialDenormalizer implements DenormalizerInterface, De
         );
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return $type === PublicKeyCredential::class;
     }

--- a/src/webauthn/src/Denormalizer/PublicKeyCredentialOptionsDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/PublicKeyCredentialOptionsDenormalizer.php
@@ -29,7 +29,7 @@ final class PublicKeyCredentialOptionsDenormalizer implements DenormalizerInterf
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
 
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         if (array_key_exists('challenge', $data)) {
             $data['challenge'] = Base64UrlSafe::decodeNoPadding($data['challenge']);
@@ -103,7 +103,7 @@ final class PublicKeyCredentialOptionsDenormalizer implements DenormalizerInterf
         throw new BadMethodCallException('Unsupported type');
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return in_array(
             $type,

--- a/src/webauthn/src/Denormalizer/PublicKeyCredentialParametersDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/PublicKeyCredentialParametersDenormalizer.php
@@ -11,7 +11,7 @@ use function array_key_exists;
 
 final class PublicKeyCredentialParametersDenormalizer implements DenormalizerInterface
 {
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         if (! array_key_exists('type', $data) || ! array_key_exists('alg', $data)) {
             throw new InvalidDataException($data, 'Missing type or alg');
@@ -20,7 +20,7 @@ final class PublicKeyCredentialParametersDenormalizer implements DenormalizerInt
         return PublicKeyCredentialParameters::create($data['type'], $data['alg']);
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return $type === PublicKeyCredentialParameters::class;
     }

--- a/src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
@@ -24,7 +24,7 @@ final class PublicKeyCredentialSourceDenormalizer implements DenormalizerInterfa
     use NormalizerAwareTrait;
     use DenormalizerAwareTrait;
 
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         $keys = ['publicKeyCredentialId', 'credentialPublicKey', 'userHandle'];
         foreach ($keys as $key) {
@@ -49,7 +49,7 @@ final class PublicKeyCredentialSourceDenormalizer implements DenormalizerInterfa
         );
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return $type === PublicKeyCredentialSource::class;
     }

--- a/src/webauthn/src/Denormalizer/PublicKeyCredentialUserEntityDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/PublicKeyCredentialUserEntityDenormalizer.php
@@ -14,7 +14,7 @@ use function assert;
 
 final class PublicKeyCredentialUserEntityDenormalizer implements DenormalizerInterface, NormalizerInterface
 {
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         if (! array_key_exists('id', $data)) {
             return $data;
@@ -29,7 +29,7 @@ final class PublicKeyCredentialUserEntityDenormalizer implements DenormalizerInt
         );
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return $type === PublicKeyCredentialUserEntity::class;
     }

--- a/src/webauthn/src/Denormalizer/TrustPathDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/TrustPathDenormalizer.php
@@ -16,7 +16,7 @@ use function assert;
 
 final class TrustPathDenormalizer implements DenormalizerInterface, NormalizerInterface
 {
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         return match (true) {
             array_key_exists('ecdaaKeyId', $data) => new EcdaaKeyIdTrustPath($data),
@@ -26,7 +26,7 @@ final class TrustPathDenormalizer implements DenormalizerInterface, NormalizerIn
         };
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return $type === TrustPath::class;
     }

--- a/src/webauthn/src/MetadataService/Psr18HttpClient.php
+++ b/src/webauthn/src/MetadataService/Psr18HttpClient.php
@@ -54,7 +54,7 @@ class Psr18HttpClient implements HttpClientInterface
     /**
      * @param ResponseInterface|iterable<array-key, ResponseInterface> $responses
      */
-    public function stream(iterable|ResponseInterface $responses, float $timeout = null): ResponseStreamInterface
+    public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
     {
         throw new LogicException('Not implemented');
     }
@@ -119,7 +119,7 @@ class Psr18HttpClient implements HttpClientInterface
                 // noop
             }
 
-            public function getInfo(string $type = null): mixed
+            public function getInfo(?string $type = null): mixed
             {
                 return null;
             }

--- a/tests/symfony/functional/FailureHandler.php
+++ b/tests/symfony/functional/FailureHandler.php
@@ -19,7 +19,7 @@ final class FailureHandler implements AuthenticationFailureHandlerInterface, Fai
         return $this->onFailure($request, $exception);
     }
 
-    public function onFailure(Request $request, Throwable $exception = null): Response
+    public function onFailure(Request $request, ?Throwable $exception = null): Response
     {
         $data = [
             'status' => 'error',


### PR DESCRIPTION
Target branch: 4.9.x
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Implicitly nullable parameter types are deprecated in PHP 8.4

https://www.php.net/manual/it/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter
