### PR TITLE
Add origin validation logic and tests for WebAuthn

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,6 +31,15 @@ parameters:
 			path: src/symfony/src/DataCollector/WebauthnCollector.php
 
 		-
+			message: '''
+				#^Call to deprecated method setSecuredRelyingPartyId\(\) of class Webauthn\\Bundle\\DependencyInjection\\Compiler\\CeremonyStepManagerFactoryCompilerPass\:
+				Will be removed in 6\.0\.0$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: src/symfony/src/DependencyInjection/Compiler/CeremonyStepManagerFactoryCompilerPass.php
+
+		-
 			message: '#^Parameter \#2 \$array of function array_key_exists expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -399,7 +408,7 @@ parameters:
 		-
 			message: '#^Parameter \#2 \$value of method Symfony\\Component\\DependencyInjection\\Container\:\:setParameter\(\) expects array\|bool\|float\|int\|string\|UnitEnum\|null, mixed given\.$#'
 			identifier: argument.type
-			count: 3
+			count: 5
 			path: src/symfony/src/DependencyInjection/WebauthnExtension.php
 
 		-
@@ -1385,6 +1394,21 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/webauthn/src/AuthenticatorDataLoader.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Webauthn\\CeremonyStep\\CheckOrigin\:
+				since 5\.2\.0 and will be removed in 6\.0\.0\. Will be replaced by CheckAllowedOrigins$#
+			'''
+			identifier: new.deprecated
+			count: 2
+			path: src/webauthn/src/CeremonyStep/CeremonyStepManagerFactory.php
+
+		-
+			message: '#^Access to an undefined property Webauthn\\PublicKeyCredentialCreationOptions\|Webauthn\\PublicKeyCredentialRequestOptions\:\:\$rp\.$#'
+			identifier: property.notFound
+			count: 1
+			path: src/webauthn/src/CeremonyStep/CheckAllowedOrigins.php
 
 		-
 			message: '#^Access to an undefined property Webauthn\\PublicKeyCredentialCreationOptions\|Webauthn\\PublicKeyCredentialRequestOptions\:\:\$rp\.$#'

--- a/src/symfony/src/Controller/AllowedOriginsController.php
+++ b/src/symfony/src/Controller/AllowedOriginsController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Bundle\Controller;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+final readonly class AllowedOriginsController
+{
+    /**
+     * @param string[] $allowedOrigins
+     */
+    public function __construct(
+        private array $allowedOrigins
+    ) {
+    }
+
+    public function __invoke(): JsonResponse
+    {
+        return new JsonResponse([
+            'origins' => $this->allowedOrigins,
+        ]);
+    }
+}

--- a/src/symfony/src/DependencyInjection/Compiler/CeremonyStepManagerFactoryCompilerPass.php
+++ b/src/symfony/src/DependencyInjection/Compiler/CeremonyStepManagerFactoryCompilerPass.php
@@ -10,11 +10,15 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Webauthn\AttestationStatement\AttestationStatementSupportManager;
 use Webauthn\AuthenticationExtensions\ExtensionOutputCheckerHandler;
+use Webauthn\Bundle\Controller\AllowedOriginsController;
+use Webauthn\Bundle\Routing\Loader;
 use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
 use Webauthn\CeremonyStep\TopOriginValidator;
 use Webauthn\MetadataService\CertificateChain\CertificateChainValidator;
 use Webauthn\MetadataService\MetadataStatementRepository;
 use Webauthn\MetadataService\StatusReportRepository;
+use function count;
+use function is_array;
 
 final class CeremonyStepManagerFactoryCompilerPass implements CompilerPassInterface
 {
@@ -31,6 +35,7 @@ final class CeremonyStepManagerFactoryCompilerPass implements CompilerPassInterf
         $this->setAlgorithmManager($container, $definition);
         $this->enableTopOriginValidator($container, $definition);
         $this->setSecuredRelyingPartyId($container, $definition);
+        $this->setAllowedOrigins($container, $definition);
     }
 
     private function setAttestationStatementSupportManager(ContainerBuilder $container, Definition $definition): void
@@ -105,6 +110,9 @@ final class CeremonyStepManagerFactoryCompilerPass implements CompilerPassInterf
         $definition->addMethodCall('setAlgorithmManager', [new Reference('webauthn.cose.algorithm.manager')]);
     }
 
+    /**
+     * @deprecated Will be removed in 6.0.0
+     */
     private function setSecuredRelyingPartyId(ContainerBuilder $container, Definition $definition): void
     {
         if (! $container->hasParameter('webauthn.secured_relying_party_ids')) {
@@ -114,5 +122,39 @@ final class CeremonyStepManagerFactoryCompilerPass implements CompilerPassInterf
         $definition->addMethodCall('setSecuredRelyingPartyId', [
             $container->getParameter('webauthn.secured_relying_party_ids'),
         ]);
+    }
+
+    private function setAllowedOrigins(ContainerBuilder $container, Definition $definition): void
+    {
+        if (! $container->hasParameter('webauthn.allowed_origins') || $container->getParameter(
+            'webauthn.allow_subdomains'
+        ) === null) {
+            return;
+        }
+        $allowedOrigins = $container->getParameter('webauthn.allowed_origins');
+        if (! is_array($allowedOrigins) || count($allowedOrigins) === 0) {
+            return;
+        }
+
+        $definition->addMethodCall('setAllowedOrigins', [
+            $container->getParameter('webauthn.allowed_origins'),
+            $container->getParameter('webauthn.allow_subdomains'),
+        ]);
+        $this->createControllerDefinition($container);
+    }
+
+    private function createControllerDefinition(ContainerBuilder $container): void
+    {
+        if (! $container->hasDefinition(Loader::class)) {
+            return;
+        }
+
+        $controllerDefinition = $container->setDefinition(
+            AllowedOriginsController::class,
+            new Definition(AllowedOriginsController::class, [$container->getParameter('webauthn.allowed_origins')])
+        );
+        $controllerDefinition->setPublic(true);
+        $definition = $container->getDefinition(Loader::class);
+        $definition->addMethodCall('add', ['/.well-known/webauthn', null, AllowedOriginsController::class, 'GET']);
     }
 }

