### PR TITLE
feat: add requireResidentKey property for backward compatibility with WebAuthn Level 3 spec

### DIFF
--- a/src/webauthn/src/AuthenticatorSelectionCriteria.php
+++ b/src/webauthn/src/AuthenticatorSelectionCriteria.php
@@ -48,6 +48,15 @@ class AuthenticatorSelectionCriteria
         self::RESIDENT_KEY_REQUIREMENT_DISCOURAGED,
     ];
 
+    /**
+     * Legacy property for backward compatibility.
+     *
+     * requireResidentKey is based on residentKey for backward compatibility
+     * Per WebAuthn Level 3 spec: "Relying Parties SHOULD set it to true if, and only if, residentKey is set to required."
+     * Only set when residentKey is "required"; leave uninitialized otherwise
+     */
+    public readonly ?bool $requireResidentKey;
+
     public function __construct(
         public null|string $authenticatorAttachment = null,
         public string $userVerification = self::USER_VERIFICATION_REQUIREMENT_PREFERRED,
@@ -62,6 +71,12 @@ class AuthenticatorSelectionCriteria
         in_array($residentKey, self::RESIDENT_KEY_REQUIREMENTS, true) || throw new InvalidArgumentException(
             'Invalid resident key'
         );
+
+        if ($residentKey === self::RESIDENT_KEY_REQUIREMENT_REQUIRED) {
+            $this->requireResidentKey = true;
+        } else {
+            $this->requireResidentKey = null;
+        }
     }
 
     public static function create(

--- a/src/webauthn/src/CeremonyStep/CeremonyStepManagerFactory.php
+++ b/src/webauthn/src/CeremonyStep/CeremonyStepManagerFactory.php
@@ -126,7 +126,7 @@ final class CeremonyStepManagerFactory
             $this->allowedOrigins === null ? new CheckOrigin(
                 $this->securedRelyingPartyId ?? []
             ) : new CheckAllowedOrigins($this->allowedOrigins, $this->allowSubdomains),
-            new CheckTopOrigin(null),
+            new CheckTopOrigin(),
             new CheckRelyingPartyIdIdHash(),
             new CheckUserWasPresent(),
             new CheckUserVerification(),

--- a/tests/MDS/Unit/BiometricAccuracyDescriptorObjectTest.php
+++ b/tests/MDS/Unit/BiometricAccuracyDescriptorObjectTest.php
@@ -39,7 +39,7 @@ final class BiometricAccuracyDescriptorObjectTest extends MdsTestCase
     public static function validObjectData(): iterable
     {
         yield [
-            BiometricAccuracyDescriptor::create(125.21, null, null, null, null),
+            BiometricAccuracyDescriptor::create(125.21, null, null),
             125.21,
             null,
             null,
@@ -48,7 +48,7 @@ final class BiometricAccuracyDescriptorObjectTest extends MdsTestCase
             '{"selfAttestedFRR":125.21}',
         ];
         yield [
-            BiometricAccuracyDescriptor::create(125.21, 0.001, null, null, null),
+            BiometricAccuracyDescriptor::create(125.21, 0.001, null),
             125.21,
             0.001,
             null,
@@ -57,7 +57,7 @@ final class BiometricAccuracyDescriptorObjectTest extends MdsTestCase
             '{"selfAttestedFRR":125.21,"selfAttestedFAR":0.001}',
         ];
         yield [
-            BiometricAccuracyDescriptor::create(125.21, 0.001, 12.3, null, null),
+            BiometricAccuracyDescriptor::create(125.21, 0.001, 12.3),
             125.21,
             0.001,
             12.3,
@@ -66,7 +66,7 @@ final class BiometricAccuracyDescriptorObjectTest extends MdsTestCase
             '{"selfAttestedFRR":125.21,"selfAttestedFAR":0.001,"maxTemplates":12.3}',
         ];
         yield [
-            BiometricAccuracyDescriptor::create(125.21, null, null, 50, null),
+            BiometricAccuracyDescriptor::create(125.21, null, null, 50),
             125.21,
             null,
             null,

--- a/tests/MDS/Unit/VerificationMethodANDCombinationsObjectTest.php
+++ b/tests/MDS/Unit/VerificationMethodANDCombinationsObjectTest.php
@@ -35,7 +35,7 @@ final class VerificationMethodANDCombinationsObjectTest extends MdsTestCase
                 VerificationMethodDescriptor::create(
                     VerificationMethodDescriptor::USER_VERIFY_PATTERN_EXTERNAL,
                     CodeAccuracyDescriptor::create(35, 5),
-                    BiometricAccuracyDescriptor::create(0.12, null, null, null, null),
+                    BiometricAccuracyDescriptor::create(0.12, null, null),
                     PatternAccuracyDescriptor::create(50)
                 ),
                 VerificationMethodDescriptor::create(VerificationMethodDescriptor::USER_VERIFY_FINGERPRINT_INTERNAL),

--- a/tests/MDS/Unit/VerificationMethodDescriptorObjectTest.php
+++ b/tests/MDS/Unit/VerificationMethodDescriptorObjectTest.php
@@ -30,19 +30,14 @@ final class VerificationMethodDescriptorObjectTest extends MdsTestCase
     public static function validObjectData(): iterable
     {
         yield [
-            VerificationMethodDescriptor::create(
-                VerificationMethodDescriptor::USER_VERIFY_FINGERPRINT_INTERNAL,
-                null,
-                null,
-                null
-            ),
+            VerificationMethodDescriptor::create(VerificationMethodDescriptor::USER_VERIFY_FINGERPRINT_INTERNAL),
             '{"userVerificationMethod":"fingerprint_internal"}',
         ];
         yield [
             VerificationMethodDescriptor::create(
                 VerificationMethodDescriptor::USER_VERIFY_PATTERN_EXTERNAL,
                 CodeAccuracyDescriptor::create(35, 5),
-                BiometricAccuracyDescriptor::create(0.12, null, null, null, null),
+                BiometricAccuracyDescriptor::create(0.12, null, null),
                 PatternAccuracyDescriptor::create(50)
             ),
             '{"userVerificationMethod":"pattern_external","caDesc":{"base":35,"minLength":5},"baDesc":{"selfAttestedFRR":0.12},"paDesc":{"minComplexity":50}}',

--- a/tests/library/Unit/AttestationStatement/AttestationObjectTest.php
+++ b/tests/library/Unit/AttestationStatement/AttestationObjectTest.php
@@ -20,7 +20,7 @@ final class AttestationObjectTest extends TestCase
     public function anAttestationObjectCanBeCreated(): void
     {
         $attestationStatement = AttestationStatement::create('', [], '', emptyTrustPath::create());
-        $authenticatorData = AuthenticatorData::create('', '', '', 0, null, null);
+        $authenticatorData = AuthenticatorData::create('', '', '', 0);
 
         $object = AttestationObject::create('rawAttestationObject', $attestationStatement, $authenticatorData);
 

--- a/tests/library/Unit/AttestationStatement/FidoU2FAttestationStatementSupportTest.php
+++ b/tests/library/Unit/AttestationStatement/FidoU2FAttestationStatementSupportTest.php
@@ -124,7 +124,7 @@ final class FidoU2FAttestationStatementSupportTest extends TestCase
             ]))
         );
 
-        $authenticatorData = AuthenticatorData::create('', 'FOO', '', 0, $attestedCredentialData, null);
+        $authenticatorData = AuthenticatorData::create('', 'FOO', '', 0, $attestedCredentialData);
 
         static::assertSame('fido-u2f', $support->name());
         static::assertFalse($support->isValid('FOO', $attestationStatement, $authenticatorData));

--- a/tests/library/Unit/AttestationStatement/NoneAttestationStatementSupportTest.php
+++ b/tests/library/Unit/AttestationStatement/NoneAttestationStatementSupportTest.php
@@ -22,7 +22,7 @@ final class NoneAttestationStatementSupportTest extends TestCase
         $support = new NoneAttestationStatementSupport();
 
         $attestationStatement = AttestationStatement::create('none', [], '', EmptyTrustPath::create());
-        $authenticatorData = AuthenticatorData::create('', '', '', 0, null, null);
+        $authenticatorData = AuthenticatorData::create('', '', '', 0);
 
         static::assertSame('none', $support->name());
         static::assertTrue($support->isValid('FOO', $attestationStatement, $authenticatorData));
@@ -36,7 +36,7 @@ final class NoneAttestationStatementSupportTest extends TestCase
         $attestationStatement = AttestationStatement::create('none', [
             'x5c' => ['FOO'],
         ], '', EmptyTrustPath::create());
-        $authenticatorData = AuthenticatorData::create('', '', '', 0, null, null);
+        $authenticatorData = AuthenticatorData::create('', '', '', 0);
 
         static::assertSame('none', $support->name());
         static::assertFalse($support->isValid('FOO', $attestationStatement, $authenticatorData));

--- a/tests/library/Unit/AuthenticatorDataTest.php
+++ b/tests/library/Unit/AuthenticatorDataTest.php
@@ -19,7 +19,7 @@ final class AuthenticatorDataTest extends TestCase
     #[Test]
     public function anAuthenticatorDataCanBeCreatedAndValueAccessed(): void
     {
-        $attestedCredentialData = AttestedCredentialData::create(Uuid::v4(), '', null);
+        $attestedCredentialData = AttestedCredentialData::create(Uuid::v4(), '');
         $extensions = AuthenticationExtensions::create();
 
         $authenticatorData = AuthenticatorData::create(

--- a/tests/library/Unit/AuthenticatorSelectionCriteriaTest.php
+++ b/tests/library/Unit/AuthenticatorSelectionCriteriaTest.php
@@ -57,7 +57,7 @@ final class AuthenticatorSelectionCriteriaTest extends AbstractTestCase
     public function anAuthenticatorSelectionCriteriaWithResidentKeyCanBeCreatedAndValueAccessed(): void
     {
         // Given
-        $expectedJson = '{"userVerification":"required","residentKey":"required","authenticatorAttachment":"platform"}';
+        $expectedJson = '{"requireResidentKey":true,"userVerification":"required","residentKey":"required","authenticatorAttachment":"platform"}';
         $authenticatorSelectionCriteria = AuthenticatorSelectionCriteria::create(
             AuthenticatorSelectionCriteria::AUTHENTICATOR_ATTACHMENT_PLATFORM,
             AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_REQUIRED,
@@ -80,6 +80,7 @@ final class AuthenticatorSelectionCriteriaTest extends AbstractTestCase
             $data->authenticatorAttachment
         );
         static::assertSame(AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_REQUIRED, $data->residentKey);
+        static::assertTrue($data->requireResidentKey);
         static::assertJsonStringEqualsJsonString($expectedJson, $this->getSerializer()->serialize($data, 'json', [
             AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
         ]));

--- a/tests/symfony/functional/Firewall/RegistrationAreaTest.php
+++ b/tests/symfony/functional/Firewall/RegistrationAreaTest.php
@@ -101,6 +101,7 @@ final class RegistrationAreaTest extends WebauthnTestCase
 
         static::assertArrayHasKey('authenticatorSelection', $data);
         static::assertSame([
+            'requireResidentKey' => true,
             'authenticatorAttachment' => 'cross-platform',
             'userVerification' => 'required',
             'residentKey' => 'required',
@@ -137,6 +138,7 @@ final class RegistrationAreaTest extends WebauthnTestCase
 
         static::assertArrayHasKey('authenticatorSelection', $data);
         static::assertSame([
+            'requireResidentKey' => true,
             'userVerification' => 'preferred',
             'residentKey' => 'required',
         ], $data['authenticatorSelection']);
@@ -181,6 +183,7 @@ final class RegistrationAreaTest extends WebauthnTestCase
 
         static::assertArrayHasKey('authenticatorSelection', $data);
         static::assertSame([
+            'requireResidentKey' => true,
             'authenticatorAttachment' => 'platform',
             'userVerification' => 'required',
             'residentKey' => 'required',


### PR DESCRIPTION
Target branch: 5.3.x
Resolves issue #757, #561

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
