### PR TITLE
Malformed phpdoc tag in PublicKeyCredentialEntity

### DIFF
--- a/src/webauthn/src/PublicKeyCredentialEntity.php
+++ b/src/webauthn/src/PublicKeyCredentialEntity.php
@@ -7,7 +7,7 @@ namespace Webauthn;
 abstract class PublicKeyCredentialEntity
 {
     /**
-     * @@deprecated since 5.1.0 and will be removed in 6.0.0. This value is always null.
+     * @deprecated since 5.1.0 and will be removed in 6.0.0. This value is always null.
      */
     public ?string $icon = null;
 


### PR DESCRIPTION
Target branch: 5.1.x
Resolves issue #679 

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations
- [ ] 
Corrected the typo in the docblock annotation from `@@deprecated` to `@deprecated`. This ensures consistency with standard annotation formatting and improves code readability for developers.