--- a/src/symfony/src/DependencyInjection/Configuration.php
+++ b/src/symfony/src/DependencyInjection/Configuration.php
@@ -87,7 +87,23 @@ final class Configuration implements ConfigurationInterface
             ->defaultValue(DummyPublicKeyCredentialUserEntityRepository::class)
             ->info('This repository is responsible of the user storage')
             ->end()
+            ->arrayNode('allowed_origins')
+            ->treatFalseLike([])
+            ->treatTrueLike([])
+            ->treatNullLike([])
+            ->useAttributeAsKey('name')
+            ->scalarPrototype()
+            ->end()
+            ->end()
+            ->booleanNode('allow_subdomains')
+            ->defaultFalse()
+            ->end()
             ->arrayNode('secured_rp_ids')
+            ->setDeprecated(
+                'web-auth/webauthn-symfony-bundle',
+                '5.2.0',
+                'The "secured_rp_ids" node is deprecated. Please use "allowed_origins" and "allow_subdomains" instead.'
+            )
             ->treatFalseLike(null)
             ->treatTrueLike(null)
             ->treatNullLike(null)
@@ -350,7 +366,23 @@ final class Configuration implements ConfigurationInterface
             ->scalarNode('options_handler')
             ->defaultValue(DefaultCreationOptionsHandler::class)
             ->end()
+            ->arrayNode('allowed_origins')
+            ->treatFalseLike([])
+            ->treatTrueLike([])
+            ->treatNullLike([])
+            ->useAttributeAsKey('name')
+            ->scalarPrototype()
+            ->end()
+            ->end()
+            ->booleanNode('allow_subdomains')
+            ->defaultFalse()
+            ->end()
             ->arrayNode('secured_rp_ids')
+            ->setDeprecated(
+                'web-auth/webauthn-symfony-bundle',
+                '5.2.0',
+                'The "secured_rp_ids" node is deprecated. Please use "allowed_origins" and "allow_subdomains" instead.'
+            )
             ->treatFalseLike([])
             ->treatTrueLike([])
             ->treatNullLike([])
@@ -406,7 +438,23 @@ final class Configuration implements ConfigurationInterface
             ->scalarNode('options_handler')
             ->defaultValue(DefaultRequestOptionsHandler::class)
             ->end()
+            ->arrayNode('allowed_origins')
+            ->treatFalseLike([])
+            ->treatTrueLike([])
+            ->treatNullLike([])
+            ->useAttributeAsKey('name')
+            ->scalarPrototype()
+            ->end()
+            ->end()
+            ->booleanNode('allow_subdomains')
+            ->defaultFalse()
+            ->end()
             ->arrayNode('secured_rp_ids')
+            ->setDeprecated(
+                'web-auth/webauthn-symfony-bundle',
+                '5.2.0',
+                'The "secured_rp_ids" node is deprecated. Please use "allowed_origins" and "allow_subdomains" instead.'
+            )
             ->treatFalseLike([])
             ->treatTrueLike([])
             ->treatNullLike([])

--- a/src/symfony/src/DependencyInjection/Factory/Security/WebauthnFactory.php
+++ b/src/symfony/src/DependencyInjection/Factory/Security/WebauthnFactory.php
@@ -121,6 +121,11 @@ final readonly class WebauthnFactory implements FirewallListenerFactoryInterface
             ->defaultValue(self::DEFAULT_FAILURE_HANDLER_SERVICE)
             ->end()
             ->arrayNode('secured_rp_ids')
+            ->setDeprecated(
+                'web-auth/webauthn-symfony-bundle',
+                '5.2.0',
+                'The "secured_rp_ids" node is deprecated. Please use "allowed_origins" and "allow_subdomains" instead.'
+            )
             ->treatFalseLike([])
             ->treatTrueLike([])
             ->treatNullLike([])
@@ -214,11 +219,13 @@ final readonly class WebauthnFactory implements FirewallListenerFactoryInterface
         $authenticatorAssertionResponseValidatorId = $this->servicesFactory->createAuthenticatorAssertionResponseValidator(
             $container,
             $firewallName,
+            // @deprecated Will be removed in 6.0.0
             $config['secured_rp_ids']
         );
         $authenticatorAttestationResponseValidatorId = $this->servicesFactory->createAuthenticatorAttestationResponseValidator(
             $container,
             $firewallName,
+            // @deprecated Will be removed in 6.0.0
             $config['secured_rp_ids']
         );
 

