### PR TITLE
Register the Symfony/UserProviderInterface

### DIFF
--- a/src/symfony/src/Resources/config/services.php
+++ b/src/symfony/src/Resources/config/services.php
@@ -131,6 +131,10 @@ return static function (ContainerConfigurator $container): void {
         ->alias('webauthn.http_client.default', HttpClientInterface::class);
 
     $service
+        ->set(UserProviderInterface::class)
+        ->alias('security.user_providers', UserProviderInterface::class);
+
+    $service
         ->set(VerificationMethodANDCombinationsDenormalizer::class)
         ->tag('serializer.normalizer', [
             'priority' => 1024,
@@ -219,5 +223,4 @@ return static function (ContainerConfigurator $container): void {
     $service->set(WebauthnSerializerFactory::class);
     $service->set(DefaultFailureHandler::class);
     $service->set(DefaultSuccessHandler::class);
-    $service->set(UserProviderInterface::class);
 };

--- a/src/symfony/src/Resources/config/services.php
+++ b/src/symfony/src/Resources/config/services.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Psr\Log\NullLogger;
 use Symfony\Component\Clock\NativeClock;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Webauthn\AttestationStatement\AttestationObjectLoader;
 use Webauthn\AttestationStatement\AttestationStatementSupportManager;
@@ -218,4 +219,5 @@ return static function (ContainerConfigurator $container): void {
     $service->set(WebauthnSerializerFactory::class);
     $service->set(DefaultFailureHandler::class);
     $service->set(DefaultSuccessHandler::class);
+    $service->set(UserProviderInterface::class);
 };


### PR DESCRIPTION
Target branch: 5.2.x

- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations


### Description

The Webauthn Badge support https://github.com/web-auth/webauthn-framework/pull/693 introduced a bug where it can not be autowired due to finding multiple existing services. This PR adds the correct interface as a service argument.


### Issue

In my case I tried to update Contao 5.5.x but it failed due to similar interfaces

```shell
 Cannot autowire service "Webauthn\Bundle\Security\Authentication\WebauthnBadgeListener": argument "$userProvider" of method "__construct()" refer
  ences interface "Symfony\Component\Security\Core\User\UserProviderInterface" but no such service exists. You should maybe alias this interface to
   one of these existing services: "security.user_providers", "contao.security.backend_user_provider", "contao.security.frontend_user_provider".
   ```

 