### PR TITLE
Bug: set trust anchor with trusted certificates

### DIFF
--- a/src/webauthn/src/MetadataService/CertificateChain/PhpCertificateChainValidator.php
+++ b/src/webauthn/src/MetadataService/CertificateChain/PhpCertificateChainValidator.php
@@ -184,10 +184,12 @@ final class PhpCertificateChainValidator implements CertificateChainValidator, C
         return false;
     }
 
-    private function validateCertificates(Certificate ...$certificates): bool
+    private function validateCertificates(Certificate $trustAnchor, Certificate ...$certificates): bool
     {
         try {
-            $config = PathValidationConfig::create($this->clock->now(), self::MAX_VALIDATION_LENGTH);
+            $config = PathValidationConfig::create($this->clock->now(), self::MAX_VALIDATION_LENGTH)->withTrustAnchor(
+                $trustAnchor
+            );
             CertificationPath::create(...$certificates)->validate($config);
 
             return true;


### PR DESCRIPTION
Target branch: 5.x
Resolves issue #788 

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

### Overview

Set the trust anchor with the trusted certificates when validating the certificate path.

### Problems

The implementation passes the trusted certificate as the first certificate of the certificate path when validating.  https://github.com/web-auth/webauthn-framework/blob/eb2aa67091a8cb564ad67808ee8ffb89adf0e19a/src/webauthn/src/MetadataService/CertificateChain/PhpCertificateChainValidator.php#L190-L191 

This works well when the trusted certificate is self-signed because the self-signed certificate can be used to [verify itself](https://github.com/Spomky-Labs/pki-framework/blob/6687a532a92bd68ab3183dc228e02a5e3d3b67ac/src/X509/CertificationPath/PathValidation/PathValidator.php#L74-L83).

But it fails when the trusted certificate is an intermediate certificate(e.g., [trust anchor from FIDO MDS](https://github.com/web-auth/webauthn-framework/blob/eb2aa67091a8cb564ad67808ee8ffb89adf0e19a/src/webauthn/src/MetadataService/CertificateChain/PhpCertificateChainValidator.php#L190)). 
The intermediate CA can not verify itself, which can only be verified with its issuer.

For any CA of FIDO MDS, we can trust it even if it is an intermediate CA, and use it as the trust anchor directly to verify the [trust path of the attestation](https://www.w3.org/TR/webauthn-3/#reg-ceremony-assess-trust).

> List of attestation trust anchors for the batch chain in the authenticator attestation. Each element of this array represents a PKIX [[RFC5280]](https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.1.1-rd-20251016.html#biblio-rfc5280) X.509 certificate that is a valid trust anchor for this authenticator model. Multiple certificates might be used for different batches of the same model. The array does not represent a certificate chain, but only the trust anchor of that chain. A trust anchor can be a root certificate, an intermediate CA certificate or even the attestation certificate itself.
