### PR TITLE
Event dispatch payloads for WebAuthn failure cases

### DIFF
--- a/src/stimulus/assets/dist/controller.js
+++ b/src/stimulus/assets/dist/controller.js
@@ -47,7 +47,7 @@ class default_1 extends Controller {
             }
         }
         catch (e) {
-            this._dispatchEvent('webauthn:assertion:failure', {exception: e});
+            this._dispatchEvent('webauthn:assertion:failure', { exception: e, assertionResponse: null });
             return;
         }
     }
@@ -70,7 +70,7 @@ class default_1 extends Controller {
             }
         }
         catch (e) {
-            this._dispatchEvent('webauthn:attestation:failure', {exception: e});
+            this._dispatchEvent('webauthn:attestation:failure', { exception: e, assertionResponse: null });
             return;
         }
     }
@@ -120,7 +120,7 @@ class default_1 extends Controller {
             body: JSON.stringify(data)
         });
         if (!optionsResponse.ok) {
-            this._dispatchEvent('webauthn:options:failure', {});
+            this._dispatchEvent('webauthn:options:failure', { exception: null, optionsResponse });
             return false;
         }
         const options = await optionsResponse.json();

--- a/src/stimulus/assets/src/controller.ts
+++ b/src/stimulus/assets/src/controller.ts
@@ -91,7 +91,7 @@ export default class extends Controller {
                 window.location.replace(this.requestSuccessRedirectUriValue);
             }
         } catch (e) {
-            this._dispatchEvent('webauthn:assertion:failure', {exception: e});
+            this._dispatchEvent('webauthn:assertion:failure', {exception: e, assertionResponse: null});
             return;
         }
     }
@@ -117,7 +117,7 @@ export default class extends Controller {
                 window.location.replace(this.creationSuccessRedirectUriValue);
             }
         } catch (e) {
-            this._dispatchEvent('webauthn:attestation:failure', {exception: e});
+            this._dispatchEvent('webauthn:attestation:failure', {exception: e, assertionResponse: null});
             return;
         }
     }
@@ -178,7 +178,7 @@ export default class extends Controller {
             body: JSON.stringify(data)
         });
         if (!optionsResponse.ok) {
-            this._dispatchEvent('webauthn:options:failure', {});
+            this._dispatchEvent('webauthn:options:failure', {exception: null, optionsResponse});
             return false;
         }
 


### PR DESCRIPTION
Update failure event payloads to include additional context, such as `assertionResponse` or `optionsResponse`, improving error handling consistency. This ensures downstream handlers have access to more detailed information during WebAuthn failures.

Target branch: 
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
