### PR TITLE
Set a length limit for publicKeyCredentialId field

### DIFF
--- a/src/symfony/src/Resources/config/doctrine-mapping/PublicKeyCredentialSource.orm.xml
+++ b/src/symfony/src/Resources/config/doctrine-mapping/PublicKeyCredentialSource.orm.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd"
 >
     <mapped-superclass name="Webauthn\PublicKeyCredentialSource">
-        <field name="publicKeyCredentialId" type="base64" unique="true"/>
+        <field name="publicKeyCredentialId" type="base64" unique="true" length="250"/>
         <field name="type"/>
         <field name="transports" type="json"/>
         <field name="attestationType"/>


### PR DESCRIPTION
Added a `length="250"` attribute to the `publicKeyCredentialId` field in the doctrine mapping. This enforces a maximum length constraint, ensuring consistency and preventing potential database issues.

Target branch: 
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
