### PR TITLE
Add validation for missing "web-token/jwt-library" dependency

### DIFF
--- a/src/webauthn/src/MetadataService/Service/FidoAllianceCompliantMetadataService.php
+++ b/src/webauthn/src/MetadataService/Service/FidoAllianceCompliantMetadataService.php
@@ -10,6 +10,7 @@ use Jose\Component\Signature\Algorithm\ES256;
 use Jose\Component\Signature\Algorithm\RS256;
 use Jose\Component\Signature\JWSVerifier;
 use Jose\Component\Signature\Serializer\CompactSerializer;
+use LogicException;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -59,6 +60,11 @@ final class FidoAllianceCompliantMetadataService implements MetadataService, Can
         private readonly ?string $rootCertificateUri = null,
         ?SerializerInterface $serializer = null,
     ) {
+        if (! class_exists(CompactSerializer::class)) {
+            throw new LogicException(
+                'The "web-token/jwt-library" package is required to use this service. Please run "composer require web-token/jwt-library".'
+            );
+        }
         $this->serializer = $serializer ?? (new WebauthnSerializerFactory(
             AttestationStatementSupportManager::create()
         ))->create();


### PR DESCRIPTION
Ensure the service throws a clear exception if the required "web-token/jwt-library" package is not installed. This prevents potential runtime issues by guiding users to install the necessary dependency upfront.

Target branch: 5.1.x
Resolves issue #682 

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
