### PR TITLE
fix: remove Composer cache from PHPStan job to ensure fresh dependencies

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -529,53 +529,6 @@ parameters:
 			path: ../src/symfony/src/DependencyInjection/Configuration.php
 
 		-
-			rawMessage: 'Method Webauthn\Bundle\DependencyInjection\Configuration::getConfigTreeBuilder() return type with generic class Symfony\Component\Config\Definition\Builder\TreeBuilder does not specify its types: T'
-			identifier: missingType.generics
-			count: 1
-			path: ../src/symfony/src/DependencyInjection/Configuration.php
-
-		-
-			rawMessage: 'PHPDoc tag `@var` for variable $rootNode contains generic class Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition but does not specify its types: TParent'
-			identifier: missingType.generics
-			path: ../src/symfony/src/DependencyInjection/Configuration.php
-
-		-
-			rawMessage: 'Method Webauthn\Bundle\DependencyInjection\Configuration::addCreationProfilesConfig() has parameter $rootNode with generic class Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition but does not specify its types: TParent'
-			identifier: missingType.generics
-			count: 1
-			path: ../src/symfony/src/DependencyInjection/Configuration.php
-
-		-
-			rawMessage: 'Method Webauthn\Bundle\DependencyInjection\Configuration::addRequestProfilesConfig() has parameter $rootNode with generic class Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition but does not specify its types: TParent'
-			identifier: missingType.generics
-			count: 1
-			path: ../src/symfony/src/DependencyInjection/Configuration.php
-
-		-
-			rawMessage: 'Method Webauthn\Bundle\DependencyInjection\Configuration::addControllersConfig() has parameter $rootNode with generic class Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition but does not specify its types: TParent'
-			identifier: missingType.generics
-			count: 1
-			path: ../src/symfony/src/DependencyInjection/Configuration.php
-
-		-
-			rawMessage: 'Method Webauthn\Bundle\DependencyInjection\Configuration::addMetadataConfig() has parameter $rootNode with generic class Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition but does not specify its types: TParent'
-			identifier: missingType.generics
-			count: 1
-			path: ../src/symfony/src/DependencyInjection/Configuration.php
-
-		-
-			rawMessage: 'Method Webauthn\Bundle\DependencyInjection\Configuration::addPasskeyEndpointsConfig() has parameter $rootNode with generic class Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition but does not specify its types: TParent'
-			identifier: missingType.generics
-			count: 1
-			path: ../src/symfony/src/DependencyInjection/Configuration.php
-
-		-
-			rawMessage: 'Method Webauthn\Bundle\DependencyInjection\Configuration::getUrlNode() return type with generic class Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition does not specify its types: TParent'
-			identifier: missingType.generics
-			count: 1
-			path: ../src/symfony/src/DependencyInjection/Configuration.php
-
-		-
 			rawMessage: '''
 				Access to constant on deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface:
 				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,18 +65,16 @@ jobs:
 
   phpstan:
     name: "1️⃣ Static Analysis (PHPStan)"
-    needs: [prepare_dependencies]
+    needs: [pre_checks]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/spomky-labs/phpqa:8.4
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/cache@v4
+      - uses: ramsey/composer-install@v3
         with:
-          path: |
-            vendor
-            ~/.composer/cache
-          key: ${{ needs.prepare_dependencies.outputs.cache-key }}
+          dependency-versions: highest
+          composer-options: --optimize-autoloader
       - run: castor phpstan
 
   ecs:


### PR DESCRIPTION
## Problem

The CI workflow's PHPStan job was using a Composer cache with `restore-keys` that could restore outdated dependencies from any previous build. Since `composer.lock` is not versioned in this repository, the cache key fell back to `composer-Linux-`, allowing very old dependency versions to be reused.

This caused PHPStan to detect errors for missing generic type annotations in Symfony Config classes, even though recent versions (8.0+) include these annotations.

## Solution

- Remove Composer cache from the PHPStan job
- PHPStan now installs fresh dependencies using `dependency-versions: highest` on each run
- Remove obsolete PHPStan baseline entries for Configuration generic types (no longer needed with Symfony 8.0+)

## Benefits

- Ensures consistent PHPStan results between local and CI environments  
- Always uses the latest dependency versions for static analysis
- Fixes failing PHPStan checks on 5.3.x branch

## Testing

The baseline cleanup was validated by running `castor phpstan` locally with Symfony Config 8.0.1, which no longer reports these generic type errors.

---

Fixes the PHPStan failures on branches like #787 and the current 5.3.x baseline.