### PR TITLE
Update WebAuthn method calls to use object parameters

### DIFF
--- a/src/stimulus/assets/dist/controller.js
+++ b/src/stimulus/assets/dist/controller.js
@@ -39,7 +39,7 @@ class default_1 extends Controller {
     }
     async _processSignin(optionsResponseJson, useBrowserAutofill) {
         try {
-            const authenticatorResponse = await startAuthentication(optionsResponseJson, useBrowserAutofill);
+            const authenticatorResponse = await startAuthentication({ optionsJSON: optionsResponseJson, useBrowserAutofill });
             this._dispatchEvent('webauthn:authenticator:response', { response: authenticatorResponse });
             const assertionResponse = await this._getAssertionResponse(authenticatorResponse);
             if (assertionResponse !== false && this.requestSuccessRedirectUriValue) {
@@ -62,7 +62,7 @@ class default_1 extends Controller {
             if (!optionsResponseJson) {
                 return;
             }
-            const authenticatorResponse = await startRegistration(optionsResponseJson);
+            const authenticatorResponse = await startRegistration({ optionsJSON: optionsResponseJson });
             this._dispatchEvent('webauthn:authenticator:response', { response: authenticatorResponse });
             const attestationResponseJSON = await this._getAttestationResponse(authenticatorResponse);
             if (attestationResponseJSON !== false && this.creationSuccessRedirectUriValue) {

--- a/src/stimulus/assets/src/controller.ts
+++ b/src/stimulus/assets/src/controller.ts
@@ -83,7 +83,7 @@ export default class extends Controller {
     private async _processSignin(optionsResponseJson: Object, useBrowserAutofill: boolean): Promise<void> {
         try {
             // @ts-ignore
-            const authenticatorResponse = await startAuthentication(optionsResponseJson, useBrowserAutofill);
+            const authenticatorResponse = await startAuthentication({ optionsJSON: optionsResponseJson, useBrowserAutofill });
             this._dispatchEvent('webauthn:authenticator:response', { response: authenticatorResponse });
 
             const assertionResponse = await this._getAssertionResponse(authenticatorResponse);
@@ -109,7 +109,7 @@ export default class extends Controller {
             }
 
             // @ts-ignore
-            const authenticatorResponse = await startRegistration(optionsResponseJson);
+            const authenticatorResponse = await startRegistration({ optionsJSON: optionsResponseJson });
             this._dispatchEvent('webauthn:authenticator:response', { response: authenticatorResponse });
 
             const attestationResponseJSON = await this._getAttestationResponse(authenticatorResponse);


### PR DESCRIPTION
Target branch: 5.1.x
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Refactored `startAuthentication` and `startRegistration` calls to use object syntax for passing parameters. This improves code clarity and aligns with expected API usage patterns.

