### PR TITLE
Fix trust path handling and improve assertions

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2011,7 +2011,7 @@ parameters:
 			path: src/webauthn/src/Denormalizer/TrustPathDenormalizer.php
 
 		-
-			message: '#^Parameter \#1 \$certificates of static method Webauthn\\TrustPath\\CertificateTrustPath\:\:create\(\) expects array\<string\>, array given\.$#'
+			message: '#^Parameter \#1 \$certificates of static method Webauthn\\TrustPath\\CertificateTrustPath\:\:create\(\) expects array\<string\>, array\<mixed, mixed\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/webauthn/src/Denormalizer/TrustPathDenormalizer.php

--- a/src/webauthn/src/Denormalizer/TrustPathDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/TrustPathDenormalizer.php
@@ -12,13 +12,14 @@ use Webauthn\TrustPath\EmptyTrustPath;
 use Webauthn\TrustPath\TrustPath;
 use function array_key_exists;
 use function assert;
+use function is_array;
 
 final class TrustPathDenormalizer implements DenormalizerInterface, NormalizerInterface
 {
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         return match (true) {
-            array_key_exists('x5c', $data) => CertificateTrustPath::create($data),
+            array_key_exists('x5c', $data) && is_array($data['x5c']) => CertificateTrustPath::create($data['x5c']),
             $data === [], isset($data['type']) && $data['type'] === EmptyTrustPath::class => EmptyTrustPath::create(),
             default => throw new InvalidTrustPathException('Unsupported trust path type'),
         };

--- a/tests/framework/ComposerJsonTest.php
+++ b/tests/framework/ComposerJsonTest.php
@@ -56,7 +56,7 @@ final class ComposerJsonTest extends TestCase
             'Dependencies declared in root composer.json, which are not declared in any sub-package: %s',
             implode('', $unusedDependencies)
         );
-        static::assertCount(0, $unusedDependencies, $message);
+        static::assertEmpty($unusedDependencies, $message);
     }
 
     #[Test]

--- a/tests/library/Unit/SerializerTest.php
+++ b/tests/library/Unit/SerializerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\Tests\Unit;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Serializer\Encoder\JsonEncode;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
@@ -13,6 +14,9 @@ use Webauthn\PublicKeyCredentialParameters;
 use Webauthn\PublicKeyCredentialRpEntity;
 use Webauthn\PublicKeyCredentialUserEntity;
 use Webauthn\Tests\AbstractTestCase;
+use Webauthn\TrustPath\CertificateTrustPath;
+use Webauthn\TrustPath\EmptyTrustPath;
+use Webauthn\TrustPath\TrustPath;
 use const JSON_THROW_ON_ERROR;
 
 /**
@@ -20,6 +24,55 @@ use const JSON_THROW_ON_ERROR;
  */
 final class SerializerTest extends AbstractTestCase
 {
+    public static function provideTrustPath(): iterable
+    {
+        yield [
+            CertificateTrustPath::create(['X509_KEY_1', 'X509_KEY_2', 'X509_KEY_3']),
+            '{"x5c":["X509_KEY_1","X509_KEY_2","X509_KEY_3"]}',
+        ];
+        yield [EmptyTrustPath::create(), '[]'];
+    }
+
+    #[Test]
+    #[DataProvider('provideTrustPath')]
+    public function theTrustPathCanBeSerialized(TrustPath $trustPath, string $expected): void
+    {
+        //When
+        $json = $this->getSerializer()
+            ->serialize(
+                $trustPath,
+                'json',
+                [
+                    JsonEncode::OPTIONS => JSON_THROW_ON_ERROR,
+                    AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+                    AbstractObjectNormalizer::SKIP_UNINITIALIZED_VALUES => true,
+                ],
+            );
+
+        //Then
+        static::assertJsonStringEqualsJsonString($expected, $json);
+    }
+
+    #[Test]
+    #[DataProvider('provideTrustPath')]
+    public function theTrustPathCanBeDeserialized(TrustPath $trustPath, string $expected): void
+    {
+        //When
+        $deserialized = $this->getSerializer()
+            ->deserialize(
+                $expected,
+                TrustPath::class,
+                'json',
+                [
+                    AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+                    AbstractObjectNormalizer::SKIP_UNINITIALIZED_VALUES => true,
+                ],
+            );
+
+        //Then
+        static::assertEquals($trustPath, $deserialized);
+    }
+
     #[Test]
     public function theCredentialCanBeDeserialized(): void
     {

--- a/tests/symfony/functional/Attestation/AttestationTest.php
+++ b/tests/symfony/functional/Attestation/AttestationTest.php
@@ -247,7 +247,7 @@ final class AttestationTest extends KernelTestCase
         );
         static::assertSame(32, strlen($options->challenge));
         static::assertSame([], $options->excludeCredentials);
-        static::assertCount(0, $options->pubKeyCredParams);
+        static::assertEmpty($options->pubKeyCredParams);
         static::assertSame('none', $options->attestation);
         static::assertNull($options->timeout);
     }


### PR DESCRIPTION
Target branch: 5.1.x
Resolves issue #681

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Updated trust path serialization and deserialization in tests, fixed parameter usage in TrustPathDenormalize.
