### PR TITLE
[5.1] Fix CheckOrigin

### DIFF
--- a/src/webauthn/src/CeremonyStep/CheckOrigin.php
+++ b/src/webauthn/src/CeremonyStep/CheckOrigin.php
@@ -41,6 +41,14 @@ final readonly class CheckOrigin implements CeremonyStep
         is_array($parsedRelyingPartyId) || throw AuthenticatorResponseVerificationException::create(
             'Invalid origin'
         );
+        // Companion application
+        if (in_array($parsedRelyingPartyId['scheme'], ['android', 'ios'])) {
+            in_array($C->origin, $this->securedRelyingPartyId, true) || throw AuthenticatorResponseVerificationException::create(
+                'Unauthorized origin.'
+            );
+            return;
+        }
+        // Web
         if (! in_array($facetId, $this->securedRelyingPartyId, true)) {
             $scheme = $parsedRelyingPartyId['scheme'] ?? '';
             $scheme === 'https' || throw AuthenticatorResponseVerificationException::create(


### PR DESCRIPTION
Target branch: 5.1.x
Resolves issue #393

- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Current `CheckOrigin` class checks that origin is a valid URL and either the facetID or a subdomain of the facetID. But it seems that native application origins are not supported (`parse_url` would not provide a `host` section).

Thus, we suggest to simply check that this kind of origins must be in the securedRelyingPartyId whitelist.

This is based on https://www.w3.org/TR/webauthn-3/#sctn-validating-origin and more specifically this example:
> A web application with a companion native application might allow [origin](https://www.w3.org/TR/webauthn-3/#dom-collectedclientdata-origin) to be an operating system dependent identifier for the native application. For example, such a [Relying Party](https://www.w3.org/TR/webauthn-3/#relying-party) might require that [origin](https://www.w3.org/TR/webauthn-3/#dom-collectedclientdata-origin) exactly equals some element of the list ["https://example.org", "example-os:appid:204ffa1a5af110ac483f131a1bef8a841a7adb0d8d135908bbd964ed05d2653b"].