### PR TITLE
Restore compatibility with Doctrine DBAL version 3

### DIFF
--- a/src/symfony/src/Doctrine/Type/AttestedCredentialDataType.php
+++ b/src/symfony/src/Doctrine/Type/AttestedCredentialDataType.php
@@ -6,10 +6,9 @@ namespace Webauthn\Bundle\Doctrine\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\JsonType;
-use Doctrine\DBAL\Types\Type;
 use Webauthn\AttestedCredentialData;
 
-final class AttestedCredentialDataType extends Type
+final class AttestedCredentialDataType extends JsonType
 {
     use SerializerTrait;
 
@@ -31,22 +30,8 @@ final class AttestedCredentialDataType extends Type
         return $this->deserialize($value, AttestedCredentialData::class);
     }
 
-    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
-    {
-        return $platform->getJsonTypeDeclarationSQL($column);
-    }
-
     public function getName(): string
     {
         return 'attested_credential_data';
-    }
-
-    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
-    {
-        if (method_exists(JsonType::class, 'requiresSQLCommentHint')) {
-            return (new JsonType())->requiresSQLCommentHint($platform);
-        }
-
-        return false;
     }
 }

--- a/src/symfony/src/Doctrine/Type/AttestedCredentialDataType.php
+++ b/src/symfony/src/Doctrine/Type/AttestedCredentialDataType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Webauthn\Bundle\Doctrine\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\JsonType;
 use Doctrine\DBAL\Types\Type;
 use Webauthn\AttestedCredentialData;
 
@@ -38,5 +39,14 @@ final class AttestedCredentialDataType extends Type
     public function getName(): string
     {
         return 'attested_credential_data';
+    }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        if (method_exists(JsonType::class, 'requiresSQLCommentHint')) {
+            return (new JsonType())->requiresSQLCommentHint($platform);
+        }
+
+        return false;
     }
 }

--- a/src/symfony/src/Doctrine/Type/PublicKeyCredentialDescriptorType.php
+++ b/src/symfony/src/Doctrine/Type/PublicKeyCredentialDescriptorType.php
@@ -6,10 +6,9 @@ namespace Webauthn\Bundle\Doctrine\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\JsonType;
-use Doctrine\DBAL\Types\Type;
 use Webauthn\PublicKeyCredentialDescriptor;
 
-final class PublicKeyCredentialDescriptorType extends Type
+final class PublicKeyCredentialDescriptorType extends JsonType
 {
     use SerializerTrait;
 
@@ -31,22 +30,8 @@ final class PublicKeyCredentialDescriptorType extends Type
         return $this->deserialize($value, PublicKeyCredentialDescriptor::class);
     }
 
-    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
-    {
-        return $platform->getJsonTypeDeclarationSQL($column);
-    }
-
     public function getName(): string
     {
         return 'public_key_credential_descriptor';
-    }
-
-    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
-    {
-        if (method_exists(JsonType::class, 'requiresSQLCommentHint')) {
-            return (new JsonType())->requiresSQLCommentHint($platform);
-        }
-
-        return false;
     }
 }

--- a/src/symfony/src/Doctrine/Type/PublicKeyCredentialDescriptorType.php
+++ b/src/symfony/src/Doctrine/Type/PublicKeyCredentialDescriptorType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Webauthn\Bundle\Doctrine\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\JsonType;
 use Doctrine\DBAL\Types\Type;
 use Webauthn\PublicKeyCredentialDescriptor;
 
@@ -38,5 +39,14 @@ final class PublicKeyCredentialDescriptorType extends Type
     public function getName(): string
     {
         return 'public_key_credential_descriptor';
+    }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        if (method_exists(JsonType::class, 'requiresSQLCommentHint')) {
+            return (new JsonType())->requiresSQLCommentHint($platform);
+        }
+
+        return false;
     }
 }

--- a/src/symfony/src/Doctrine/Type/TrustPathDataType.php
+++ b/src/symfony/src/Doctrine/Type/TrustPathDataType.php
@@ -6,10 +6,9 @@ namespace Webauthn\Bundle\Doctrine\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\JsonType;
-use Doctrine\DBAL\Types\Type;
 use Webauthn\TrustPath\TrustPath;
 
-final class TrustPathDataType extends Type
+final class TrustPathDataType extends JsonType
 {
     use SerializerTrait;
 
@@ -31,22 +30,8 @@ final class TrustPathDataType extends Type
         return $this->deserialize($value, TrustPath::class);
     }
 
-    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
-    {
-        return $platform->getJsonTypeDeclarationSQL($column);
-    }
-
     public function getName(): string
     {
         return 'trust_path';
-    }
-
-    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
-    {
-        if (method_exists(JsonType::class, 'requiresSQLCommentHint')) {
-            return (new JsonType())->requiresSQLCommentHint($platform);
-        }
-
-        return false;
     }
 }

--- a/src/symfony/src/Doctrine/Type/TrustPathDataType.php
+++ b/src/symfony/src/Doctrine/Type/TrustPathDataType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Webauthn\Bundle\Doctrine\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\JsonType;
 use Doctrine\DBAL\Types\Type;
 use Webauthn\TrustPath\TrustPath;
 
@@ -38,5 +39,14 @@ final class TrustPathDataType extends Type
     public function getName(): string
     {
         return 'trust_path';
+    }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        if (method_exists(JsonType::class, 'requiresSQLCommentHint')) {
+            return (new JsonType())->requiresSQLCommentHint($platform);
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Target branch: 5.1.x
Resolves issue N/A

- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Using the `TrustPathDataType` together with MariaDB 10.4.3+ causes issues using the Doctrine comparator because it keeps trying to change the column from `JSON NOT NULL COMMENT '(DC2Type:json)'` to `JSON NOT NULL`. This PR fixes that mismatch.

Doctrine DBAL version 4 does not use column comments anymore, so this has no effect there but it fixes the comparator in version 3.