### PR TITLE
Add index on publicKeyCredentialId in Doctrine mapping

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2101,12 +2101,6 @@ parameters:
 			path: src/webauthn/src/MetadataService/Statement/MetadataStatement.php
 
 		-
-			message: '#^Since web\-auth/webauthn\-lib 5\.1\.0\: The parameter "\$icon" is deprecated since 5\.1\.0 and will be removed in 6\.0\.0\. This value has no effect\. Please set "null" instead\.\.$#'
-			identifier: todoBy.sfDeprecation
-			count: 1
-			path: src/webauthn/src/PublicKeyCredentialEntity.php
-
-		-
 			message: '#^Parameter \#1 \$extensions of static method Webauthn\\AuthenticationExtensions\\AuthenticationExtensions\:\:create\(\) expects array\<Webauthn\\AuthenticationExtensions\\AuthenticationExtension\>, array\<Webauthn\\AuthenticationExtensions\\AuthenticationExtensions\> given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/symfony/src/Resources/config/doctrine-mapping/PublicKeyCredentialSource.orm.xml
+++ b/src/symfony/src/Resources/config/doctrine-mapping/PublicKeyCredentialSource.orm.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd"
 >
     <mapped-superclass name="Webauthn\PublicKeyCredentialSource">
-        <field name="publicKeyCredentialId" type="base64"/>
+        <field name="publicKeyCredentialId" type="base64" unique="true"/>
         <field name="type"/>
         <field name="transports" type="json"/>
         <field name="attestationType"/>


### PR DESCRIPTION
This commit introduces a database index on the `publicKeyCredentialId` field in the `PublicKeyCredentialSource` mapping. The added index aims to optimize query performance for operations involving this column.

Target branch: 5.1.x
Resolves issue #665 

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
