### PR TITLE
Deprecate DoctrineCredentialSourceRepository in Symfony.

### DIFF
--- a/src/symfony/src/Repository/DoctrineCredentialSourceRepository.php
+++ b/src/symfony/src/Repository/DoctrineCredentialSourceRepository.php
@@ -14,6 +14,8 @@ use function sprintf;
 /**
  * @template T of PublicKeyCredentialSource
  * @template-extends  ServiceEntityRepository<T>
+ *
+ * @deprecated since 5.2.0, to be removed in 6.0.0. Please create your own doctrine-based repository.
  */
 class DoctrineCredentialSourceRepository extends ServiceEntityRepository implements PublicKeyCredentialSourceRepositoryInterface, CanSaveCredentialSource
 {


### PR DESCRIPTION
Marked DoctrineCredentialSourceRepository as deprecated in preparation for removal in version 6.0.0. Developers are advised to create their own doctrine-based repository implementations.

Target branch: 
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [x] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