--- a/src/symfony/src/DependencyInjection/Factory/Security/WebauthnServicesFactory.php
+++ b/src/symfony/src/DependencyInjection/Factory/Security/WebauthnServicesFactory.php
@@ -42,6 +42,7 @@ class WebauthnServicesFactory
     public function createAuthenticatorAssertionResponseValidator(
         ContainerBuilder $container,
         string $firewallName,
+        // @deprecated Will be removed in 6.0.0
         array $securedRpIds
     ): string {
         $ceremonyStepManagerId = WebauthnFactory::CEREMONY_STEP_MANAGER_ID_PREFIX . 'request.' . $firewallName;
@@ -70,6 +71,7 @@ class WebauthnServicesFactory
     public function createAuthenticatorAttestationResponseValidator(
         ContainerBuilder $container,
         string $firewallName,
+        // @deprecated Will be removed in 6.0.0
         array $securedRpIds
     ): string {
         $ceremonyStepManagerId = WebauthnFactory::CEREMONY_STEP_MANAGER_ID_PREFIX . 'creation.' . $firewallName;

--- a/src/symfony/src/DependencyInjection/WebauthnExtension.php
+++ b/src/symfony/src/DependencyInjection/WebauthnExtension.php
@@ -88,7 +88,10 @@ final class WebauthnExtension extends Extension implements PrependExtensionInter
         $container->registerForAutoconfiguration(CanLogData::class)->addTag(LoggerSetterCompilerPass::TAG);
         $container->registerForAutoconfiguration(Algorithm::class)->addTag(CoseAlgorithmCompilerPass::TAG);
 
+        // @deprecated Will be removed in 6.0.0
         $container->setParameter('webauthn.secured_relying_party_ids', $config['secured_rp_ids']);
+        $container->setParameter('webauthn.allowed_origins', $config['allowed_origins']);
+        $container->setParameter('webauthn.allow_subdomains', $config['allow_subdomains']);
         $container->setAlias('webauthn.event_dispatcher', $config['event_dispatcher']);
         $container->setAlias('webauthn.clock', $config['clock']);
         if ($config['top_origin_validator'] !== null) {
@@ -220,6 +223,7 @@ final class WebauthnExtension extends Extension implements PrependExtensionInter
             $container
                 ->setDefinition($creationCeremonyStepManagerId, new Definition(CeremonyStepManager::class))
                 ->setFactory([new Reference(CeremonyStepManagerFactory::class), 'creationCeremony'])
+                // @deprecated Will be removed in 6.0.0
                 ->setArguments([$creationConfig['secured_rp_ids']])
             ;
 
@@ -300,6 +304,7 @@ final class WebauthnExtension extends Extension implements PrependExtensionInter
             $container
                 ->setDefinition($requestCeremonyStepManagerId, new Definition(CeremonyStepManager::class))
                 ->setFactory([new Reference(CeremonyStepManagerFactory::class), 'requestCeremony'])
+                // @deprecated Will be removed in 6.0.0
                 ->setArguments([$requestConfig['secured_rp_ids']])
             ;
 

--- a/src/symfony/src/Resources/config/services.php
+++ b/src/symfony/src/Resources/config/services.php
@@ -51,83 +51,81 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $container): void {
-    $container = $container->services()
+    $service = $container->services()
         ->defaults()
         ->private()
         ->autoconfigure();
 
-    $container
+    $service
         ->set(CeremonyStepManagerFactory::class)
     ;
 
-    $container
+    $service
         ->set('webauthn.clock.default')
         ->class(NativeClock::class)
     ;
 
-    $container
+    $service
         ->set('webauthn.ceremony_step_manager.creation')
         ->class(CeremonyStepManager::class)
         ->factory([service(CeremonyStepManagerFactory::class), 'creationCeremony'])
-        ->args([param('webauthn.secured_relying_party_ids')])
     ;
 
-    $container
+    $service
         ->set(SimpleFakeCredentialGenerator::class)
         ->args([service(CacheItemPoolInterface::class)->nullOnInvalid()])
     ;
 
-    $container
+    $service
         ->set('webauthn.ceremony_step_manager.request')
         ->class(CeremonyStepManager::class)
         ->factory([service(CeremonyStepManagerFactory::class), 'requestCeremony'])
-        ->args([param('webauthn.secured_relying_party_ids')])
     ;
 
-    $container
+    $service
         ->set(AuthenticatorAttestationResponseValidator::class)
         ->args([service('webauthn.ceremony_step_manager.creation')])
         ->public();
-    $container
+    $service
         ->set(AuthenticatorAssertionResponseValidator::class)
         ->class(AuthenticatorAssertionResponseValidator::class)
         ->args([service('webauthn.ceremony_step_manager.request')])
         ->public();
-    $container
+    $service
         ->set(PublicKeyCredentialCreationOptionsFactory::class)
         ->args([param('webauthn.creation_profiles')])
         ->public();
-    $container
+    $service
         ->set(PublicKeyCredentialRequestOptionsFactory::class)
         ->args([param('webauthn.request_profiles')])
         ->public();
 
-    $container
+    $service
         ->set(ExtensionOutputCheckerHandler::class);
-    $container
+    $service
         ->set(AttestationObjectLoader::class)
         ->args([service(AttestationStatementSupportManager::class)]);
-    $container
+    $service
         ->set(AttestationStatementSupportManager::class);
-    $container
+    $service
         ->set(NoneAttestationStatementSupport::class);
 
-    $container
+    $service
         ->set(ThrowExceptionIfInvalid::class)
         ->autowire(false);
 
-    $container
+    $service
         ->set(Loader::class)
         ->tag('routing.loader');
 
-    $container
+    $service
         ->set(AttestationControllerFactory::class)
         ->args([
             service(SerializerInterface::class),
             service(AuthenticatorAttestationResponseValidator::class),
             service(PublicKeyCredentialSourceRepositoryInterface::class),
         ]);
-    $container
+    $service
         ->set(AssertionControllerFactory::class)
         ->args([
             service(SerializerInterface::class),
@@ -135,112 +133,112 @@ return static function (ContainerConfigurator $container): void {
             service(PublicKeyCredentialSourceRepositoryInterface::class),
         ]);
 
-    $container
+    $service
         ->set(DummyPublicKeyCredentialSourceRepository::class)
         ->autowire(false);
-    $container
+    $service
         ->set(DummyPublicKeyCredentialUserEntityRepository::class)
         ->autowire(false);
 
-    $container
+    $service
         ->set(DummyControllerFactory::class);
 
-    $container
+    $service
         ->set('webauthn.logger.default')
         ->class(NullLogger::class);
 
-    $container
+    $service
         ->alias('webauthn.http_client.default', HttpClientInterface::class);
 
-    $container
+    $service
         ->set(VerificationMethodANDCombinationsDenormalizer::class)
         ->tag('serializer.normalizer', [
             'priority' => 1024,
         ]);
-    $container
+    $service
         ->set(ExtensionDescriptorDenormalizer::class)
         ->tag('serializer.normalizer', [
             'priority' => 1024,
         ]);
-    $container
+    $service
         ->set(AttestationObjectDenormalizer::class)
         ->tag('serializer.normalizer', [
             'priority' => 1024,
         ]);
-    $container
+    $service
         ->set(AttestationStatementDenormalizer::class)
         ->args([service(AttestationStatementSupportManager::class)])
         ->tag('serializer.normalizer', [
             'priority' => 1024,
         ]);
-    $container
+    $service
         ->set(AuthenticationExtensionNormalizer::class)
         ->tag('serializer.normalizer', [
             'priority' => 1024,
         ]);
-    $container
+    $service
         ->set(PublicKeyCredentialDescriptorNormalizer::class)
         ->tag('serializer.normalizer', [
             'priority' => 1024,
         ]);
-    $container
+    $service
         ->set(AttestedCredentialDataNormalizer::class)
         ->tag('serializer.normalizer', [
             'priority' => 1024,
         ]);
-    $container
+    $service
         ->set(AuthenticationExtensionsDenormalizer::class)
         ->tag('serializer.normalizer', [
             'priority' => 1024,
         ]);
-    $container
+    $service
         ->set(AuthenticatorAssertionResponseDenormalizer::class)
         ->tag('serializer.normalizer', [
             'priority' => 1024,
         ]);
-    $container
+    $service
         ->set(AuthenticatorAttestationResponseDenormalizer::class)
         ->tag('serializer.normalizer', [
             'priority' => 1024,
         ]);
-    $container
+    $service
         ->set(AuthenticatorDataDenormalizer::class)
         ->tag('serializer.normalizer', [
             'priority' => 1024,
         ]);
-    $container
+    $service
         ->set(AuthenticatorResponseDenormalizer::class)
         ->tag('serializer.normalizer', [
             'priority' => 1024,
         ]);
-    $container
+    $service
         ->set(CollectedClientDataDenormalizer::class)
         ->tag('serializer.normalizer', [
             'priority' => 1024,
         ]);
-    $container
+    $service
         ->set(PublicKeyCredentialDenormalizer::class)
         ->tag('serializer.normalizer', [
             'priority' => 1024,
         ]);
-    $container
+    $service
         ->set(PublicKeyCredentialOptionsDenormalizer::class)
         ->tag('serializer.normalizer', [
             'priority' => 1024,
         ]);
-    $container
+    $service
         ->set(PublicKeyCredentialSourceDenormalizer::class)
         ->tag('serializer.normalizer', [
             'priority' => 1024,
         ]);
-    $container
+    $service
         ->set(PublicKeyCredentialUserEntityDenormalizer::class)
         ->tag('serializer.normalizer', [
             'priority' => 1024,
         ]);
-    $container->set(WebauthnSerializerFactory::class)
+    $service->set(WebauthnSerializerFactory::class)
         ->args([service(AttestationStatementSupportManager::class)])
     ;
-    $container->set(DefaultFailureHandler::class);
-    $container->set(DefaultSuccessHandler::class);
+    $service->set(DefaultFailureHandler::class);
+    $service->set(DefaultSuccessHandler::class);
 };

--- a/src/symfony/src/Security/WebauthnFirewallConfig.php
+++ b/src/symfony/src/Security/WebauthnFirewallConfig.php
@@ -126,6 +126,7 @@ final readonly class WebauthnFirewallConfig
     }
 
     /**
+     * @deprecated since 5.2.0 and will be removed in 6.0.
      * @return string[]
      */
     public function getSecuredRpIds(): array

--- a/src/webauthn/src/CeremonyStep/CeremonyStepManagerFactory.php
+++ b/src/webauthn/src/CeremonyStep/CeremonyStepManagerFactory.php
@@ -35,6 +35,13 @@ final class CeremonyStepManagerFactory
      */
     private null|array $securedRelyingPartyId = null;
 
+    /**
+     * @var string[]
+     */
+    private null|array $allowedOrigins = null;
+
+    private bool $allowSubdomains = false;
+
     private AttestationStatementSupportManager $attestationStatementSupportManager;
 
     private ExtensionOutputCheckerHandler $extensionOutputCheckerHandler;
@@ -55,11 +62,21 @@ final class CeremonyStepManagerFactory
     }
 
     /**
+     * @deprecated since 5.2.0 and will be removed in 6.0.0. Use setAllowedOrigins instead.
      * @param string[] $securedRelyingPartyId
      */
     public function setSecuredRelyingPartyId(array $securedRelyingPartyId): void
     {
         $this->securedRelyingPartyId = $securedRelyingPartyId;
+    }
+
+    /**
+     * @param string[] $allowedOrigins
+     */
+    public function setAllowedOrigins(array $allowedOrigins, bool $allowSubdomains = false): void
+    {
+        $this->allowedOrigins = $allowedOrigins;
+        $this->allowSubdomains = $allowSubdomains;
     }
 
     public function setExtensionOutputCheckerHandler(ExtensionOutputCheckerHandler $extensionOutputCheckerHandler): void
@@ -116,7 +133,9 @@ final class CeremonyStepManagerFactory
         return new CeremonyStepManager([
             new CheckClientDataCollectorType(),
             new CheckChallenge(),
-            new CheckOrigin($this->securedRelyingPartyId ?? []),
+            $this->allowedOrigins === null ? new CheckOrigin(
+                $this->securedRelyingPartyId ?? []
+            ) : new CheckAllowedOrigins($this->allowedOrigins, $this->allowSubdomains),
             new CheckTopOrigin($this->topOriginValidator),
             new CheckRelyingPartyIdIdHash(),
             new CheckUserWasPresent(),
@@ -139,7 +158,9 @@ final class CeremonyStepManagerFactory
             new CheckUserHandle(),
             new CheckClientDataCollectorType(),
             new CheckChallenge(),
-            new CheckOrigin($this->securedRelyingPartyId ?? []),
+            $this->allowedOrigins === null ? new CheckOrigin(
+                $this->securedRelyingPartyId ?? []
+            ) : new CheckAllowedOrigins($this->allowedOrigins, $this->allowSubdomains),
             new CheckTopOrigin(null),
             new CheckRelyingPartyIdIdHash(),
             new CheckUserWasPresent(),

--- a/src/webauthn/src/CeremonyStep/CheckAllowedOrigins.php
+++ b/src/webauthn/src/CeremonyStep/CheckAllowedOrigins.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\CeremonyStep;
+
+use InvalidArgumentException;
+use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\Exception\AuthenticatorResponseVerificationException;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\PublicKeyCredentialSource;
+use function count;
+use function in_array;
+use function is_array;
+use function is_string;
+use function sprintf;
+use function strlen;
+use function substr;
+
+final readonly class CheckAllowedOrigins implements CeremonyStep
+{
+    /**
+     * @var string[]
+     */
+    private array $allowedOrigins;
+
+    /**
+     * @param string[] $allowedOrigins
+     */
+    public function __construct(
+        array $allowedOrigins,
+        private bool $allowSubdomains = false
+    ) {
+        $origins = [];
+        foreach ($allowedOrigins as $allowedOrigin) {
+            $parsedAllowedOrigin = parse_url($allowedOrigin);
+            $parsedAllowedOrigin !== false || throw new InvalidArgumentException(sprintf(
+                'Invalid origin: %s',
+                $allowedOrigin
+            ));
+            $allowedOriginHost = $parsedAllowedOrigin['host'] ?? '';
+            if ($allowedOriginHost === '') {
+                $allowedOriginHost = $allowedOrigin;
+            }
+            $origins[] = $allowedOriginHost;
+        }
+
+        $this->allowedOrigins = array_unique($origins);
+    }
+
+    public function process(
+        PublicKeyCredentialSource $publicKeyCredentialSource,
+        AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
+        PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
+        ?string $userHandle,
+        string $host
+    ): void {
+        $authData = $authenticatorResponse instanceof AuthenticatorAssertionResponse ? $authenticatorResponse->authenticatorData : $authenticatorResponse->attestationObject->authData;
+        $C = $authenticatorResponse->clientDataJSON;
+
+        $parsedRelyingPartyId = parse_url($C->origin);
+        $clientDataRpId = $parsedRelyingPartyId['host'] ?? '';
+        if ($clientDataRpId === '') {
+            $clientDataRpId = $C->origin;
+        }
+        is_array($parsedRelyingPartyId) || throw AuthenticatorResponseVerificationException::create(
+            'Invalid origin. Unable to parse the origin.'
+        );
+        if (in_array($clientDataRpId, $this->allowedOrigins, true)) {
+            return;
+        }
+        $isSubDomain = $this->isSubdomain($this->allowedOrigins, $clientDataRpId);
+        if ($this->allowSubdomains && $isSubDomain) {
+            return;
+        }
+        if (! $this->allowSubdomains && $isSubDomain) {
+            throw AuthenticatorResponseVerificationException::create('Invalid origin. Subdomains are not allowed.');
+        }
+        if (count($this->allowedOrigins) !== 0) {
+            throw AuthenticatorResponseVerificationException::create(
+                'Invalid origin. Not in the list of allowed origins.'
+            );
+        }
+
+        $rpId = $publicKeyCredentialOptions->rpId ?? $publicKeyCredentialOptions->rp->id ?? $host;
+        $facetId = $this->getFacetId($rpId, $publicKeyCredentialOptions->extensions, $authData->extensions);
+        $facetId !== '' || throw AuthenticatorResponseVerificationException::create(
+            'Invalid origin. Unable to determine the facet ID.'
+        );
+        if ($clientDataRpId === $facetId) {
+            return;
+        }
+        $isSubDomains = $this->isSubdomainOf($clientDataRpId, $facetId);
+        if ($this->allowSubdomains && $isSubDomains) {
+            return;
+        }
+        if (! $this->allowSubdomains && $isSubDomains) {
+            throw AuthenticatorResponseVerificationException::create('Invalid origin. Subdomains are not allowed.');
+        }
+
+        $scheme = $parsedRelyingPartyId['scheme'] ?? '';
+        $scheme === 'https' || throw AuthenticatorResponseVerificationException::create(
+            'Invalid scheme. HTTPS required.'
+        );
+    }
+
+    private function isSubdomainOf(string $subdomain, string $domain): bool
+    {
+        return substr('.' . $subdomain, -strlen('.' . $domain)) === '.' . $domain;
+    }
+
+    private function getFacetId(
+        string $rpId,
+        AuthenticationExtensions $AuthenticationExtensions,
+        ?AuthenticationExtensions $authenticationExtensionsClientOutputs
+    ): string {
+        if ($authenticationExtensionsClientOutputs === null
+            || ! $AuthenticationExtensions->has('appid')
+            || ! $authenticationExtensionsClientOutputs->has('appid')) {
+            return $rpId;
+        }
+
+        $appId = $AuthenticationExtensions->get('appid')
+            ->value;
+        $wasUsed = $authenticationExtensionsClientOutputs->get('appid')
+            ->value;
+
+        return (is_string($appId) && $wasUsed === true) ? $appId : $rpId;
+    }
+
+    /**
+     * @param string[] $origins
+     */
+    private function isSubdomain(array $origins, string $domain): bool
+    {
+        foreach ($origins as $allowedOrigin) {
+            if ($this->isSubdomainOf($domain, $allowedOrigin)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/webauthn/src/CeremonyStep/CheckOrigin.php
+++ b/src/webauthn/src/CeremonyStep/CheckOrigin.php
@@ -16,6 +16,9 @@ use function is_array;
 use function is_string;
 use function strlen;
 
+/**
+ * @deprecated since 5.2.0 and will be removed in 6.0.0. Will be replaced by CheckAllowedOrigins
+ */
 final readonly class CheckOrigin implements CeremonyStep
 {
     /**

--- a/tests/library/AbstractTestCase.php
+++ b/tests/library/AbstractTestCase.php
@@ -101,7 +101,16 @@ abstract class AbstractTestCase extends TestCase
             $this->ceremonyStepManagerFactory->setExtensionOutputCheckerHandler(
                 ExtensionOutputCheckerHandler::create()
             );
-            $this->ceremonyStepManagerFactory->setSecuredRelyingPartyId(['localhost']);
+            $this->ceremonyStepManagerFactory->setAllowedOrigins([
+                'http://localhost',
+                'https://localhost',
+                'https://dev.dontneeda.pw',
+                'https://spomky-webauthn.herokuapp.com',
+                'https://tuleap-web.tuleap-aio-dev.docker',
+                'https://webauthn.spomky-labs.com',
+                'https://webauthn.morselli.fr',
+                'https://webauthn.firstyear.id.au',
+            ]);
         }
 
         return $this->ceremonyStepManagerFactory;

--- a/tests/library/Functional/CheckAllowedOriginsTest.php
+++ b/tests/library/Functional/CheckAllowedOriginsTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Functional;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+use Webauthn\CeremonyStep\CheckAllowedOrigins;
+use Webauthn\Exception\AuthenticatorResponseVerificationException;
+use Webauthn\PublicKeyCredential;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\PublicKeyCredentialSource;
+use Webauthn\Tests\AbstractTestCase;
+
+final class CheckAllowedOriginsTest extends AbstractTestCase
+{
+    #[Test]
+    public function theOriginIsNotInAllowedOrigins(): void
+    {
+        //Then
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+        $this->expectExceptionMessage('Invalid origin');
+
+        //Given
+        $checkOrigins = new CheckAllowedOrigins(['https://example.org']);
+        $publicKeyCredentialSource = $this->getPublicKeyCredentialSource();
+        $publicKeyCredentialRequestOptions = $this->getPublicKeyCredentialRequestOptions();
+        $publicKeyCredential = $this->getPublicKeyCredential();
+
+        //When
+        $checkOrigins->process(
+            $publicKeyCredentialSource,
+            $publicKeyCredential->response,
+            $publicKeyCredentialRequestOptions,
+            null,
+            'example.org',
+        );
+    }
+
+    #[Test]
+    public function theOriginIsValid(): void
+    {
+        //Given
+        $checkOrigins = new CheckAllowedOrigins(['https://webauthn.spomky-labs.com']);
+        $publicKeyCredentialSource = $this->getPublicKeyCredentialSource();
+        $publicKeyCredentialRequestOptions = $this->getPublicKeyCredentialRequestOptions();
+        $publicKeyCredential = $this->getPublicKeyCredential();
+
+        //When
+        $checkOrigins->process(
+            $publicKeyCredentialSource,
+            $publicKeyCredential->response,
+            $publicKeyCredentialRequestOptions,
+            null,
+            'webauthn.spomky-labs.com',
+        );
+
+        //Then
+        static::assertTrue(true);
+    }
+
+    #[Test]
+    public function validSubdomainWithAllowSubdomains(): void
+    {
+        //Given
+        $checkOrigins = new CheckAllowedOrigins(['spomky-labs.com'], true);
+        $publicKeyCredentialSource = $this->getPublicKeyCredentialSource();
+        $publicKeyCredentialRequestOptions = $this->getPublicKeyCredentialRequestOptions();
+        $publicKeyCredential = $this->getPublicKeyCredential();
+
+        //When
+        $checkOrigins->process(
+            $publicKeyCredentialSource,
+            $publicKeyCredential->response,
+            $publicKeyCredentialRequestOptions,
+            null,
+            'spomky-labs.com',
+        );
+
+        //Then
+        static::assertTrue(true);
+    }
+
+    #[Test]
+    public function invalidSubdomainWithoutAllowSubdomains(): void
+    {
+        //Then
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+        $this->expectExceptionMessage('Invalid origin');
+
+        //Given
+        $checkOrigins = new CheckAllowedOrigins(['https://spomky-labs.com']);
+        $publicKeyCredentialSource = $this->getPublicKeyCredentialSource();
+        $publicKeyCredentialRequestOptions = $this->getPublicKeyCredentialRequestOptions();
+        $publicKeyCredential = $this->getPublicKeyCredential();
+
+        //When
+        $checkOrigins->process(
+            $publicKeyCredentialSource,
+            $publicKeyCredential->response,
+            $publicKeyCredentialRequestOptions,
+            null,
+            'spomky-labs.com',
+        );
+    }
+
+    #[Test]
+    public function emptyAllowedOriginsDefaultsToHttps(): void
+    {
+        //Given
+        $checkOrigins = new CheckAllowedOrigins([]);
+        $publicKeyCredentialSource = $this->getPublicKeyCredentialSource();
+        $publicKeyCredentialRequestOptions = $this->getPublicKeyCredentialRequestOptions();
+        $publicKeyCredential = $this->getPublicKeyCredential();
+
+        //When
+        $checkOrigins->process(
+            $publicKeyCredentialSource,
+            $publicKeyCredential->response,
+            $publicKeyCredentialRequestOptions,
+            null,
+            'webauthn.spomky-labs.com',
+        );
+
+        //Then
+        static::assertTrue(true); // if no exception, test passes
+    }
+
+    #[Test]
+    public function emptyAllowedOriginsWithoutSubdomains(): void
+    {
+        //Then
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+        $this->expectExceptionMessage('Invalid origin. Subdomains are not allowed.');
+
+        //Given
+        $checkOrigins = new CheckAllowedOrigins([], false);
+        $publicKeyCredentialSource = $this->getPublicKeyCredentialSource();
+        $publicKeyCredentialRequestOptions = $this->getPublicKeyCredentialRequestOptions();
+        $publicKeyCredential = $this->getPublicKeyCredential();
+
+        //When
+        $checkOrigins->process(
+            $publicKeyCredentialSource,
+            $publicKeyCredential->response,
+            $publicKeyCredentialRequestOptions,
+            null,
+            'spomky-labs.com',
+        );
+    }
+
+    #[Test]
+    public function emptyAllowedOriginsWithSubdomains(): void
+    {
+        //Given
+        $checkOrigins = new CheckAllowedOrigins([], true);
+        $publicKeyCredentialSource = $this->getPublicKeyCredentialSource();
+        $publicKeyCredentialRequestOptions = $this->getPublicKeyCredentialRequestOptions();
+        $publicKeyCredential = $this->getPublicKeyCredential();
+
+        //When
+        $checkOrigins->process(
+            $publicKeyCredentialSource,
+            $publicKeyCredential->response,
+            $publicKeyCredentialRequestOptions,
+            null,
+            'spomky-labs.com',
+        );
+
+        //Then
+        static::assertTrue(true); // if no exception, test passes
+    }
+
+    #[Test]
+    public function emptyAllowedOriginsWithoutSubdomainsAndValidHost(): void
+    {
+        //Given
+        $checkOrigins = new CheckAllowedOrigins([], false);
+        $publicKeyCredentialSource = $this->getPublicKeyCredentialSource();
+        $publicKeyCredentialRequestOptions = $this->getPublicKeyCredentialRequestOptions();
+        $publicKeyCredential = $this->getPublicKeyCredential();
+
+        //When
+        $checkOrigins->process(
+            $publicKeyCredentialSource,
+            $publicKeyCredential->response,
+            $publicKeyCredentialRequestOptions,
+            null,
+            'webauthn.spomky-labs.com',
+        );
+
+        //Then
+        static::assertTrue(true); // if no exception, test passes
+    }
+
+    #[Test]
+    public function emptyAllowedOriginsWithSubdomainsAndInvalidHost(): void
+    {
+        //Then
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+        $this->expectExceptionMessage('Invalid origin. Subdomains are not allowed.');
+
+        //Given
+        $checkOrigins = new CheckAllowedOrigins([], false);
+        $publicKeyCredentialSource = $this->getPublicKeyCredentialSource();
+        $publicKeyCredentialRequestOptions = $this->getPublicKeyCredentialRequestOptions();
+        $publicKeyCredential = $this->getPublicKeyCredential();
+
+        //When
+        $checkOrigins->process(
+            $publicKeyCredentialSource,
+            $publicKeyCredential->response,
+            $publicKeyCredentialRequestOptions,
+            null,
+            'spomky-labs.com',
+        );
+    }
+
+    private function getPublicKeyCredentialSource(): PublicKeyCredentialSource
+    {
+        return $this->createPublicKeyCredentialSource(
+            base64_decode(
+                'eHouz/Zi7+BmByHjJ/tx9h4a1WZsK4IzUmgGjkhyOodPGAyUqUp/B9yUkflXY3yHWsNtsrgCXQ3HjAIFUeZB+w==',
+                true
+            ),
+            'foo',
+            100,
+            Uuid::fromString('00000000-0000-0000-0000-000000000000'),
+            base64_decode(
+                'pQECAyYgASFYIJV56vRrFusoDf9hm3iDmllcxxXzzKyO9WruKw4kWx7zIlgg/nq63l8IMJcIdKDJcXRh9hoz0L+nVwP1Oxil3/oNQYs=',
+                true
+            )
+        );
+    }
+
+    private function getPublicKeyCredential(): PublicKeyCredential
+    {
+        return $this->getSerializer()
+            ->deserialize(
+                '{"id":"12Q1ykFsRWcUbO_y23o3cimk9Bn3rFahaKEAUHyMjrg","rawId":"12Q1ykFsRWcUbO_y23o3cimk9Bn3rFahaKEAUHyMjrg","response":{"attestationObject":"o2NmbXRmcGFja2VkZ2F0dFN0bXSjY2FsZyZjc2lnWEgwRgIhAIVT1JJcjJlU4xyiEWB1DO3OqMLJdC62t8es-JvwbDTgAiEA4E9bIHL-bq4_r09qUBDcm-qCqz0a7NP42K_fSj1YoqBjeDVjglkCkjCCAo4wggI0oAMCAQICAQEwCgYIKoZIzj0EAwIwga8xJjAkBgNVBAMMHUZJRE8yIElOVEVSTUVESUFURSBwcmltZTI1NnYxMTEwLwYJKoZIhvcNAQkBFiJjb25mb3JtYW5jZS10b29sc0BmaWRvYWxsaWFuY2Uub3JnMRYwFAYDVQQKDA1GSURPIEFsbGlhbmNlMQwwCgYDVQQLDANDV0cxCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJNWTESMBAGA1UEBwwJV2FrZWZpZWxkMB4XDTE4MDUyMzE0Mzc0MVoXDTI4MDUyMDE0Mzc0MVowgcIxIzAhBgNVBAMMGkZJRE8yIEJBVENIIEtFWSBwcmltZTI1NnYxMTEwLwYJKoZIhvcNAQkBFiJjb25mb3JtYW5jZS10b29sc0BmaWRvYWxsaWFuY2Uub3JnMRYwFAYDVQQKDA1GSURPIEFsbGlhbmNlMSIwIAYDVQQLDBlBdXRoZW50aWNhdG9yIEF0dGVzdGF0aW9uMQswCQYDVQQGEwJVUzELMAkGA1UECAwCTVkxEjAQBgNVBAcMCVdha2VmaWVsZDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABLrZYqzxrVIvmvsKDJIcF9vrOpmT0KSjZmO-xPXL8hr7gGRpZRxRkYP0fJEPzCo0ZTK3D-vHFtsdDgG9V24pSGSjLDAqMAkGA1UdEwQCMAAwHQYDVR0OBBYEFEpU5QbSkURPbQ8zXdb9x0ZsuV9UMAoGCCqGSM49BAMCA0gAMEUCIQC5Wza0c32jrBDTDb7165XlBCdCWkSVfzvhhqHTfyfqRQIgTQuswDhApHwqT_X6W8aYccqenKb9HKF8DNaRhHM3KXhZBDUwggQxMIICGaADAgECAgECMA0GCSqGSIb3DQEBCwUAMIGhMRgwFgYDVQQDDA9GSURPMiBURVNUIFJPT1QxMTAvBgkqhkiG9w0BCQEWImNvbmZvcm1hbmNlLXRvb2xzQGZpZG9hbGxpYW5jZS5vcmcxFjAUBgNVBAoMDUZJRE8gQWxsaWFuY2UxDDAKBgNVBAsMA0NXRzELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAk1ZMRIwEAYDVQQHDAlXYWtlZmllbGQwHhcNMTgwNzIzMTQyOTA3WhcNNDUxMjA4MTQyOTA3WjCBrzEmMCQGA1UEAwwdRklETzIgSU5URVJNRURJQVRFIHByaW1lMjU2djExMTAvBgkqhkiG9w0BCQEWImNvbmZvcm1hbmNlLXRvb2xzQGZpZG9hbGxpYW5jZS5vcmcxFjAUBgNVBAoMDUZJRE8gQWxsaWFuY2UxDDAKBgNVBAsMA0NXRzELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAk1ZMRIwEAYDVQQHDAlXYWtlZmllbGQwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATcQR3fVW1_TXOMqXUUelVx9GMAKSPWb7R7XpeHIHBZBQ7JzoepbzRXitTdCLTCfNXpLE1G6JRcstPmX9tLSXnzoy8wLTAMBgNVHRMEBTADAQH_MB0GA1UdDgQWBBRnwRmSkFv1XQDB1iEOjC12IZJHwDANBgkqhkiG9w0BAQsFAAOCAgEAC5gup7NUuwcndifv5dwlZ6GISPTEciQdMxmNo9nE9BRAO2btQ0DdJdifA8GnQQd29dIgk8U48WucY4qzuvRZaK6z6AIrU2bAUlJrKnlTZvjdiM3oiTY9WTiB9eyfmK_ZgEv7W9DEFW7vrh32-pjSNF1VyxuMEpna1X6syqtNDVG-w0YLjdkXi0ciuRJy0Q9A90vmMKgAxgnRfCol5aQUlHpZMTiK-8OCp8sSoq05QN39iy34u4AeKGUWeuKjYEwNsgKgn-v1-A1dbUw2cWYg53Oi5m_DQLlt-Ws1hokuwXxCekaBvieB9nu13fYXv7SkgwuWPNwyFPlQkWpIPgb9eZME3knUiJ2EAS1UE7kraWNg3cQO2v6tY24-5-FmEyuWinGChrHswT0sYtmhQGlWa0bCV9fELL69bCO64RiWoenLsiX15hmmC7-ZbF9D1VHj1BHR9eioAZUVonEiDJSZHtVxXlmU3jQBhrEPztF5Rn670dzq_E4HLPfzbrKW-L2F2i-WEWF7cticNVBBLXUHsFAvGYMqv7DE0zDGaZ7L-jXIjSCiE2IjixChMYw_aFYwmx0N6yuXeJDYu8fCSXOKTPR6ZRsLCQ38tXFSQRyn1T5Fgvxds7Q2sxgtVXCNy8FMoof27gjMu5i4pAt2ldXEOx1zI2P-Nv6GFxY2U_BtXINoYXV0aERhdGFYpJYE6oKCTpikraFLRGLQ1zqOxGkTDakbGTB0WSKfdKNZQQAAABuA9T0ehS5D7bs_0C8TIuWvACDXZDXKQWxFZxRs7_LbejdyKaT0GfesVqFooQBQfIyOuKUBAgMmIAEhWCCR3V4iMssbPhNCS1rk4wtdZKaqX9L5e3DwGUJKi0OBgCJYIKBBtvFMQHD3m-EgmcQOXmQhctxiyh68RT1QmNq_xWm4","clientDataJSON":"eyJvcmlnaW4iOiJodHRwczovL3dlYmF1dGhuLnNwb21reS1sYWJzLmNvbSIsImNoYWxsZW5nZSI6IjhoUFo1YWdiUXg2YkN3X1g5Yzc1SnlFM0RQMVBBdlcxd3YzV2tucHFCaGMiLCJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIn0"},"getClientExtensionResults":{},"type":"public-key"}',
+                PublicKeyCredential::class,
+                'json'
+            );
+    }
+
+    private function getPublicKeyCredentialRequestOptions(): PublicKeyCredentialRequestOptions
+    {
+        return $this->getSerializer()
+            ->deserialize(
+                '{"rp":{"name":"Webauthn Demo, by Spomky-Labs","id":"webauthn.spomky-labs.com"},"pubKeyCredParams":[{"type":"public-key","alg":-8},{"type":"public-key","alg":-46},{"type":"public-key","alg":-7},{"type":"public-key","alg":-35},{"type":"public-key","alg":-36},{"type":"public-key","alg":-257},{"type":"public-key","alg":-258},{"type":"public-key","alg":-259},{"type":"public-key","alg":-37},{"type":"public-key","alg":-38},{"type":"public-key","alg":-39},{"type":"public-key","alg":-65535}],"challenge":"8hPZ5agbQx6bCw_X9c75JyE3DP1PAvW1wv3WknpqBhc","attestation":"direct","user":{"name":"DQ3SnF1Eeq5Av2WCPtlP","id":"MDFHN1JTR1RKTk5OVEpFOUUyS1M2Q0I1U1M","displayName":"Clarice Zemlicka"},"authenticatorSelection":{"userVerification":"preferred"},"excludeCredentials":[],"timeout":60000,"status":"ok","errorMessage":""}',
+                PublicKeyCredentialRequestOptions::class,
+                'json'
+            );
+    }
+}

--- a/tests/symfony/config/config.yml
+++ b/tests/symfony/config/config.yml
@@ -126,6 +126,12 @@ doctrine:
 webauthn:
   credential_repository: 'Webauthn\Tests\Bundle\Functional\PublicKeyCredentialSourceRepository'
   user_repository: 'Webauthn\Tests\Bundle\Functional\PublicKeyCredentialUserEntityRepository'
+  allowed_origins:
+    - 'https://localhost'
+    - 'https://bar.acme'
+    - 'https://webauthn.spomky-labs.com'
+    - 'https://spomky-webauthn.herokuapp.com'
+  allow_subdomains: false
   controllers:
     enabled: true
     creation:

--- a/tests/symfony/functional/Firewall/AllowedOriginsTest.php
+++ b/tests/symfony/functional/Firewall/AllowedOriginsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Bundle\Functional\Firewall;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+final class AllowedOriginsTest extends WebTestCase
+{
+    #[Test]
+    public function allowedOriginsAreAvailable(): void
+    {
+        //Given
+        $client = static::createClient(server: [
+            'HTTPS' => 'on',
+        ]);
+
+        //When
+        $client->request(Request::METHOD_GET, '/.well-known/webauthn');
+
+        //Then
+        static::assertResponseIsSuccessful();
+        static::assertSame(
+            '{"origins":["https:\/\/localhost","https:\/\/bar.acme","https:\/\/webauthn.spomky-labs.com","https:\/\/spomky-webauthn.herokuapp.com"]}',
+            $client->getResponse()
+                ->getContent()
+        );
+    }
+}


### PR DESCRIPTION
Introduced `AllowedOriginsController` and `CheckAllowedOrigins` class to handle allowed origin validation for WebAuthn ceremonies. Added functional and unit tests to cover various scenarios, including subdomain handling and empty allowed origins. Updated service configuration for consistency by standardizing `$service` variable usage.

Target branch: 
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
