### PR TITLE
refactor: make PublicKeyCredentialSource extend CredentialRecord

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -50,15 +50,6 @@ parameters:
 
 		-
 			rawMessage: '''
-				Call to method findOneByCredentialId() of deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
-			'''
-			identifier: method.deprecatedInterface
-			count: 1
-			path: ../src/symfony/src/Controller/AssertionResponseController.php
-
-		-
-			rawMessage: '''
 				Parameter $publicKeyCredentialSourceRepository of method Webauthn\Bundle\Controller\AssertionResponseController::__construct() has typehint with deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface:
 				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
 			'''
@@ -131,24 +122,6 @@ parameters:
 
 		-
 			rawMessage: '''
-				Call to method findOneByCredentialId() of deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
-			'''
-			identifier: method.deprecatedInterface
-			count: 1
-			path: ../src/symfony/src/Controller/AttestationResponseController.php
-
-		-
-			rawMessage: '''
-				Call to method saveCredentialSource() of deprecated interface Webauthn\Bundle\Repository\CanSaveCredentialSource:
-				since 5.3, use CanSaveCredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: method.deprecatedInterface
-			count: 1
-			path: ../src/symfony/src/Controller/AttestationResponseController.php
-
-		-
-			rawMessage: '''
 				Instanceof references deprecated interface Webauthn\Bundle\Repository\CanSaveCredentialSource:
 				since 5.3, use CanSaveCredentialRecord instead. Will be removed in 6.0.
 			'''
@@ -176,33 +149,6 @@ parameters:
 
 		-
 			rawMessage: '''
-				Call to method findAllForUserEntity() of deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
-			'''
-			identifier: method.deprecatedInterface
-			count: 1
-			path: ../src/symfony/src/CredentialOptionsBuilder/ProfileBasedCreationOptionsBuilder.php
-
-		-
-			rawMessage: '''
-				Call to method getPublicKeyCredentialDescriptor() of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: method.deprecatedClass
-			count: 1
-			path: ../src/symfony/src/CredentialOptionsBuilder/ProfileBasedCreationOptionsBuilder.php
-
-		-
-			rawMessage: '''
-				Parameter $credential of anonymous function has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/symfony/src/CredentialOptionsBuilder/ProfileBasedCreationOptionsBuilder.php
-
-		-
-			rawMessage: '''
 				Parameter $credentialSourceRepository of method Webauthn\Bundle\CredentialOptionsBuilder\ProfileBasedCreationOptionsBuilder::__construct() has typehint with deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface:
 				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
 			'''
@@ -218,24 +164,6 @@ parameters:
 			identifier: property.deprecatedInterface
 			count: 1
 			path: ../src/symfony/src/CredentialOptionsBuilder/ProfileBasedCreationOptionsBuilder.php
-
-		-
-			rawMessage: '''
-				Call to method findAllForUserEntity() of deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
-			'''
-			identifier: method.deprecatedInterface
-			count: 1
-			path: ../src/symfony/src/CredentialOptionsBuilder/ProfileBasedRequestOptionsBuilder.php
-
-		-
-			rawMessage: '''
-				Call to method getPublicKeyCredentialDescriptor() of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: method.deprecatedClass
-			count: 1
-			path: ../src/symfony/src/CredentialOptionsBuilder/ProfileBasedRequestOptionsBuilder.php
 
 		-
 			rawMessage: Constructor in Webauthn\Bundle\CredentialOptionsBuilder\ProfileBasedRequestOptionsBuilder has parameter $fakeCredentialGenerator with default value.
@@ -281,15 +209,6 @@ parameters:
 
 		-
 			rawMessage: '''
-				Parameter $credential of anonymous function has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/symfony/src/CredentialOptionsBuilder/ProfileBasedRequestOptionsBuilder.php
-
-		-
-			rawMessage: '''
 				Parameter $credentialSourceRepository of method Webauthn\Bundle\CredentialOptionsBuilder\ProfileBasedRequestOptionsBuilder::__construct() has typehint with deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface:
 				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
 			'''
@@ -323,15 +242,6 @@ parameters:
 			identifier: ergebnis.noParameterWithNullDefaultValue
 			count: 1
 			path: ../src/symfony/src/CredentialOptionsBuilder/PublicKeyCredentialRequestOptionsBuilder.php
-
-		-
-			rawMessage: '''
-				Access to property $publicKeyCredentialId of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 2
-			path: ../src/symfony/src/DataCollector/WebauthnCollector.php
 
 		-
 			rawMessage: Class "Webauthn\Bundle\DataCollector\WebauthnCollector" is not allowed to extend "Symfony\Component\HttpKernel\DataCollector\DataCollector".
@@ -589,12 +499,6 @@ parameters:
 			rawMessage: Cannot access offset 'routes' on mixed.
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 14
-			path: ../src/symfony/src/DependencyInjection/Factory/Security/WebauthnFactory.php
-
-		-
-			rawMessage: 'Method Webauthn\Bundle\DependencyInjection\Factory\Security\WebauthnFactory::addConfiguration() has parameter $builder with generic class Symfony\Component\Config\Definition\Builder\NodeDefinition but does not specify its types: TParent'
-			identifier: missingType.generics
-			count: 1
 			path: ../src/symfony/src/DependencyInjection/Factory/Security/WebauthnFactory.php
 
 		-
@@ -1417,35 +1321,8 @@ parameters:
 			path: ../src/symfony/src/Repository/CanGenerateUserEntity.php
 
 		-
-			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\Bundle\Repository\CanSaveCredentialRecord::saveCredentialSource() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/symfony/src/Repository/CanSaveCredentialRecord.php
-
-		-
 			rawMessage: 'Method Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface::findOneByCredentialId() has a nullable return type declaration.'
 			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: ../src/symfony/src/Repository/CredentialRecordRepositoryInterface.php
-
-		-
-			rawMessage: '''
-				Return type of method Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface::findAllForUserEntity() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: return.deprecatedClass
-			count: 1
-			path: ../src/symfony/src/Repository/CredentialRecordRepositoryInterface.php
-
-		-
-			rawMessage: '''
-				Return type of method Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface::findOneByCredentialId() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: return.deprecatedClass
 			count: 1
 			path: ../src/symfony/src/Repository/CredentialRecordRepositoryInterface.php
 
@@ -1462,7 +1339,7 @@ parameters:
 			path: ../src/symfony/src/Repository/DoctrineCredentialSourceRepository.php
 
 		-
-			rawMessage: 'Method Webauthn\Bundle\Repository\DoctrineCredentialSourceRepository::findAllForUserEntity() should return array<Webauthn\CredentialRecord|Webauthn\PublicKeyCredentialSource> but returns mixed.'
+			rawMessage: 'Method Webauthn\Bundle\Repository\DoctrineCredentialSourceRepository::findAllForUserEntity() should return array<Webauthn\CredentialRecord> but returns mixed.'
 			identifier: return.type
 			count: 1
 			path: ../src/symfony/src/Repository/DoctrineCredentialSourceRepository.php
@@ -1474,7 +1351,7 @@ parameters:
 			path: ../src/symfony/src/Repository/DoctrineCredentialSourceRepository.php
 
 		-
-			rawMessage: 'Method Webauthn\Bundle\Repository\DoctrineCredentialSourceRepository::findOneByCredentialId() should return Webauthn\CredentialRecord|Webauthn\PublicKeyCredentialSource|null but returns mixed.'
+			rawMessage: 'Method Webauthn\Bundle\Repository\DoctrineCredentialSourceRepository::findOneByCredentialId() should return Webauthn\CredentialRecord|null but returns mixed.'
 			identifier: return.type
 			count: 1
 			path: ../src/symfony/src/Repository/DoctrineCredentialSourceRepository.php
@@ -1494,24 +1371,6 @@ parameters:
 		-
 			rawMessage: 'Method Webauthn\Bundle\Repository\DummyCredentialRecordRepository::findOneByCredentialId() has a nullable return type declaration.'
 			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: ../src/symfony/src/Repository/DummyCredentialRecordRepository.php
-
-		-
-			rawMessage: '''
-				Return type of method Webauthn\Bundle\Repository\DummyCredentialRecordRepository::findAllForUserEntity() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: return.deprecatedClass
-			count: 1
-			path: ../src/symfony/src/Repository/DummyCredentialRecordRepository.php
-
-		-
-			rawMessage: '''
-				Return type of method Webauthn\Bundle\Repository\DummyCredentialRecordRepository::findOneByCredentialId() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: return.deprecatedClass
 			count: 1
 			path: ../src/symfony/src/Repository/DummyCredentialRecordRepository.php
 
@@ -1543,24 +1402,6 @@ parameters:
 			path: ../src/symfony/src/Repository/DummyPublicKeyCredentialSourceRepository.php
 
 		-
-			rawMessage: '''
-				Return type of method Webauthn\Bundle\Repository\DummyPublicKeyCredentialSourceRepository::findAllForUserEntity() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: return.deprecatedClass
-			count: 1
-			path: ../src/symfony/src/Repository/DummyPublicKeyCredentialSourceRepository.php
-
-		-
-			rawMessage: '''
-				Return type of method Webauthn\Bundle\Repository\DummyPublicKeyCredentialSourceRepository::findOneByCredentialId() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: return.deprecatedClass
-			count: 1
-			path: ../src/symfony/src/Repository/DummyPublicKeyCredentialSourceRepository.php
-
-		-
 			rawMessage: Class Webauthn\Bundle\Repository\DummyPublicKeyCredentialUserEntityRepository is neither abstract nor final.
 			identifier: ergebnis.final
 			count: 1
@@ -1583,12 +1424,6 @@ parameters:
 			identifier: ergebnis.noNullableReturnTypeDeclaration
 			count: 1
 			path: ../src/symfony/src/Repository/DummyPublicKeyCredentialUserEntityRepository.php
-
-		-
-			rawMessage: 'Method Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface::findOneByCredentialId() has a nullable return type declaration.'
-			identifier: ergebnis.noNullableReturnTypeDeclaration
-			count: 1
-			path: ../src/symfony/src/Repository/PublicKeyCredentialSourceRepositoryInterface.php
 
 		-
 			rawMessage: 'Method Webauthn\Bundle\Repository\PublicKeyCredentialUserEntityRepositoryInterface::findOneByUserHandle() has a nullable return type declaration.'
@@ -1786,15 +1621,6 @@ parameters:
 			path: ../src/symfony/src/Security/Authentication/WebauthnAuthenticator.php
 
 		-
-			rawMessage: '''
-				Call to method getPublicKeyCredentialDescriptor() of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: method.deprecatedClass
-			count: 1
-			path: ../src/symfony/src/Security/Authentication/WebauthnAuthenticator.php
-
-		-
 			rawMessage: Cannot access property $authData on mixed.
 			identifier: property.nonObject
 			count: 1
@@ -1918,15 +1744,6 @@ parameters:
 			path: ../src/symfony/src/Security/Authentication/WebauthnBadge.php
 
 		-
-			rawMessage: '''
-				Access to property $userHandle of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/symfony/src/Security/Authentication/WebauthnBadge.php
-
-		-
 			rawMessage: Class "Webauthn\Bundle\Security\Authentication\WebauthnBadge" is not allowed to extend "Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge".
 			identifier: ergebnis.noExtends
 			count: 1
@@ -2017,35 +1834,8 @@ parameters:
 			path: ../src/symfony/src/Security/Authentication/WebauthnBadge.php
 
 		-
-			rawMessage: '''
-				Parameter $publicKeyCredentialSource of method Webauthn\Bundle\Security\Authentication\WebauthnBadge::markResolved() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/symfony/src/Security/Authentication/WebauthnBadge.php
-
-		-
-			rawMessage: '''
-				Property $publicKeyCredentialSource references deprecated class Webauthn\PublicKeyCredentialSource in its type:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/symfony/src/Security/Authentication/WebauthnBadge.php
-
-		-
 			rawMessage: 'Property Webauthn\Bundle\Security\Authentication\WebauthnBadge::$user (Symfony\Component\Security\Core\User\UserInterface) does not accept mixed.'
 			identifier: assign.propertyType
-			count: 1
-			path: ../src/symfony/src/Security/Authentication/WebauthnBadge.php
-
-		-
-			rawMessage: '''
-				Return type of method Webauthn\Bundle\Security\Authentication\WebauthnBadge::getPublicKeyCredentialSource() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: return.deprecatedClass
 			count: 1
 			path: ../src/symfony/src/Security/Authentication/WebauthnBadge.php
 
@@ -2062,33 +1852,6 @@ parameters:
 			'''
 			identifier: property.deprecated
 			count: 1
-			path: ../src/symfony/src/Security/Authentication/WebauthnBadgeListener.php
-
-		-
-			rawMessage: '''
-				Access to property $userHandle of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/symfony/src/Security/Authentication/WebauthnBadgeListener.php
-
-		-
-			rawMessage: '''
-				Call to method findOneByCredentialId() of deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
-			'''
-			identifier: method.deprecatedInterface
-			count: 2
-			path: ../src/symfony/src/Security/Authentication/WebauthnBadgeListener.php
-
-		-
-			rawMessage: '''
-				Call to method saveCredentialSource() of deprecated interface Webauthn\Bundle\Repository\CanSaveCredentialSource:
-				since 5.3, use CanSaveCredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: method.deprecatedInterface
-			count: 2
 			path: ../src/symfony/src/Security/Authentication/WebauthnBadgeListener.php
 
 		-
@@ -2354,74 +2117,11 @@ parameters:
 
 		-
 			rawMessage: '''
-				Parameter $publicKeyCredentialSource of method Webauthn\Bundle\Security\Http\Authenticator\Passport\Credentials\WebauthnCredentials::__construct() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/symfony/src/Security/Http/Authenticator/Passport/Credentials/WebauthnCredentials.php
-
-		-
-			rawMessage: '''
-				Property $publicKeyCredentialSource references deprecated class Webauthn\PublicKeyCredentialSource in its type:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/symfony/src/Security/Http/Authenticator/Passport/Credentials/WebauthnCredentials.php
-
-		-
-			rawMessage: '''
-				Return type of method Webauthn\Bundle\Security\Http\Authenticator\Passport\Credentials\WebauthnCredentials::getPublicKeyCredentialSource() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: return.deprecatedClass
-			count: 1
-			path: ../src/symfony/src/Security/Http/Authenticator/Passport/Credentials/WebauthnCredentials.php
-
-		-
-			rawMessage: '''
 				Access to deprecated property $name of class Webauthn\PublicKeyCredentialEntity:
 				since 5.3.0 and will be removed in 6.0.0. Please set "" and use PublicKeyCredentialUserEntity.name instead.
 			'''
 			identifier: property.deprecated
 			count: 3
-			path: ../src/symfony/src/Security/Http/Authenticator/WebauthnAuthenticator.php
-
-		-
-			rawMessage: '''
-				Access to property $userHandle of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/symfony/src/Security/Http/Authenticator/WebauthnAuthenticator.php
-
-		-
-			rawMessage: '''
-				Call to method findOneByCredentialId() of deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
-			'''
-			identifier: method.deprecatedInterface
-			count: 2
-			path: ../src/symfony/src/Security/Http/Authenticator/WebauthnAuthenticator.php
-
-		-
-			rawMessage: '''
-				Call to method getPublicKeyCredentialDescriptor() of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: method.deprecatedClass
-			count: 1
-			path: ../src/symfony/src/Security/Http/Authenticator/WebauthnAuthenticator.php
-
-		-
-			rawMessage: '''
-				Call to method saveCredentialSource() of deprecated interface Webauthn\Bundle\Repository\CanSaveCredentialSource:
-				since 5.3, use CanSaveCredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: method.deprecatedInterface
-			count: 2
 			path: ../src/symfony/src/Security/Http/Authenticator/WebauthnAuthenticator.php
 
 		-
@@ -3790,42 +3490,6 @@ parameters:
 			path: ../src/webauthn/src/AuthenticatorAssertionResponse.php
 
 		-
-			rawMessage: '''
-				Access to property $backupEligible of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 4
-			path: ../src/webauthn/src/AuthenticatorAssertionResponseValidator.php
-
-		-
-			rawMessage: '''
-				Access to property $backupStatus of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 4
-			path: ../src/webauthn/src/AuthenticatorAssertionResponseValidator.php
-
-		-
-			rawMessage: '''
-				Access to property $counter of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/AuthenticatorAssertionResponseValidator.php
-
-		-
-			rawMessage: '''
-				Access to property $uvInitialized of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 2
-			path: ../src/webauthn/src/AuthenticatorAssertionResponseValidator.php
-
-		-
 			rawMessage: Class Webauthn\AuthenticatorAssertionResponseValidator is neither abstract nor final.
 			identifier: ergebnis.final
 			count: 1
@@ -3855,42 +3519,6 @@ parameters:
 		-
 			rawMessage: 'Method Webauthn\AuthenticatorAssertionResponseValidator::createAuthenticatorAssertionResponseValidationSucceededEvent() has parameter $userHandle with a nullable type declaration.'
 			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/webauthn/src/AuthenticatorAssertionResponseValidator.php
-
-		-
-			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\AuthenticatorAssertionResponseValidator::check() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/AuthenticatorAssertionResponseValidator.php
-
-		-
-			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\AuthenticatorAssertionResponseValidator::createAuthenticatorAssertionResponseValidationFailedEvent() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/AuthenticatorAssertionResponseValidator.php
-
-		-
-			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\AuthenticatorAssertionResponseValidator::createAuthenticatorAssertionResponseValidationSucceededEvent() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/AuthenticatorAssertionResponseValidator.php
-
-		-
-			rawMessage: '''
-				Return type of method Webauthn\AuthenticatorAssertionResponseValidator::check() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: return.deprecatedClass
 			count: 1
 			path: ../src/webauthn/src/AuthenticatorAssertionResponseValidator.php
 
@@ -4064,15 +3692,6 @@ parameters:
 
 		-
 			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\CeremonyStep\CeremonyStep::process() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CeremonyStep.php
-
-		-
-			rawMessage: '''
 				Instanceof references deprecated class Webauthn\PublicKeyCredentialSource:
 				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
 			'''
@@ -4083,15 +3702,6 @@ parameters:
 		-
 			rawMessage: 'Method Webauthn\CeremonyStep\CeremonyStepManager::process() has parameter $userHandle with a nullable type declaration.'
 			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CeremonyStepManager.php
-
-		-
-			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\CeremonyStep\CeremonyStepManager::process() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
 			count: 1
 			path: ../src/webauthn/src/CeremonyStep/CeremonyStepManager.php
 
@@ -4112,15 +3722,6 @@ parameters:
 			identifier: new.deprecatedClass
 			count: 2
 			path: ../src/webauthn/src/CeremonyStep/CeremonyStepManagerFactory.php
-
-		-
-			rawMessage: '''
-				Call to method getAttestedCredentialData() of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: method.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckAlgorithm.php
 
 		-
 			rawMessage: Class Webauthn\CeremonyStep\CheckAlgorithm is neither abstract nor final.
@@ -4145,24 +3746,6 @@ parameters:
 
 		-
 			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\CeremonyStep\CheckAlgorithm::process() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckAlgorithm.php
-
-		-
-			rawMessage: '''
-				Access to property $publicKeyCredentialId of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckAllowedCredentialList.php
-
-		-
-			rawMessage: '''
 				Instanceof references deprecated class Webauthn\PublicKeyCredentialSource:
 				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
 			'''
@@ -4173,15 +3756,6 @@ parameters:
 		-
 			rawMessage: 'Method Webauthn\CeremonyStep\CheckAllowedCredentialList::process() has parameter $userHandle with a nullable type declaration.'
 			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckAllowedCredentialList.php
-
-		-
-			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\CeremonyStep\CheckAllowedCredentialList::process() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
 			count: 1
 			path: ../src/webauthn/src/CeremonyStep/CheckAllowedCredentialList.php
 
@@ -4214,15 +3788,6 @@ parameters:
 
 		-
 			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\CeremonyStep\CheckAllowedOrigins::process() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckAllowedOrigins.php
-
-		-
-			rawMessage: '''
 				Instanceof references deprecated class Webauthn\PublicKeyCredentialSource:
 				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
 			'''
@@ -4233,15 +3798,6 @@ parameters:
 		-
 			rawMessage: 'Method Webauthn\CeremonyStep\CheckAttestationFormatIsKnownAndValid::process() has parameter $userHandle with a nullable type declaration.'
 			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckAttestationFormatIsKnownAndValid.php
-
-		-
-			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\CeremonyStep\CheckAttestationFormatIsKnownAndValid::process() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
 			count: 1
 			path: ../src/webauthn/src/CeremonyStep/CheckAttestationFormatIsKnownAndValid.php
 
@@ -4262,15 +3818,6 @@ parameters:
 
 		-
 			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\CeremonyStep\CheckBackupBitsAreConsistent::process() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckBackupBitsAreConsistent.php
-
-		-
-			rawMessage: '''
 				Instanceof references deprecated class Webauthn\PublicKeyCredentialSource:
 				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
 			'''
@@ -4281,15 +3828,6 @@ parameters:
 		-
 			rawMessage: 'Method Webauthn\CeremonyStep\CheckChallenge::process() has parameter $userHandle with a nullable type declaration.'
 			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckChallenge.php
-
-		-
-			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\CeremonyStep\CheckChallenge::process() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
 			count: 1
 			path: ../src/webauthn/src/CeremonyStep/CheckChallenge.php
 
@@ -4328,24 +3866,6 @@ parameters:
 
 		-
 			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\CeremonyStep\CheckClientDataCollectorType::process() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckClientDataCollectorType.php
-
-		-
-			rawMessage: '''
-				Access to property $counter of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 2
-			path: ../src/webauthn/src/CeremonyStep/CheckCounter.php
-
-		-
-			rawMessage: '''
 				Instanceof references deprecated class Webauthn\PublicKeyCredentialSource:
 				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
 			'''
@@ -4358,24 +3878,6 @@ parameters:
 			identifier: ergebnis.noParameterWithNullableTypeDeclaration
 			count: 1
 			path: ../src/webauthn/src/CeremonyStep/CheckCounter.php
-
-		-
-			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\CeremonyStep\CheckCounter::process() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckCounter.php
-
-		-
-			rawMessage: '''
-				Access to property $publicKeyCredentialId of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckCredentialId.php
 
 		-
 			rawMessage: Class Webauthn\CeremonyStep\CheckCredentialId is neither abstract nor final.
@@ -4400,15 +3902,6 @@ parameters:
 
 		-
 			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\CeremonyStep\CheckCredentialId::process() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckCredentialId.php
-
-		-
-			rawMessage: '''
 				Instanceof references deprecated class Webauthn\PublicKeyCredentialSource:
 				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
 			'''
@@ -4419,15 +3912,6 @@ parameters:
 		-
 			rawMessage: 'Method Webauthn\CeremonyStep\CheckExtensions::process() has parameter $userHandle with a nullable type declaration.'
 			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckExtensions.php
-
-		-
-			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\CeremonyStep\CheckExtensions::process() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
 			count: 1
 			path: ../src/webauthn/src/CeremonyStep/CheckExtensions.php
 
@@ -4448,15 +3932,6 @@ parameters:
 
 		-
 			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\CeremonyStep\CheckHasAttestedCredentialData::process() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckHasAttestedCredentialData.php
-
-		-
-			rawMessage: '''
 				Instanceof references deprecated class Webauthn\PublicKeyCredentialSource:
 				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
 			'''
@@ -4471,15 +3946,6 @@ parameters:
 			path: ../src/webauthn/src/CeremonyStep/CheckMetadataStatement.php
 
 		-
-			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\CeremonyStep\CheckMetadataStatement::process() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckMetadataStatement.php
-
-		-
 			rawMessage: 'Method Webauthn\CeremonyStep\CheckOrigin::getFacetId() has parameter $authenticationExtensionsClientOutputs with a nullable type declaration.'
 			identifier: ergebnis.noParameterWithNullableTypeDeclaration
 			count: 1
@@ -4490,15 +3956,6 @@ parameters:
 			identifier: ergebnis.noParameterWithNullableTypeDeclaration
 			count: 1
 			path: ../src/webauthn/src/CeremonyStep/CheckOrigin.php
-
-		-
-			rawMessage: '''
-				Call to method getAttestedCredentialData() of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: method.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckRelyingPartyIdIdHash.php
 
 		-
 			rawMessage: '''
@@ -4520,24 +3977,6 @@ parameters:
 			identifier: ergebnis.noParameterWithNullableTypeDeclaration
 			count: 1
 			path: ../src/webauthn/src/CeremonyStep/CheckRelyingPartyIdIdHash.php
-
-		-
-			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\CeremonyStep\CheckRelyingPartyIdIdHash::process() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckRelyingPartyIdIdHash.php
-
-		-
-			rawMessage: '''
-				Call to method getAttestedCredentialData() of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: method.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckSignature.php
 
 		-
 			rawMessage: Constructor in Webauthn\CeremonyStep\CheckSignature has parameter $algorithmManager with default value.
@@ -4569,15 +4008,6 @@ parameters:
 		-
 			rawMessage: 'Method Webauthn\CeremonyStep\CheckSignature::process() has parameter $userHandle with a nullable type declaration.'
 			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckSignature.php
-
-		-
-			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\CeremonyStep\CheckSignature::process() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
 			count: 1
 			path: ../src/webauthn/src/CeremonyStep/CheckSignature.php
 
@@ -4622,24 +4052,6 @@ parameters:
 
 		-
 			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\CeremonyStep\CheckTopOrigin::process() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckTopOrigin.php
-
-		-
-			rawMessage: '''
-				Access to property $userHandle of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckUserHandle.php
-
-		-
-			rawMessage: '''
 				Instanceof references deprecated class Webauthn\PublicKeyCredentialSource:
 				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
 			'''
@@ -4655,15 +4067,6 @@ parameters:
 
 		-
 			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\CeremonyStep\CheckUserHandle::process() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckUserHandle.php
-
-		-
-			rawMessage: '''
 				Instanceof references deprecated class Webauthn\PublicKeyCredentialSource:
 				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
 			'''
@@ -4674,15 +4077,6 @@ parameters:
 		-
 			rawMessage: 'Method Webauthn\CeremonyStep\CheckUserVerification::process() has parameter $userHandle with a nullable type declaration.'
 			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckUserVerification.php
-
-		-
-			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\CeremonyStep\CheckUserVerification::process() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
 			count: 1
 			path: ../src/webauthn/src/CeremonyStep/CheckUserVerification.php
 
@@ -4704,15 +4098,6 @@ parameters:
 		-
 			rawMessage: 'Method Webauthn\CeremonyStep\CheckUserWasPresent::process() has parameter $userHandle with a nullable type declaration.'
 			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/webauthn/src/CeremonyStep/CheckUserWasPresent.php
-
-		-
-			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\CeremonyStep\CheckUserWasPresent::process() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
 			count: 1
 			path: ../src/webauthn/src/CeremonyStep/CheckUserWasPresent.php
 
@@ -4741,24 +4126,6 @@ parameters:
 			path: ../src/webauthn/src/CollectedClientData.php
 
 		-
-			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\Counter\CounterChecker::check() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Counter/CounterChecker.php
-
-		-
-			rawMessage: '''
-				Access to property $counter of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 3
-			path: ../src/webauthn/src/Counter/ThrowExceptionIfInvalid.php
-
-		-
 			rawMessage: Constructor in Webauthn\Counter\ThrowExceptionIfInvalid has parameter $logger with default value.
 			identifier: ergebnis.noConstructorParameterWithDefaultValue
 			count: 1
@@ -4770,15 +4137,6 @@ parameters:
 				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
 			'''
 			identifier: instanceof.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Counter/ThrowExceptionIfInvalid.php
-
-		-
-			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\Counter\ThrowExceptionIfInvalid::check() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
 			count: 1
 			path: ../src/webauthn/src/Counter/ThrowExceptionIfInvalid.php
 
@@ -6047,124 +5405,7 @@ parameters:
 
 		-
 			rawMessage: '''
-				Access to property $aaguid of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
-
-		-
-			rawMessage: '''
-				Access to property $attestationType of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
-
-		-
-			rawMessage: '''
-				Access to property $backupEligible of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
-
-		-
-			rawMessage: '''
-				Access to property $backupStatus of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
-
-		-
-			rawMessage: '''
-				Access to property $counter of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
-
-		-
-			rawMessage: '''
-				Access to property $credentialPublicKey of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
-
-		-
-			rawMessage: '''
-				Access to property $otherUI of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
-
-		-
-			rawMessage: '''
-				Access to property $publicKeyCredentialId of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
-
-		-
-			rawMessage: '''
-				Access to property $transports of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
-
-		-
-			rawMessage: '''
-				Access to property $trustPath of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
-
-		-
-			rawMessage: '''
-				Access to property $type of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
-
-		-
-			rawMessage: '''
-				Access to property $userHandle of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
-
-		-
-			rawMessage: '''
-				Access to property $uvInitialized of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
-
-		-
-			rawMessage: '''
-				Call to method create() of deprecated class Webauthn\PublicKeyCredentialSource:
+				Call to static method create() on deprecated class Webauthn\PublicKeyCredentialSource:
 				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
 			'''
 			identifier: staticMethod.deprecatedClass
@@ -6319,7 +5560,7 @@ parameters:
 			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
 
 		-
-			rawMessage: 'Parameter #1 $publicKeyCredentialId of static method Webauthn\PublicKeyCredentialSource::create() expects string, mixed given.'
+			rawMessage: 'Parameter #1 $publicKeyCredentialId of static method Webauthn\CredentialRecord::create() expects string, mixed given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
@@ -6331,25 +5572,25 @@ parameters:
 			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
 
 		-
-			rawMessage: 'Parameter #10 $otherUI of static method Webauthn\PublicKeyCredentialSource::create() expects array<string, mixed>|null, mixed given.'
+			rawMessage: 'Parameter #10 $otherUI of static method Webauthn\CredentialRecord::create() expects array<string, mixed>|null, mixed given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
 
 		-
-			rawMessage: 'Parameter #11 $backupEligible of static method Webauthn\PublicKeyCredentialSource::create() expects bool|null, mixed given.'
+			rawMessage: 'Parameter #11 $backupEligible of static method Webauthn\CredentialRecord::create() expects bool|null, mixed given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
 
 		-
-			rawMessage: 'Parameter #12 $backupStatus of static method Webauthn\PublicKeyCredentialSource::create() expects bool|null, mixed given.'
+			rawMessage: 'Parameter #12 $backupStatus of static method Webauthn\CredentialRecord::create() expects bool|null, mixed given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
 
 		-
-			rawMessage: 'Parameter #13 $uvInitialized of static method Webauthn\PublicKeyCredentialSource::create() expects bool|null, mixed given.'
+			rawMessage: 'Parameter #13 $uvInitialized of static method Webauthn\CredentialRecord::create() expects bool|null, mixed given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
@@ -6361,37 +5602,37 @@ parameters:
 			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
 
 		-
-			rawMessage: 'Parameter #2 $type of static method Webauthn\PublicKeyCredentialSource::create() expects string, mixed given.'
+			rawMessage: 'Parameter #2 $type of static method Webauthn\CredentialRecord::create() expects string, mixed given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
 
 		-
-			rawMessage: 'Parameter #3 $transports of static method Webauthn\PublicKeyCredentialSource::create() expects array<string>, mixed given.'
+			rawMessage: 'Parameter #3 $transports of static method Webauthn\CredentialRecord::create() expects array<string>, mixed given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
 
 		-
-			rawMessage: 'Parameter #4 $attestationType of static method Webauthn\PublicKeyCredentialSource::create() expects string, mixed given.'
+			rawMessage: 'Parameter #4 $attestationType of static method Webauthn\CredentialRecord::create() expects string, mixed given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
 
 		-
-			rawMessage: 'Parameter #7 $credentialPublicKey of static method Webauthn\PublicKeyCredentialSource::create() expects string, mixed given.'
+			rawMessage: 'Parameter #7 $credentialPublicKey of static method Webauthn\CredentialRecord::create() expects string, mixed given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
 
 		-
-			rawMessage: 'Parameter #8 $userHandle of static method Webauthn\PublicKeyCredentialSource::create() expects string, mixed given.'
+			rawMessage: 'Parameter #8 $userHandle of static method Webauthn\CredentialRecord::create() expects string, mixed given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
 
 		-
-			rawMessage: 'Parameter #9 $counter of static method Webauthn\PublicKeyCredentialSource::create() expects int, mixed given.'
+			rawMessage: 'Parameter #9 $counter of static method Webauthn\CredentialRecord::create() expects int, mixed given.'
 			identifier: argument.type
 			count: 1
 			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
@@ -6832,24 +6073,6 @@ parameters:
 			path: ../src/webauthn/src/Event/AuthenticatorAssertionResponseValidationFailedEvent.php
 
 		-
-			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\Event\AuthenticatorAssertionResponseValidationFailedEvent::__construct() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Event/AuthenticatorAssertionResponseValidationFailedEvent.php
-
-		-
-			rawMessage: '''
-				Property $credentialRecord references deprecated class Webauthn\PublicKeyCredentialSource in its type:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Event/AuthenticatorAssertionResponseValidationFailedEvent.php
-
-		-
 			rawMessage: Class Webauthn\Event\AuthenticatorAssertionResponseValidationSucceededEvent is neither abstract nor final.
 			identifier: ergebnis.final
 			count: 1
@@ -6858,24 +6081,6 @@ parameters:
 		-
 			rawMessage: 'Method Webauthn\Event\AuthenticatorAssertionResponseValidationSucceededEvent::__construct() has parameter $userHandle with a nullable type declaration.'
 			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/webauthn/src/Event/AuthenticatorAssertionResponseValidationSucceededEvent.php
-
-		-
-			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\Event\AuthenticatorAssertionResponseValidationSucceededEvent::__construct() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Event/AuthenticatorAssertionResponseValidationSucceededEvent.php
-
-		-
-			rawMessage: '''
-				Property $credentialRecord references deprecated class Webauthn\PublicKeyCredentialSource in its type:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
 			count: 1
 			path: ../src/webauthn/src/Event/AuthenticatorAssertionResponseValidationSucceededEvent.php
 
@@ -6892,24 +6097,6 @@ parameters:
 			path: ../src/webauthn/src/Event/AuthenticatorAttestationResponseValidationSucceededEvent.php
 
 		-
-			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\Event\AuthenticatorAttestationResponseValidationSucceededEvent::__construct() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Event/AuthenticatorAttestationResponseValidationSucceededEvent.php
-
-		-
-			rawMessage: '''
-				Property $credentialRecord references deprecated class Webauthn\PublicKeyCredentialSource in its type:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Event/AuthenticatorAttestationResponseValidationSucceededEvent.php
-
-		-
 			rawMessage: 'Method Webauthn\Event\BackupEligibilityChangedEvent::__construct() has parameter $newValue with a nullable type declaration.'
 			identifier: ergebnis.noParameterWithNullableTypeDeclaration
 			count: 1
@@ -6922,24 +6109,6 @@ parameters:
 			path: ../src/webauthn/src/Event/BackupEligibilityChangedEvent.php
 
 		-
-			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\Event\BackupEligibilityChangedEvent::__construct() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Event/BackupEligibilityChangedEvent.php
-
-		-
-			rawMessage: '''
-				Property $credentialRecord references deprecated class Webauthn\PublicKeyCredentialSource in its type:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Event/BackupEligibilityChangedEvent.php
-
-		-
 			rawMessage: 'Method Webauthn\Event\BackupStatusChangedEvent::__construct() has parameter $newValue with a nullable type declaration.'
 			identifier: ergebnis.noParameterWithNullableTypeDeclaration
 			count: 1
@@ -6948,24 +6117,6 @@ parameters:
 		-
 			rawMessage: 'Method Webauthn\Event\BackupStatusChangedEvent::__construct() has parameter $previousValue with a nullable type declaration.'
 			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/webauthn/src/Event/BackupStatusChangedEvent.php
-
-		-
-			rawMessage: '''
-				Parameter $credentialRecord of method Webauthn\Event\BackupStatusChangedEvent::__construct() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Event/BackupStatusChangedEvent.php
-
-		-
-			rawMessage: '''
-				Property $credentialRecord references deprecated class Webauthn\PublicKeyCredentialSource in its type:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
 			count: 1
 			path: ../src/webauthn/src/Event/BackupStatusChangedEvent.php
 
@@ -9640,128 +8791,14 @@ parameters:
 			path: ../src/webauthn/src/PublicKeyCredentialRpEntity.php
 
 		-
+			rawMessage: Class "Webauthn\PublicKeyCredentialSource" is not allowed to extend "Webauthn\CredentialRecord".
+			identifier: ergebnis.noExtends
+			count: 1
+			path: ../src/webauthn/src/PublicKeyCredentialSource.php
+
+		-
 			rawMessage: Class Webauthn\PublicKeyCredentialSource is neither abstract nor final.
 			identifier: ergebnis.final
-			count: 1
-			path: ../src/webauthn/src/PublicKeyCredentialSource.php
-
-		-
-			rawMessage: Constructor in Webauthn\PublicKeyCredentialSource has parameter $backupEligible with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/webauthn/src/PublicKeyCredentialSource.php
-
-		-
-			rawMessage: Constructor in Webauthn\PublicKeyCredentialSource has parameter $backupStatus with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/webauthn/src/PublicKeyCredentialSource.php
-
-		-
-			rawMessage: Constructor in Webauthn\PublicKeyCredentialSource has parameter $otherUI with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/webauthn/src/PublicKeyCredentialSource.php
-
-		-
-			rawMessage: Constructor in Webauthn\PublicKeyCredentialSource has parameter $uvInitialized with default value.
-			identifier: ergebnis.noConstructorParameterWithDefaultValue
-			count: 1
-			path: ../src/webauthn/src/PublicKeyCredentialSource.php
-
-		-
-			rawMessage: 'Method Webauthn\PublicKeyCredentialSource::__construct() has parameter $backupEligible with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/webauthn/src/PublicKeyCredentialSource.php
-
-		-
-			rawMessage: 'Method Webauthn\PublicKeyCredentialSource::__construct() has parameter $backupEligible with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/webauthn/src/PublicKeyCredentialSource.php
-
-		-
-			rawMessage: 'Method Webauthn\PublicKeyCredentialSource::__construct() has parameter $backupStatus with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/webauthn/src/PublicKeyCredentialSource.php
-
-		-
-			rawMessage: 'Method Webauthn\PublicKeyCredentialSource::__construct() has parameter $backupStatus with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/webauthn/src/PublicKeyCredentialSource.php
-
-		-
-			rawMessage: 'Method Webauthn\PublicKeyCredentialSource::__construct() has parameter $otherUI with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/webauthn/src/PublicKeyCredentialSource.php
-
-		-
-			rawMessage: 'Method Webauthn\PublicKeyCredentialSource::__construct() has parameter $otherUI with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/webauthn/src/PublicKeyCredentialSource.php
-
-		-
-			rawMessage: 'Method Webauthn\PublicKeyCredentialSource::__construct() has parameter $uvInitialized with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/webauthn/src/PublicKeyCredentialSource.php
-
-		-
-			rawMessage: 'Method Webauthn\PublicKeyCredentialSource::__construct() has parameter $uvInitialized with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/webauthn/src/PublicKeyCredentialSource.php
-
-		-
-			rawMessage: 'Method Webauthn\PublicKeyCredentialSource::create() has parameter $backupEligible with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/webauthn/src/PublicKeyCredentialSource.php
-
-		-
-			rawMessage: 'Method Webauthn\PublicKeyCredentialSource::create() has parameter $backupEligible with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/webauthn/src/PublicKeyCredentialSource.php
-
-		-
-			rawMessage: 'Method Webauthn\PublicKeyCredentialSource::create() has parameter $backupStatus with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/webauthn/src/PublicKeyCredentialSource.php
-
-		-
-			rawMessage: 'Method Webauthn\PublicKeyCredentialSource::create() has parameter $backupStatus with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/webauthn/src/PublicKeyCredentialSource.php
-
-		-
-			rawMessage: 'Method Webauthn\PublicKeyCredentialSource::create() has parameter $otherUI with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/webauthn/src/PublicKeyCredentialSource.php
-
-		-
-			rawMessage: 'Method Webauthn\PublicKeyCredentialSource::create() has parameter $otherUI with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
-			count: 1
-			path: ../src/webauthn/src/PublicKeyCredentialSource.php
-
-		-
-			rawMessage: 'Method Webauthn\PublicKeyCredentialSource::create() has parameter $uvInitialized with a nullable type declaration.'
-			identifier: ergebnis.noParameterWithNullableTypeDeclaration
-			count: 1
-			path: ../src/webauthn/src/PublicKeyCredentialSource.php
-
-		-
-			rawMessage: 'Method Webauthn\PublicKeyCredentialSource::create() has parameter $uvInitialized with null as default value.'
-			identifier: ergebnis.noParameterWithNullDefaultValue
 			count: 1
 			path: ../src/webauthn/src/PublicKeyCredentialSource.php
 
@@ -9881,138 +8918,3 @@ parameters:
 			identifier: ergebnis.noSwitch
 			count: 1
 			path: ../src/webauthn/src/Util/CoseSignatureFixer.php
-
-		-
-			rawMessage: '''
-				Access to property $aaguid of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Util/CredentialRecordConverter.php
-
-		-
-			rawMessage: '''
-				Access to property $attestationType of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Util/CredentialRecordConverter.php
-
-		-
-			rawMessage: '''
-				Access to property $backupEligible of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Util/CredentialRecordConverter.php
-
-		-
-			rawMessage: '''
-				Access to property $backupStatus of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Util/CredentialRecordConverter.php
-
-		-
-			rawMessage: '''
-				Access to property $counter of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Util/CredentialRecordConverter.php
-
-		-
-			rawMessage: '''
-				Access to property $credentialPublicKey of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Util/CredentialRecordConverter.php
-
-		-
-			rawMessage: '''
-				Access to property $otherUI of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Util/CredentialRecordConverter.php
-
-		-
-			rawMessage: '''
-				Access to property $publicKeyCredentialId of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Util/CredentialRecordConverter.php
-
-		-
-			rawMessage: '''
-				Access to property $transports of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Util/CredentialRecordConverter.php
-
-		-
-			rawMessage: '''
-				Access to property $trustPath of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Util/CredentialRecordConverter.php
-
-		-
-			rawMessage: '''
-				Access to property $type of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Util/CredentialRecordConverter.php
-
-		-
-			rawMessage: '''
-				Access to property $userHandle of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Util/CredentialRecordConverter.php
-
-		-
-			rawMessage: '''
-				Access to property $uvInitialized of deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Util/CredentialRecordConverter.php
-
-		-
-			rawMessage: '''
-				Parameter $source of method Webauthn\Util\CredentialRecordConverter::toCredentialRecord() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 2
-			path: ../src/webauthn/src/Util/CredentialRecordConverter.php
-
-		-
-			rawMessage: '''
-				Parameter $sources of method Webauthn\Util\CredentialRecordConverter::toCredentialRecords() has typehint with deprecated class Webauthn\PublicKeyCredentialSource:
-				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedClass
-			count: 1
-			path: ../src/webauthn/src/Util/CredentialRecordConverter.php

--- a/src/symfony/src/CredentialOptionsBuilder/ProfileBasedCreationOptionsBuilder.php
+++ b/src/symfony/src/CredentialOptionsBuilder/ProfileBasedCreationOptionsBuilder.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\CredentialOptionsBuilder;
 
+use function count;
 use InvalidArgumentException;
+use function is_array;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -19,10 +21,7 @@ use Webauthn\Bundle\Service\PublicKeyCredentialCreationOptionsFactory;
 use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialDescriptor;
-use Webauthn\PublicKeyCredentialSource;
 use Webauthn\PublicKeyCredentialUserEntity;
-use function count;
-use function is_array;
 
 final readonly class ProfileBasedCreationOptionsBuilder implements PublicKeyCredentialCreationOptionsBuilder
 {
@@ -83,7 +82,7 @@ final readonly class ProfileBasedCreationOptionsBuilder implements PublicKeyCred
         $credentialSources = $this->credentialSourceRepository->findAllForUserEntity($userEntity);
 
         return array_map(
-            static fn (CredentialRecord|PublicKeyCredentialSource $credential): PublicKeyCredentialDescriptor => $credential->getPublicKeyCredentialDescriptor(),
+            static fn (CredentialRecord $credential): PublicKeyCredentialDescriptor => $credential->getPublicKeyCredentialDescriptor(),
             $credentialSources
         );
     }

--- a/src/symfony/src/CredentialOptionsBuilder/ProfileBasedRequestOptionsBuilder.php
+++ b/src/symfony/src/CredentialOptionsBuilder/ProfileBasedRequestOptionsBuilder.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\CredentialOptionsBuilder;
 
+use function count;
+use function is_array;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -20,10 +22,7 @@ use Webauthn\CredentialRecord;
 use Webauthn\FakeCredentialGenerator;
 use Webauthn\PublicKeyCredentialDescriptor;
 use Webauthn\PublicKeyCredentialRequestOptions;
-use Webauthn\PublicKeyCredentialSource;
 use Webauthn\PublicKeyCredentialUserEntity;
-use function count;
-use function is_array;
 
 final readonly class ProfileBasedRequestOptionsBuilder implements PublicKeyCredentialRequestOptionsBuilder
 {
@@ -86,7 +85,7 @@ final readonly class ProfileBasedRequestOptionsBuilder implements PublicKeyCrede
         $credentialSources = $this->credentialSourceRepository->findAllForUserEntity($userEntity);
 
         return array_map(
-            static fn (CredentialRecord|PublicKeyCredentialSource $credential): PublicKeyCredentialDescriptor => $credential->getPublicKeyCredentialDescriptor(),
+            static fn (CredentialRecord $credential): PublicKeyCredentialDescriptor => $credential->getPublicKeyCredentialDescriptor(),
             $credentialSources
         );
     }

--- a/src/symfony/src/DataCollector/WebauthnCollector.php
+++ b/src/symfony/src/DataCollector/WebauthnCollector.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\DataCollector;
 
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -21,8 +23,6 @@ use Webauthn\Event\AuthenticatorAssertionResponseValidationFailedEvent;
 use Webauthn\Event\AuthenticatorAssertionResponseValidationSucceededEvent;
 use Webauthn\Event\AuthenticatorAttestationResponseValidationFailedEvent;
 use Webauthn\Event\AuthenticatorAttestationResponseValidationSucceededEvent;
-use const JSON_PRETTY_PRINT;
-use const JSON_THROW_ON_ERROR;
 
 class WebauthnCollector extends DataCollector implements EventSubscriberInterface
 {

--- a/src/symfony/src/DependencyInjection/Compiler/CeremonyStepManagerFactoryCompilerPass.php
+++ b/src/symfony/src/DependencyInjection/Compiler/CeremonyStepManagerFactoryCompilerPass.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\DependencyInjection\Compiler;
 
+use function count;
+use function is_array;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -17,8 +19,6 @@ use Webauthn\CeremonyStep\TopOriginValidator;
 use Webauthn\MetadataService\CertificateChain\CertificateChainValidator;
 use Webauthn\MetadataService\MetadataStatementRepository;
 use Webauthn\MetadataService\StatusReportRepository;
-use function count;
-use function is_array;
 
 final class CeremonyStepManagerFactoryCompilerPass implements CompilerPassInterface
 {

--- a/src/symfony/src/DependencyInjection/Compiler/DynamicRouteCompilerPass.php
+++ b/src/symfony/src/DependencyInjection/Compiler/DynamicRouteCompilerPass.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\DependencyInjection\Compiler;
 
+use function array_key_exists;
 use InvalidArgumentException;
+use function sprintf;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Webauthn\Bundle\Routing\Loader;
-use function array_key_exists;
-use function sprintf;
 
 final readonly class DynamicRouteCompilerPass implements CompilerPassInterface
 {

--- a/src/symfony/src/DependencyInjection/Configuration.php
+++ b/src/symfony/src/DependencyInjection/Configuration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\DependencyInjection;
 
+use function assert;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -21,7 +22,6 @@ use Webauthn\Counter\ThrowExceptionIfInvalid;
 use Webauthn\MetadataService\CertificateChain\PhpCertificateChainValidator;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\SimpleFakeCredentialGenerator;
-use function assert;
 
 final readonly class Configuration implements ConfigurationInterface
 {

--- a/src/symfony/src/DependencyInjection/Factory/Security/WebauthnFactory.php
+++ b/src/symfony/src/DependencyInjection/Factory/Security/WebauthnFactory.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\DependencyInjection\Factory\Security;
 
+use function array_key_exists;
+use function assert;
+use function sprintf;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\FirewallListenerFactoryInterface;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
@@ -38,9 +41,6 @@ use Webauthn\Bundle\Service\PublicKeyCredentialCreationOptionsFactory;
 use Webauthn\Bundle\Service\PublicKeyCredentialRequestOptionsFactory;
 use Webauthn\Denormalizer\WebauthnSerializerFactory;
 use Webauthn\FakeCredentialGenerator;
-use function array_key_exists;
-use function assert;
-use function sprintf;
 
 final readonly class WebauthnFactory implements FirewallListenerFactoryInterface, AuthenticatorFactoryInterface
 {

--- a/src/symfony/src/DependencyInjection/WebauthnExtension.php
+++ b/src/symfony/src/DependencyInjection/WebauthnExtension.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\DependencyInjection;
 
+use function array_key_exists;
 use Cose\Algorithm\Algorithm;
+use function count;
+use function is_array;
+use function sprintf;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
@@ -52,10 +56,6 @@ use Webauthn\MetadataService\CanLogData;
 use Webauthn\MetadataService\CertificateChain\CertificateChainValidator;
 use Webauthn\MetadataService\MetadataStatementRepository;
 use Webauthn\MetadataService\StatusReportRepository;
-use function array_key_exists;
-use function count;
-use function is_array;
-use function sprintf;
 
 final class WebauthnExtension extends Extension implements PrependExtensionInterface
 {

--- a/src/symfony/src/Doctrine/Type/AAGUIDDataType.php
+++ b/src/symfony/src/Doctrine/Type/AAGUIDDataType.php
@@ -6,8 +6,8 @@ namespace Webauthn\Bundle\Doctrine\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
-use Symfony\Component\Uid\Uuid;
 use function is_string;
+use Symfony\Component\Uid\Uuid;
 
 final class AAGUIDDataType extends Type
 {

--- a/src/symfony/src/Doctrine/Type/Base64BinaryDataType.php
+++ b/src/symfony/src/Doctrine/Type/Base64BinaryDataType.php
@@ -6,8 +6,8 @@ namespace Webauthn\Bundle\Doctrine\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
-use ParagonIE\ConstantTime\Base64;
 use function is_string;
+use ParagonIE\ConstantTime\Base64;
 
 final class Base64BinaryDataType extends Type
 {

--- a/src/symfony/src/Doctrine/Type/SerializerTrait.php
+++ b/src/symfony/src/Doctrine/Type/SerializerTrait.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\Doctrine\Type;
 
+use const JSON_THROW_ON_ERROR;
 use Symfony\Component\Serializer\Encoder\JsonEncode;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Webauthn\AttestationStatement\AttestationStatementSupportManager;
 use Webauthn\Denormalizer\WebauthnSerializerFactory;
-use const JSON_THROW_ON_ERROR;
 
 trait SerializerTrait
 {

--- a/src/symfony/src/Repository/CanSaveCredentialRecord.php
+++ b/src/symfony/src/Repository/CanSaveCredentialRecord.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace Webauthn\Bundle\Repository;
 
 use Webauthn\CredentialRecord;
-use Webauthn\PublicKeyCredentialSource;
 
 /**
  * Interface for repositories that can save credential records.
  */
 interface CanSaveCredentialRecord
 {
-    public function saveCredentialSource(CredentialRecord|PublicKeyCredentialSource $credentialRecord): void;
+    public function saveCredentialSource(CredentialRecord $credentialRecord): void;
 }

--- a/src/symfony/src/Repository/CanSaveCredentialSource.php
+++ b/src/symfony/src/Repository/CanSaveCredentialSource.php
@@ -4,13 +4,9 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\Repository;
 
-use Webauthn\CredentialRecord;
-use Webauthn\PublicKeyCredentialSource;
-
 /**
  * @deprecated since 5.3, use CanSaveCredentialRecord instead. Will be removed in 6.0.
  */
-interface CanSaveCredentialSource
+interface CanSaveCredentialSource extends CanSaveCredentialRecord
 {
-    public function saveCredentialSource(CredentialRecord|PublicKeyCredentialSource $credentialRecord): void;
 }

--- a/src/symfony/src/Repository/CredentialRecordRepositoryInterface.php
+++ b/src/symfony/src/Repository/CredentialRecordRepositoryInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Webauthn\Bundle\Repository;
 
 use Webauthn\CredentialRecord;
-use Webauthn\PublicKeyCredentialSource;
 use Webauthn\PublicKeyCredentialUserEntity;
 
 /**
@@ -16,11 +15,9 @@ use Webauthn\PublicKeyCredentialUserEntity;
 interface CredentialRecordRepositoryInterface
 {
     /**
-     * @return array<CredentialRecord|PublicKeyCredentialSource>
+     * @return array<CredentialRecord>
      */
     public function findAllForUserEntity(PublicKeyCredentialUserEntity $publicKeyCredentialUserEntity): array;
 
-    public function findOneByCredentialId(
-        string $publicKeyCredentialId
-    ): CredentialRecord|PublicKeyCredentialSource|null;
+    public function findOneByCredentialId(string $publicKeyCredentialId): ?CredentialRecord;
 }

--- a/src/symfony/src/Repository/DoctrineCredentialSourceRepository.php
+++ b/src/symfony/src/Repository/DoctrineCredentialSourceRepository.php
@@ -7,13 +7,12 @@ namespace Webauthn\Bundle\Repository;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use InvalidArgumentException;
-use Webauthn\CredentialRecord;
-use Webauthn\PublicKeyCredentialSource;
-use Webauthn\PublicKeyCredentialUserEntity;
 use function sprintf;
+use Webauthn\CredentialRecord;
+use Webauthn\PublicKeyCredentialUserEntity;
 
 /**
- * @template T of PublicKeyCredentialSource
+ * @template T of CredentialRecord
  * @template-extends  ServiceEntityRepository<T>
  *
  * @deprecated since 5.2.0, to be removed in 6.0.0. Please create your own doctrine-based repository.
@@ -30,15 +29,18 @@ class DoctrineCredentialSourceRepository extends ServiceEntityRepository impleme
      */
     public function __construct(ManagerRegistry $registry, string $class)
     {
-        is_subclass_of($class, PublicKeyCredentialSource::class) || throw new InvalidArgumentException(sprintf(
-            'Invalid class. Must be an instance of "Webauthn\PublicKeyCredentialSource", got "%s" instead.',
-            $class
-        ));
+        is_subclass_of(
+            $class,
+            CredentialRecord::class,
+            true
+        ) || $class === CredentialRecord::class || throw new InvalidArgumentException(
+            sprintf('Invalid class. Must be an instance of "Webauthn\CredentialRecord", got "%s" instead.', $class)
+        );
         $this->class = $class;
         parent::__construct($registry, $class);
     }
 
-    public function saveCredentialSource(CredentialRecord|PublicKeyCredentialSource $credentialRecord): void
+    public function saveCredentialSource(CredentialRecord $credentialRecord): void
     {
         $this->getEntityManager()
             ->persist($credentialRecord);
@@ -58,9 +60,8 @@ class DoctrineCredentialSourceRepository extends ServiceEntityRepository impleme
             ->execute();
     }
 
-    public function findOneByCredentialId(
-        string $publicKeyCredentialId
-    ): CredentialRecord|PublicKeyCredentialSource|null {
+    public function findOneByCredentialId(string $publicKeyCredentialId): ?CredentialRecord
+    {
         return $this->getEntityManager()
             ->createQueryBuilder()
             ->from($this->class, 'c')

--- a/src/symfony/src/Repository/DummyCredentialRecordRepository.php
+++ b/src/symfony/src/Repository/DummyCredentialRecordRepository.php
@@ -9,7 +9,6 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Webauthn\CredentialRecord;
 use Webauthn\MetadataService\CanLogData;
-use Webauthn\PublicKeyCredentialSource;
 use Webauthn\PublicKeyCredentialUserEntity;
 
 /**
@@ -33,9 +32,8 @@ class DummyCredentialRecordRepository implements CredentialRecordRepositoryInter
         $this->throwException();
     }
 
-    public function findOneByCredentialId(
-        string $publicKeyCredentialId
-    ): CredentialRecord|PublicKeyCredentialSource|null {
+    public function findOneByCredentialId(string $publicKeyCredentialId): ?CredentialRecord
+    {
         $this->throwException();
     }
 

--- a/src/symfony/src/Repository/DummyPublicKeyCredentialSourceRepository.php
+++ b/src/symfony/src/Repository/DummyPublicKeyCredentialSourceRepository.php
@@ -9,7 +9,6 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Webauthn\CredentialRecord;
 use Webauthn\MetadataService\CanLogData;
-use Webauthn\PublicKeyCredentialSource;
 use Webauthn\PublicKeyCredentialUserEntity;
 
 /**
@@ -33,9 +32,8 @@ class DummyPublicKeyCredentialSourceRepository implements PublicKeyCredentialSou
         $this->throwException();
     }
 
-    public function findOneByCredentialId(
-        string $publicKeyCredentialId
-    ): CredentialRecord|PublicKeyCredentialSource|null {
+    public function findOneByCredentialId(string $publicKeyCredentialId): ?CredentialRecord
+    {
         $this->throwException();
     }
 

--- a/src/symfony/src/Repository/PublicKeyCredentialSourceRepositoryInterface.php
+++ b/src/symfony/src/Repository/PublicKeyCredentialSourceRepositoryInterface.php
@@ -4,21 +4,9 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\Repository;
 
-use Webauthn\CredentialRecord;
-use Webauthn\PublicKeyCredentialSource;
-use Webauthn\PublicKeyCredentialUserEntity;
-
 /**
  * @deprecated since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
  */
-interface PublicKeyCredentialSourceRepositoryInterface
+interface PublicKeyCredentialSourceRepositoryInterface extends CredentialRecordRepositoryInterface
 {
-    /**
-     * @return array<CredentialRecord|PublicKeyCredentialSource>
-     */
-    public function findAllForUserEntity(PublicKeyCredentialUserEntity $publicKeyCredentialUserEntity): array;
-
-    public function findOneByCredentialId(
-        string $publicKeyCredentialId
-    ): CredentialRecord|PublicKeyCredentialSource|null;
 }

--- a/src/symfony/src/Resources/config/metadata_statement_supports.php
+++ b/src/symfony/src/Resources/config/metadata_statement_supports.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use Webauthn\AttestationStatement\AndroidKeyAttestationStatementSupport;
 use Webauthn\AttestationStatement\AppleAttestationStatementSupport;
 use Webauthn\AttestationStatement\CompoundAttestationStatementSupport;
@@ -10,7 +11,6 @@ use Webauthn\AttestationStatement\FidoU2FAttestationStatementSupport;
 use Webauthn\AttestationStatement\PackedAttestationStatementSupport;
 use Webauthn\AttestationStatement\TPMAttestationStatementSupport;
 use Webauthn\MetadataService\CertificateChain\PhpCertificateChainValidator;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $container): void {
     $service = $container->services()

--- a/src/symfony/src/Resources/config/security.php
+++ b/src/symfony/src/Resources/config/security.php
@@ -3,7 +3,9 @@
 declare(strict_types=1);
 
 use Psr\Cache\CacheItemPoolInterface;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\abstract_arg;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use Symfony\Component\Serializer\SerializerInterface;
 use Webauthn\Bundle\DependencyInjection\Factory\Security\WebauthnFactory;
 use Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface;
@@ -21,8 +23,6 @@ use Webauthn\Bundle\Security\Http\Authenticator\WebauthnAuthenticator;
 use Webauthn\Bundle\Security\Storage\CacheStorage;
 use Webauthn\Bundle\Security\Storage\SessionStorage;
 use Webauthn\Bundle\Security\WebauthnFirewallConfig;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\abstract_arg;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $container): void {
     $service = $container->services()

--- a/src/symfony/src/Resources/config/services.php
+++ b/src/symfony/src/Resources/config/services.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use Psr\Log\NullLogger;
 use Symfony\Component\Clock\NativeClock;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Webauthn\AttestationStatement\AttestationObjectLoader;
 use Webauthn\AttestationStatement\AttestationStatementSupportManager;
@@ -49,8 +51,6 @@ use Webauthn\Denormalizer\UrlNormalizer;
 use Webauthn\Denormalizer\VerificationMethodANDCombinationsDenormalizer;
 use Webauthn\Denormalizer\WebauthnSerializerFactory;
 use Webauthn\SimpleFakeCredentialGenerator;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $container): void {
     $service = $container->services()

--- a/src/symfony/src/Routing/Loader.php
+++ b/src/symfony/src/Routing/Loader.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\Routing;
 
+use function sprintf;
 use Symfony\Component\Config\Loader\Loader as SymfonyLoader;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
-use function sprintf;
 
 class Loader extends SymfonyLoader
 {

--- a/src/symfony/src/Security/Authentication/Token/WebauthnToken.php
+++ b/src/symfony/src/Security/Authentication/Token/WebauthnToken.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\Security\Authentication\Token;
 
+use function assert;
+use function is_array;
 use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
 use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
 use Webauthn\Bundle\Security\Authorization\Voter\IsUserPresentVoter;
@@ -11,8 +13,6 @@ use Webauthn\Bundle\Security\Authorization\Voter\IsUserVerifiedVoter;
 use Webauthn\PublicKeyCredentialDescriptor;
 use Webauthn\PublicKeyCredentialOptions;
 use Webauthn\PublicKeyCredentialUserEntity;
-use function assert;
-use function is_array;
 
 class WebauthnToken extends AbstractToken
 {

--- a/src/symfony/src/Security/Authentication/WebauthnAuthenticator.php
+++ b/src/symfony/src/Security/Authentication/WebauthnAuthenticator.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\Security\Authentication;
 
+use function assert;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Http\Authenticator\AbstractLoginFormAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\Bundle\Security\Authentication\Token\WebauthnToken;
-use function assert;
 
 abstract class WebauthnAuthenticator extends AbstractLoginFormAuthenticator
 {

--- a/src/symfony/src/Security/Authentication/WebauthnBadge.php
+++ b/src/symfony/src/Security/Authentication/WebauthnBadge.php
@@ -5,15 +5,14 @@ declare(strict_types=1);
 namespace Webauthn\Bundle\Security\Authentication;
 
 use LogicException;
+use function sprintf;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Webauthn\AuthenticatorResponse;
 use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredentialOptions;
-use Webauthn\PublicKeyCredentialSource;
 use Webauthn\PublicKeyCredentialUserEntity;
-use function sprintf;
 
 final class WebauthnBadge extends UserBadge
 {
@@ -25,7 +24,7 @@ final class WebauthnBadge extends UserBadge
 
     private PublicKeyCredentialUserEntity $publicKeyCredentialUserEntity;
 
-    private CredentialRecord|PublicKeyCredentialSource $publicKeyCredentialSource;
+    private CredentialRecord $publicKeyCredentialSource;
 
     private UserInterface $user;
 
@@ -73,7 +72,7 @@ final class WebauthnBadge extends UserBadge
         return $this->publicKeyCredentialUserEntity;
     }
 
-    public function getPublicKeyCredentialSource(): CredentialRecord|PublicKeyCredentialSource
+    public function getPublicKeyCredentialSource(): CredentialRecord
     {
         if (! $this->isResolved) {
             throw new LogicException('The badge is not resolved.');
@@ -93,7 +92,7 @@ final class WebauthnBadge extends UserBadge
         AuthenticatorResponse $authenticatorResponse,
         PublicKeyCredentialOptions $publicKeyCredentialOptions,
         PublicKeyCredentialUserEntity $publicKeyCredentialUserEntity,
-        CredentialRecord|PublicKeyCredentialSource $publicKeyCredentialSource,
+        CredentialRecord $publicKeyCredentialSource,
     ): void {
         if ($this->userLoader === null) {
             throw new LogicException(sprintf(

--- a/src/symfony/src/Security/Guesser/RequestBodyUserEntityGuesser.php
+++ b/src/symfony/src/Security/Guesser/RequestBodyUserEntityGuesser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\Security\Guesser;
 
+use function count;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -14,7 +15,6 @@ use Webauthn\Bundle\Repository\CanGenerateUserEntity;
 use Webauthn\Bundle\Repository\PublicKeyCredentialUserEntityRepositoryInterface;
 use Webauthn\Exception\InvalidDataException;
 use Webauthn\PublicKeyCredentialUserEntity;
-use function count;
 
 final readonly class RequestBodyUserEntityGuesser implements UserEntityGuesser
 {

--- a/src/symfony/src/Security/Handler/DefaultCreationOptionsHandler.php
+++ b/src/symfony/src/Security/Handler/DefaultCreationOptionsHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\Security\Handler;
 
+use function is_array;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -13,7 +14,6 @@ use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialUserEntity;
-use function is_array;
 
 final readonly class DefaultCreationOptionsHandler implements CreationOptionsHandler
 {

--- a/src/symfony/src/Security/Handler/DefaultRequestOptionsHandler.php
+++ b/src/symfony/src/Security/Handler/DefaultRequestOptionsHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\Security\Handler;
 
+use function is_array;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -13,7 +14,6 @@ use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialUserEntity;
-use function is_array;
 
 final readonly class DefaultRequestOptionsHandler implements RequestOptionsHandler
 {

--- a/src/symfony/src/Security/Http/Authenticator/Passport/Credentials/WebauthnCredentials.php
+++ b/src/symfony/src/Security/Http/Authenticator/Passport/Credentials/WebauthnCredentials.php
@@ -8,7 +8,6 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\Credentia
 use Webauthn\AuthenticatorResponse;
 use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredentialOptions;
-use Webauthn\PublicKeyCredentialSource;
 use Webauthn\PublicKeyCredentialUserEntity;
 
 class WebauthnCredentials implements CredentialsInterface
@@ -17,7 +16,7 @@ class WebauthnCredentials implements CredentialsInterface
         private readonly AuthenticatorResponse $authenticatorResponse,
         private readonly PublicKeyCredentialOptions $publicKeyCredentialOptions,
         private readonly PublicKeyCredentialUserEntity $publicKeyCredentialUserEntity,
-        private readonly CredentialRecord|PublicKeyCredentialSource $publicKeyCredentialSource,
+        private readonly CredentialRecord $publicKeyCredentialSource,
         private readonly string $firewallName,
     ) {
     }
@@ -37,7 +36,7 @@ class WebauthnCredentials implements CredentialsInterface
         return $this->publicKeyCredentialUserEntity;
     }
 
-    public function getPublicKeyCredentialSource(): CredentialRecord|PublicKeyCredentialSource
+    public function getPublicKeyCredentialSource(): CredentialRecord
     {
         return $this->publicKeyCredentialSource;
     }

--- a/src/symfony/src/Security/Storage/CacheStorage.php
+++ b/src/symfony/src/Security/Storage/CacheStorage.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Webauthn\Bundle\Security\Storage;
 
 use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use function sprintf;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 final readonly class CacheStorage implements OptionsStorage
 {

--- a/src/symfony/src/Security/Storage/SessionStorage.php
+++ b/src/symfony/src/Security/Storage/SessionStorage.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\Security\Storage;
 
+use function array_key_exists;
+use function is_array;
+use function sprintf;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Webauthn\PublicKeyCredentialOptions;
 use Webauthn\PublicKeyCredentialUserEntity;
-use function array_key_exists;
-use function is_array;
-use function sprintf;
 
 final readonly class SessionStorage implements OptionsStorage
 {

--- a/src/symfony/src/Service/PublicKeyCredentialCreationOptionsFactory.php
+++ b/src/symfony/src/Service/PublicKeyCredentialCreationOptionsFactory.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\Service;
 
+use function array_key_exists;
+use function gettype;
 use InvalidArgumentException;
+use function is_int;
+use function is_string;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use function sprintf;
 use Webauthn\AuthenticationExtensions\AuthenticationExtension;
 use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
 use Webauthn\AuthenticatorSelectionCriteria;
@@ -17,11 +22,6 @@ use Webauthn\PublicKeyCredentialDescriptor;
 use Webauthn\PublicKeyCredentialParameters;
 use Webauthn\PublicKeyCredentialRpEntity;
 use Webauthn\PublicKeyCredentialUserEntity;
-use function array_key_exists;
-use function gettype;
-use function is_int;
-use function is_string;
-use function sprintf;
 
 final class PublicKeyCredentialCreationOptionsFactory implements CanDispatchEvents
 {

--- a/src/symfony/src/Service/PublicKeyCredentialRequestOptionsFactory.php
+++ b/src/symfony/src/Service/PublicKeyCredentialRequestOptionsFactory.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\Service;
 
+use function array_key_exists;
+use function gettype;
 use InvalidArgumentException;
+use function is_int;
+use function is_string;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use function sprintf;
 use Webauthn\AuthenticationExtensions\AuthenticationExtension;
 use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
 use Webauthn\Bundle\Event\PublicKeyCredentialRequestOptionsCreatedEvent;
@@ -13,11 +18,6 @@ use Webauthn\Event\CanDispatchEvents;
 use Webauthn\Event\NullEventDispatcher;
 use Webauthn\PublicKeyCredentialDescriptor;
 use Webauthn\PublicKeyCredentialRequestOptions;
-use function array_key_exists;
-use function gettype;
-use function is_int;
-use function is_string;
-use function sprintf;
 
 final class PublicKeyCredentialRequestOptionsFactory implements CanDispatchEvents
 {

--- a/src/symfony/src/WebauthnBundle.php
+++ b/src/symfony/src/WebauthnBundle.php
@@ -6,6 +6,7 @@ namespace Webauthn\Bundle;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
 use LogicException;
+use function realpath;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -23,7 +24,6 @@ use Webauthn\Bundle\DependencyInjection\Compiler\PasskeyEndpointsCompilerPass;
 use Webauthn\Bundle\DependencyInjection\Factory\Security\WebauthnFactory;
 use Webauthn\Bundle\DependencyInjection\Factory\Security\WebauthnServicesFactory;
 use Webauthn\Bundle\DependencyInjection\WebauthnExtension;
-use function realpath;
 
 final class WebauthnBundle extends Bundle
 {

--- a/src/webauthn/composer.json
+++ b/src/webauthn/composer.json
@@ -24,7 +24,7 @@
         "ext-json": "*",
         "ext-openssl": "*",
         "paragonie/constant_time_encoding": "^2.6|^3.0",
-        "phpdocumentor/reflection-docblock": "^5.3",
+        "phpdocumentor/reflection-docblock": "^5.3|^6.0",
         "psr/clock": "^1.0",
         "psr/event-dispatcher": "^1.0",
         "psr/log": "^1.0|^2.0|^3.0",

--- a/src/webauthn/src/AttestationStatement/AndroidKeyAttestationStatementSupport.php
+++ b/src/webauthn/src/AttestationStatement/AndroidKeyAttestationStatementSupport.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Webauthn\AttestationStatement;
 
+use function array_key_exists;
 use CBOR\Decoder;
 use CBOR\Normalizable;
 use Cose\Algorithms;
 use Cose\Key\Ec2Key;
 use Cose\Key\Key;
 use Cose\Key\RsaKey;
+use function count;
+use function openssl_verify;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use SpomkyLabs\Pki\ASN1\Type\Constructed\Sequence;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\OctetString;
@@ -17,6 +20,7 @@ use SpomkyLabs\Pki\ASN1\Type\Tagged\ExplicitTagging;
 use SpomkyLabs\Pki\CryptoEncoding\PEM;
 use SpomkyLabs\Pki\X509\Certificate\Certificate;
 use SpomkyLabs\Pki\X509\Certificate\Extension\UnknownExtension;
+use function sprintf;
 use Webauthn\AuthenticatorData;
 use Webauthn\Event\AttestationStatementLoaded;
 use Webauthn\Event\CanDispatchEvents;
@@ -27,10 +31,6 @@ use Webauthn\Exception\InvalidAttestationStatementException;
 use Webauthn\MetadataService\CertificateChain\CertificateToolbox;
 use Webauthn\StringStream;
 use Webauthn\TrustPath\CertificateTrustPath;
-use function array_key_exists;
-use function count;
-use function openssl_verify;
-use function sprintf;
 
 final class AndroidKeyAttestationStatementSupport implements AttestationStatementSupport, CanDispatchEvents
 {

--- a/src/webauthn/src/AttestationStatement/AppleAttestationStatementSupport.php
+++ b/src/webauthn/src/AttestationStatement/AppleAttestationStatementSupport.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Webauthn\AttestationStatement;
 
+use function array_key_exists;
 use CBOR\Decoder;
 use CBOR\Normalizable;
 use Cose\Key\Ec2Key;
 use Cose\Key\Key;
 use Cose\Key\RsaKey;
+use function count;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use SpomkyLabs\Pki\ASN1\Type\Constructed\Sequence;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\OctetString;
@@ -26,8 +28,6 @@ use Webauthn\Exception\InvalidAttestationStatementException;
 use Webauthn\MetadataService\CertificateChain\CertificateToolbox;
 use Webauthn\StringStream;
 use Webauthn\TrustPath\CertificateTrustPath;
-use function array_key_exists;
-use function count;
 
 final class AppleAttestationStatementSupport implements AttestationStatementSupport, CanDispatchEvents
 {

--- a/src/webauthn/src/AttestationStatement/AttestationObjectLoader.php
+++ b/src/webauthn/src/AttestationStatement/AttestationObjectLoader.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Webauthn\AttestationStatement;
 
+use function array_key_exists;
 use CBOR\Decoder;
 use CBOR\Normalizable;
+use function is_array;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -18,8 +20,6 @@ use Webauthn\Exception\InvalidDataException;
 use Webauthn\MetadataService\CanLogData;
 use Webauthn\StringStream;
 use Webauthn\Util\Base64;
-use function array_key_exists;
-use function is_array;
 
 class AttestationObjectLoader implements CanDispatchEvents, CanLogData
 {

--- a/src/webauthn/src/AttestationStatement/AttestationStatement.php
+++ b/src/webauthn/src/AttestationStatement/AttestationStatement.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Webauthn\AttestationStatement;
 
-use Webauthn\Exception\InvalidDataException;
-use Webauthn\TrustPath\TrustPath;
 use function array_key_exists;
 use function sprintf;
+use Webauthn\Exception\InvalidDataException;
+use Webauthn\TrustPath\TrustPath;
 
 class AttestationStatement
 {

--- a/src/webauthn/src/AttestationStatement/AttestationStatementSupportManager.php
+++ b/src/webauthn/src/AttestationStatement/AttestationStatementSupportManager.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Webauthn\AttestationStatement;
 
-use Webauthn\Exception\InvalidDataException;
 use function array_key_exists;
 use function sprintf;
+use Webauthn\Exception\InvalidDataException;
 
 class AttestationStatementSupportManager
 {

--- a/src/webauthn/src/AttestationStatement/CompoundAttestationStatementSupport.php
+++ b/src/webauthn/src/AttestationStatement/CompoundAttestationStatementSupport.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace Webauthn\AttestationStatement;
 
+use function array_key_exists;
+use function count;
 use InvalidArgumentException;
+use function is_array;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use function sprintf;
 use Throwable;
 use Webauthn\AuthenticatorData;
 use Webauthn\Event\AttestationStatementLoaded;
@@ -15,10 +19,6 @@ use Webauthn\Exception\AttestationStatementLoadingException;
 use Webauthn\Exception\AttestationStatementVerificationException;
 use Webauthn\Exception\InvalidDataException;
 use Webauthn\TrustPath\EmptyTrustPath;
-use function array_key_exists;
-use function count;
-use function is_array;
-use function sprintf;
 
 /**
  * Compound Attestation Statement Support

--- a/src/webauthn/src/AttestationStatement/FidoU2FAttestationStatementSupport.php
+++ b/src/webauthn/src/AttestationStatement/FidoU2FAttestationStatementSupport.php
@@ -4,10 +4,17 @@ declare(strict_types=1);
 
 namespace Webauthn\AttestationStatement;
 
+use function array_key_exists;
 use CBOR\Decoder;
 use CBOR\MapObject;
 use Cose\Key\Ec2Key;
+use function count;
+use function is_array;
+use const OPENSSL_ALGO_SHA256;
+use function openssl_pkey_get_public;
+use function openssl_verify;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use function sprintf;
 use Throwable;
 use Webauthn\AuthenticatorData;
 use Webauthn\Event\AttestationStatementLoaded;
@@ -19,13 +26,6 @@ use Webauthn\Exception\InvalidAttestationStatementException;
 use Webauthn\MetadataService\CertificateChain\CertificateToolbox;
 use Webauthn\StringStream;
 use Webauthn\TrustPath\CertificateTrustPath;
-use function array_key_exists;
-use function count;
-use function is_array;
-use function openssl_pkey_get_public;
-use function openssl_verify;
-use function sprintf;
-use const OPENSSL_ALGO_SHA256;
 
 final class FidoU2FAttestationStatementSupport implements AttestationStatementSupport, CanDispatchEvents
 {

--- a/src/webauthn/src/AttestationStatement/NoneAttestationStatementSupport.php
+++ b/src/webauthn/src/AttestationStatement/NoneAttestationStatementSupport.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Webauthn\AttestationStatement;
 
+use function count;
+use function is_array;
+use function is_string;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Webauthn\AuthenticatorData;
 use Webauthn\Event\AttestationStatementLoaded;
@@ -11,9 +14,6 @@ use Webauthn\Event\CanDispatchEvents;
 use Webauthn\Event\NullEventDispatcher;
 use Webauthn\Exception\AttestationStatementLoadingException;
 use Webauthn\TrustPath\EmptyTrustPath;
-use function count;
-use function is_array;
-use function is_string;
 
 final class NoneAttestationStatementSupport implements AttestationStatementSupport, CanDispatchEvents
 {

--- a/src/webauthn/src/AttestationStatement/PackedAttestationStatementSupport.php
+++ b/src/webauthn/src/AttestationStatement/PackedAttestationStatementSupport.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace Webauthn\AttestationStatement;
 
+use function array_key_exists;
 use CBOR\Decoder;
 use CBOR\MapObject;
 use Cose\Algorithm\Manager;
 use Cose\Algorithm\Signature\Signature;
 use Cose\Algorithms;
 use Cose\Key\Key;
+use function count;
+use function is_array;
+use function is_string;
+use function openssl_verify;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use SpomkyLabs\Pki\ASN1\Type\Primitive\OctetString;
 use SpomkyLabs\Pki\ASN1\Type\UnspecifiedType;
@@ -31,11 +36,6 @@ use Webauthn\StringStream;
 use Webauthn\TrustPath\CertificateTrustPath;
 use Webauthn\TrustPath\EmptyTrustPath;
 use Webauthn\Util\CoseSignatureFixer;
-use function array_key_exists;
-use function count;
-use function is_array;
-use function is_string;
-use function openssl_verify;
 
 final class PackedAttestationStatementSupport implements AttestationStatementSupport, CanDispatchEvents
 {

--- a/src/webauthn/src/AttestationStatement/TPMAttestationStatementSupport.php
+++ b/src/webauthn/src/AttestationStatement/TPMAttestationStatementSupport.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\AttestationStatement;
 
+use function array_key_exists;
 use CBOR\Decoder;
 use CBOR\MapObject;
 use Cose\Algorithms;
@@ -11,7 +12,9 @@ use Cose\Key\Ec2Key;
 use Cose\Key\Key;
 use Cose\Key\OkpKey;
 use Cose\Key\RsaKey;
+use function count;
 use DateTimeImmutable;
+use function openssl_verify;
 use ParagonIE\ConstantTime\Base64UrlSafe;
 use Psr\Clock\ClockInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -21,7 +24,9 @@ use SpomkyLabs\Pki\CryptoEncoding\PEM;
 use SpomkyLabs\Pki\X509\Certificate\Certificate;
 use SpomkyLabs\Pki\X509\Certificate\Extension\UnknownExtension;
 use SpomkyLabs\Pki\X509\Certificate\TBSCertificate;
+use function sprintf;
 use Symfony\Component\Clock\NativeClock;
+use function unpack;
 use Webauthn\AuthenticatorData;
 use Webauthn\Event\AttestationStatementLoaded;
 use Webauthn\Event\CanDispatchEvents;
@@ -32,11 +37,6 @@ use Webauthn\Exception\InvalidAttestationStatementException;
 use Webauthn\MetadataService\CertificateChain\CertificateToolbox;
 use Webauthn\StringStream;
 use Webauthn\TrustPath\CertificateTrustPath;
-use function array_key_exists;
-use function count;
-use function openssl_verify;
-use function sprintf;
-use function unpack;
 
 final class TPMAttestationStatementSupport implements AttestationStatementSupport, CanDispatchEvents
 {

--- a/src/webauthn/src/AuthenticationExtensions/AuthenticationExtensions.php
+++ b/src/webauthn/src/AuthenticationExtensions/AuthenticationExtensions.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Webauthn\AuthenticationExtensions;
 
+use function array_key_exists;
 use ArrayAccess;
 use ArrayIterator;
+use function count;
+use const COUNT_NORMAL;
 use Countable;
+use function is_string;
 use Iterator;
 use IteratorAggregate;
-use Webauthn\Exception\AuthenticationExtensionException;
-use function array_key_exists;
-use function count;
-use function is_string;
 use function sprintf;
-use const COUNT_NORMAL;
+use Webauthn\Exception\AuthenticationExtensionException;
 
 /**
  * @implements IteratorAggregate<AuthenticationExtension>

--- a/src/webauthn/src/AuthenticationExtensions/PseudoRandomFunctionInputExtensionBuilder.php
+++ b/src/webauthn/src/AuthenticationExtensions/PseudoRandomFunctionInputExtensionBuilder.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Webauthn\AuthenticationExtensions;
 
-use ParagonIE\ConstantTime\Base64UrlSafe;
 use function array_key_exists;
+use ParagonIE\ConstantTime\Base64UrlSafe;
 
 final class PseudoRandomFunctionInputExtensionBuilder
 {

--- a/src/webauthn/src/AuthenticatorAssertionResponseValidator.php
+++ b/src/webauthn/src/AuthenticatorAssertionResponseValidator.php
@@ -8,6 +8,7 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Throwable;
+use function trigger_deprecation;
 use Webauthn\CeremonyStep\CeremonyStepManager;
 use Webauthn\Event\AuthenticatorAssertionResponseValidationFailedEvent;
 use Webauthn\Event\AuthenticatorAssertionResponseValidationSucceededEvent;
@@ -17,7 +18,6 @@ use Webauthn\Event\CanDispatchEvents;
 use Webauthn\Event\NullEventDispatcher;
 use Webauthn\Exception\AuthenticatorResponseVerificationException;
 use Webauthn\MetadataService\CanLogData;
-use function trigger_deprecation;
 
 class AuthenticatorAssertionResponseValidator implements CanLogData, CanDispatchEvents
 {
@@ -41,12 +41,12 @@ class AuthenticatorAssertionResponseValidator implements CanLogData, CanDispatch
      * @see https://www.w3.org/TR/webauthn/#verifying-assertion
      */
     public function check(
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse $authenticatorAssertionResponse,
         PublicKeyCredentialRequestOptions $publicKeyCredentialRequestOptions,
         string $host,
         ?string $userHandle,
-    ): CredentialRecord|PublicKeyCredentialSource {
+    ): CredentialRecord {
         if ($credentialRecord instanceof PublicKeyCredentialSource) {
             trigger_deprecation(
                 'web-auth/webauthn-lib',
@@ -157,7 +157,7 @@ class AuthenticatorAssertionResponseValidator implements CanLogData, CanDispatch
         PublicKeyCredentialRequestOptions $publicKeyCredentialRequestOptions,
         string $host,
         ?string $userHandle,
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord
+        CredentialRecord $credentialRecord
     ): AuthenticatorAssertionResponseValidationSucceededEvent {
         return new AuthenticatorAssertionResponseValidationSucceededEvent(
             $authenticatorAssertionResponse,
@@ -169,7 +169,7 @@ class AuthenticatorAssertionResponseValidator implements CanLogData, CanDispatch
     }
 
     protected function createAuthenticatorAssertionResponseValidationFailedEvent(
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse $authenticatorAssertionResponse,
         PublicKeyCredentialRequestOptions $publicKeyCredentialRequestOptions,
         string $host,

--- a/src/webauthn/src/AuthenticatorData.php
+++ b/src/webauthn/src/AuthenticatorData.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Webauthn;
 
-use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
 use function ord;
+use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
 
 /**
  * @see https://www.w3.org/TR/webauthn/#sec-authenticator-data

--- a/src/webauthn/src/AuthenticatorDataLoader.php
+++ b/src/webauthn/src/AuthenticatorDataLoader.php
@@ -11,11 +11,11 @@ use CBOR\MapObject;
 use CBOR\NegativeIntegerObject;
 use CBOR\TextStringObject;
 use CBOR\UnsignedIntegerObject;
+use function chr;
+use function ord;
 use Symfony\Component\Uid\Uuid;
 use Webauthn\AuthenticationExtensions\AuthenticationExtensionLoader;
 use Webauthn\Exception\InvalidDataException;
-use function chr;
-use function ord;
 
 final readonly class AuthenticatorDataLoader
 {

--- a/src/webauthn/src/AuthenticatorSelectionCriteria.php
+++ b/src/webauthn/src/AuthenticatorSelectionCriteria.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Webauthn;
 
-use InvalidArgumentException;
 use function in_array;
+use InvalidArgumentException;
 
 class AuthenticatorSelectionCriteria
 {

--- a/src/webauthn/src/CeremonyStep/CeremonyStep.php
+++ b/src/webauthn/src/CeremonyStep/CeremonyStep.php
@@ -9,12 +9,11 @@ use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
-use Webauthn\PublicKeyCredentialSource;
 
 interface CeremonyStep
 {
     public function process(
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
         PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
         ?string $userHandle,

--- a/src/webauthn/src/CeremonyStep/CeremonyStepManager.php
+++ b/src/webauthn/src/CeremonyStep/CeremonyStepManager.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Webauthn\CeremonyStep;
 
+use function trigger_deprecation;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
-use function trigger_deprecation;
 
 final readonly class CeremonyStepManager
 {
@@ -23,7 +23,7 @@ final readonly class CeremonyStepManager
     }
 
     public function process(
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
         PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
         ?string $userHandle,

--- a/src/webauthn/src/CeremonyStep/CheckAlgorithm.php
+++ b/src/webauthn/src/CeremonyStep/CheckAlgorithm.php
@@ -8,6 +8,11 @@ use CBOR\Decoder;
 use CBOR\Normalizable;
 use Cose\Algorithms;
 use Cose\Key\Key;
+use function count;
+use function in_array;
+use function is_array;
+use function sprintf;
+use function trigger_deprecation;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\CredentialRecord;
@@ -17,16 +22,11 @@ use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
 use Webauthn\StringStream;
 use Webauthn\U2FPublicKey;
-use function count;
-use function in_array;
-use function is_array;
-use function sprintf;
-use function trigger_deprecation;
 
 class CheckAlgorithm implements CeremonyStep
 {
     public function process(
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
         PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
         ?string $userHandle,

--- a/src/webauthn/src/CeremonyStep/CheckAllowedCredentialList.php
+++ b/src/webauthn/src/CeremonyStep/CheckAllowedCredentialList.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Webauthn\CeremonyStep;
 
+use function count;
+use function trigger_deprecation;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\CredentialRecord;
@@ -11,13 +13,11 @@ use Webauthn\Exception\AuthenticatorResponseVerificationException;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
-use function count;
-use function trigger_deprecation;
 
 final class CheckAllowedCredentialList implements CeremonyStep
 {
     public function process(
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
         PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
         ?string $userHandle,

--- a/src/webauthn/src/CeremonyStep/CheckAllowedOrigins.php
+++ b/src/webauthn/src/CeremonyStep/CheckAllowedOrigins.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace Webauthn\CeremonyStep;
 
+use function count;
+use function in_array;
 use InvalidArgumentException;
+use function is_array;
+use function is_string;
+use function sprintf;
+use function trigger_deprecation;
 use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
@@ -13,12 +19,6 @@ use Webauthn\Exception\AuthenticatorResponseVerificationException;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
-use function count;
-use function in_array;
-use function is_array;
-use function is_string;
-use function sprintf;
-use function trigger_deprecation;
 
 final readonly class CheckAllowedOrigins implements CeremonyStep
 {
@@ -52,7 +52,7 @@ final readonly class CheckAllowedOrigins implements CeremonyStep
     }
 
     public function process(
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
         PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
         ?string $userHandle,

--- a/src/webauthn/src/CeremonyStep/CheckAttestationFormatIsKnownAndValid.php
+++ b/src/webauthn/src/CeremonyStep/CheckAttestationFormatIsKnownAndValid.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\CeremonyStep;
 
+use function trigger_deprecation;
 use Webauthn\AttestationStatement\AttestationStatementSupportManager;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
@@ -12,7 +13,6 @@ use Webauthn\Exception\AuthenticatorResponseVerificationException;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
-use function trigger_deprecation;
 
 final readonly class CheckAttestationFormatIsKnownAndValid implements CeremonyStep
 {
@@ -22,7 +22,7 @@ final readonly class CheckAttestationFormatIsKnownAndValid implements CeremonySt
     }
 
     public function process(
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
         PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
         ?string $userHandle,

--- a/src/webauthn/src/CeremonyStep/CheckBackupBitsAreConsistent.php
+++ b/src/webauthn/src/CeremonyStep/CheckBackupBitsAreConsistent.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\CeremonyStep;
 
+use function trigger_deprecation;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\CredentialRecord;
@@ -11,12 +12,11 @@ use Webauthn\Exception\AuthenticatorResponseVerificationException;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
-use function trigger_deprecation;
 
 final class CheckBackupBitsAreConsistent implements CeremonyStep
 {
     public function process(
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
         PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
         ?string $userHandle,

--- a/src/webauthn/src/CeremonyStep/CheckChallenge.php
+++ b/src/webauthn/src/CeremonyStep/CheckChallenge.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\CeremonyStep;
 
+use function trigger_deprecation;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\CredentialRecord;
@@ -11,12 +12,11 @@ use Webauthn\Exception\AuthenticatorResponseVerificationException;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
-use function trigger_deprecation;
 
 final class CheckChallenge implements CeremonyStep
 {
     public function process(
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
         PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
         ?string $userHandle,

--- a/src/webauthn/src/CeremonyStep/CheckClientDataCollectorType.php
+++ b/src/webauthn/src/CeremonyStep/CheckClientDataCollectorType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\CeremonyStep;
 
+use function trigger_deprecation;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\ClientDataCollector\ClientDataCollectorManager;
@@ -12,7 +13,6 @@ use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
-use function trigger_deprecation;
 
 final readonly class CheckClientDataCollectorType implements CeremonyStep
 {
@@ -26,7 +26,7 @@ final readonly class CheckClientDataCollectorType implements CeremonyStep
     }
 
     public function process(
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
         PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
         ?string $userHandle,

--- a/src/webauthn/src/CeremonyStep/CheckCounter.php
+++ b/src/webauthn/src/CeremonyStep/CheckCounter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\CeremonyStep;
 
+use function trigger_deprecation;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\Counter\CounterChecker;
@@ -11,7 +12,6 @@ use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
-use function trigger_deprecation;
 
 final readonly class CheckCounter implements CeremonyStep
 {
@@ -21,7 +21,7 @@ final readonly class CheckCounter implements CeremonyStep
     }
 
     public function process(
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
         PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
         ?string $userHandle,

--- a/src/webauthn/src/CeremonyStep/CheckCredentialId.php
+++ b/src/webauthn/src/CeremonyStep/CheckCredentialId.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Webauthn\CeremonyStep;
 
+use function strlen;
+use function trigger_deprecation;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\CredentialRecord;
@@ -11,13 +13,11 @@ use Webauthn\Exception\AuthenticatorResponseVerificationException;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
-use function strlen;
-use function trigger_deprecation;
 
 class CheckCredentialId implements CeremonyStep
 {
     public function process(
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
         PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
         ?string $userHandle,

--- a/src/webauthn/src/CeremonyStep/CheckExtensions.php
+++ b/src/webauthn/src/CeremonyStep/CheckExtensions.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\CeremonyStep;
 
+use function trigger_deprecation;
 use Webauthn\AuthenticationExtensions\ExtensionOutputCheckerHandler;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
@@ -11,7 +12,6 @@ use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
-use function trigger_deprecation;
 
 final readonly class CheckExtensions implements CeremonyStep
 {
@@ -21,7 +21,7 @@ final readonly class CheckExtensions implements CeremonyStep
     }
 
     public function process(
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
         PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
         ?string $userHandle,

--- a/src/webauthn/src/CeremonyStep/CheckHasAttestedCredentialData.php
+++ b/src/webauthn/src/CeremonyStep/CheckHasAttestedCredentialData.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\CeremonyStep;
 
+use function trigger_deprecation;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\CredentialRecord;
@@ -11,12 +12,11 @@ use Webauthn\Exception\AuthenticatorResponseVerificationException;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
-use function trigger_deprecation;
 
 final class CheckHasAttestedCredentialData implements CeremonyStep
 {
     public function process(
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
         PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
         ?string $userHandle,

--- a/src/webauthn/src/CeremonyStep/CheckMetadataStatement.php
+++ b/src/webauthn/src/CeremonyStep/CheckMetadataStatement.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace Webauthn\CeremonyStep;
 
+use function count;
+use function in_array;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use function sprintf;
+use function trigger_deprecation;
 use Webauthn\AttestationStatement\AttestationStatement;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
@@ -21,10 +25,6 @@ use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
 use Webauthn\TrustPath\CertificateTrustPath;
-use function count;
-use function in_array;
-use function sprintf;
-use function trigger_deprecation;
 
 final class CheckMetadataStatement implements CeremonyStep, CanLogData
 {
@@ -62,7 +62,7 @@ final class CheckMetadataStatement implements CeremonyStep, CanLogData
     }
 
     public function process(
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
         PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
         ?string $userHandle,

--- a/src/webauthn/src/CeremonyStep/CheckOrigin.php
+++ b/src/webauthn/src/CeremonyStep/CheckOrigin.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Webauthn\CeremonyStep;
 
+use function in_array;
+use function is_array;
+use function is_string;
+use function strlen;
+use function trigger_deprecation;
 use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
@@ -12,11 +17,6 @@ use Webauthn\Exception\AuthenticatorResponseVerificationException;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
-use function in_array;
-use function is_array;
-use function is_string;
-use function strlen;
-use function trigger_deprecation;
 
 /**
  * @deprecated since 5.2.0 and will be removed in 6.0.0. Will be replaced by CheckAllowedOrigins
@@ -32,7 +32,7 @@ final readonly class CheckOrigin implements CeremonyStep
     }
 
     public function process(
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
         PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
         ?string $userHandle,

--- a/src/webauthn/src/CeremonyStep/CheckRelyingPartyIdIdHash.php
+++ b/src/webauthn/src/CeremonyStep/CheckRelyingPartyIdIdHash.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Webauthn\CeremonyStep;
 
+use function is_string;
+use function trigger_deprecation;
 use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
@@ -13,13 +15,11 @@ use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
 use Webauthn\U2FPublicKey;
-use function is_string;
-use function trigger_deprecation;
 
 final class CheckRelyingPartyIdIdHash implements CeremonyStep
 {
     public function process(
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
         PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
         ?string $userHandle,

--- a/src/webauthn/src/CeremonyStep/CheckSignature.php
+++ b/src/webauthn/src/CeremonyStep/CheckSignature.php
@@ -11,6 +11,8 @@ use Cose\Algorithm\Signature\ECDSA\ES256;
 use Cose\Algorithm\Signature\RSA\RS256;
 use Cose\Algorithm\Signature\Signature;
 use Cose\Key\Key;
+use function is_array;
+use function trigger_deprecation;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\CredentialRecord;
@@ -21,8 +23,6 @@ use Webauthn\PublicKeyCredentialSource;
 use Webauthn\StringStream;
 use Webauthn\U2FPublicKey;
 use Webauthn\Util\CoseSignatureFixer;
-use function is_array;
-use function trigger_deprecation;
 
 final readonly class CheckSignature implements CeremonyStep
 {
@@ -34,7 +34,7 @@ final readonly class CheckSignature implements CeremonyStep
     }
 
     public function process(
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
         PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
         ?string $userHandle,

--- a/src/webauthn/src/CeremonyStep/CheckTopOrigin.php
+++ b/src/webauthn/src/CeremonyStep/CheckTopOrigin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\CeremonyStep;
 
+use function trigger_deprecation;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\CredentialRecord;
@@ -11,7 +12,6 @@ use Webauthn\Exception\AuthenticatorResponseVerificationException;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
-use function trigger_deprecation;
 
 class CheckTopOrigin implements CeremonyStep
 {
@@ -21,7 +21,7 @@ class CheckTopOrigin implements CeremonyStep
     }
 
     public function process(
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
         PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
         ?string $userHandle,

--- a/src/webauthn/src/CeremonyStep/CheckUserHandle.php
+++ b/src/webauthn/src/CeremonyStep/CheckUserHandle.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\CeremonyStep;
 
+use function trigger_deprecation;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\CredentialRecord;
@@ -11,12 +12,11 @@ use Webauthn\Exception\InvalidUserHandleException;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
-use function trigger_deprecation;
 
 final class CheckUserHandle implements CeremonyStep
 {
     public function process(
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
         PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
         ?string $userHandle,

--- a/src/webauthn/src/CeremonyStep/CheckUserVerification.php
+++ b/src/webauthn/src/CeremonyStep/CheckUserVerification.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\CeremonyStep;
 
+use function trigger_deprecation;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\AuthenticatorSelectionCriteria;
@@ -12,12 +13,11 @@ use Webauthn\Exception\AuthenticatorResponseVerificationException;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
-use function trigger_deprecation;
 
 final class CheckUserVerification implements CeremonyStep
 {
     public function process(
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
         PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
         ?string $userHandle,

--- a/src/webauthn/src/CeremonyStep/CheckUserWasPresent.php
+++ b/src/webauthn/src/CeremonyStep/CheckUserWasPresent.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\CeremonyStep;
 
+use function trigger_deprecation;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\CredentialRecord;
@@ -11,7 +12,6 @@ use Webauthn\Exception\AuthenticatorResponseVerificationException;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
-use function trigger_deprecation;
 
 /**
  * Conditional check for user presence
@@ -29,7 +29,7 @@ final readonly class CheckUserWasPresent implements CeremonyStep
     }
 
     public function process(
-        CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
         PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
         ?string $userHandle,

--- a/src/webauthn/src/ClientDataCollector/ClientDataCollectorManager.php
+++ b/src/webauthn/src/ClientDataCollector/ClientDataCollectorManager.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Webauthn\ClientDataCollector;
 
+use function in_array;
 use Webauthn\AuthenticatorResponse;
 use Webauthn\CollectedClientData;
 use Webauthn\Exception\AuthenticatorResponseVerificationException;
 use Webauthn\PublicKeyCredentialOptions;
-use function in_array;
 
 final readonly class ClientDataCollectorManager
 {

--- a/src/webauthn/src/ClientDataCollector/WebauthnAuthenticationCollector.php
+++ b/src/webauthn/src/ClientDataCollector/WebauthnAuthenticationCollector.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Webauthn\ClientDataCollector;
 
+use function in_array;
+use function sprintf;
 use Webauthn\AuthenticatorResponse;
 use Webauthn\CollectedClientData;
 use Webauthn\Exception\AuthenticatorResponseVerificationException;
 use Webauthn\PublicKeyCredentialOptions;
-use function in_array;
-use function sprintf;
 
 final class WebauthnAuthenticationCollector implements ClientDataCollector
 {

--- a/src/webauthn/src/CollectedClientData.php
+++ b/src/webauthn/src/CollectedClientData.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Webauthn;
 
-use ParagonIE\ConstantTime\Base64UrlSafe;
-use Webauthn\Exception\InvalidDataException;
 use function array_key_exists;
 use function is_array;
 use function is_string;
-use function sprintf;
 use const JSON_THROW_ON_ERROR;
+use ParagonIE\ConstantTime\Base64UrlSafe;
+use function sprintf;
+use Webauthn\Exception\InvalidDataException;
 
 class CollectedClientData
 {

--- a/src/webauthn/src/Counter/CounterChecker.php
+++ b/src/webauthn/src/Counter/CounterChecker.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace Webauthn\Counter;
 
 use Webauthn\CredentialRecord;
-use Webauthn\PublicKeyCredentialSource;
 
 interface CounterChecker
 {
-    public function check(CredentialRecord|PublicKeyCredentialSource $credentialRecord, int $currentCounter): void;
+    public function check(CredentialRecord $credentialRecord, int $currentCounter): void;
 }

--- a/src/webauthn/src/Counter/ThrowExceptionIfInvalid.php
+++ b/src/webauthn/src/Counter/ThrowExceptionIfInvalid.php
@@ -6,11 +6,11 @@ namespace Webauthn\Counter;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use function trigger_deprecation;
 use Webauthn\CredentialRecord;
 use Webauthn\Exception\CounterException;
 use Webauthn\MetadataService\CanLogData;
 use Webauthn\PublicKeyCredentialSource;
-use function trigger_deprecation;
 
 final class ThrowExceptionIfInvalid implements CounterChecker, CanLogData
 {
@@ -24,7 +24,7 @@ final class ThrowExceptionIfInvalid implements CounterChecker, CanLogData
         $this->logger = $logger;
     }
 
-    public function check(CredentialRecord|PublicKeyCredentialSource $credentialRecord, int $currentCounter): void
+    public function check(CredentialRecord $credentialRecord, int $currentCounter): void
     {
         if ($credentialRecord instanceof PublicKeyCredentialSource) {
             trigger_deprecation(

--- a/src/webauthn/src/Denormalizer/AttestedCredentialDataNormalizer.php
+++ b/src/webauthn/src/Denormalizer/AttestedCredentialDataNormalizer.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Webauthn\Denormalizer;
 
+use function assert;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Webauthn\AttestedCredentialData;
-use function assert;
 
 final class AttestedCredentialDataNormalizer implements NormalizerInterface, NormalizerAwareInterface
 {

--- a/src/webauthn/src/Denormalizer/AuthenticationExtensionNormalizer.php
+++ b/src/webauthn/src/Denormalizer/AuthenticationExtensionNormalizer.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Webauthn\Denormalizer;
 
+use function assert;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Webauthn\AuthenticationExtensions\AuthenticationExtension;
-use function assert;
 
 final class AuthenticationExtensionNormalizer implements NormalizerInterface
 {

--- a/src/webauthn/src/Denormalizer/AuthenticationExtensionsDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/AuthenticationExtensionsDenormalizer.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Webauthn\Denormalizer;
 
+use function assert;
+use function is_array;
+use function is_string;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Webauthn\AuthenticationExtensions\AuthenticationExtension;
 use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
-use function assert;
-use function is_array;
-use function is_string;
 
 final class AuthenticationExtensionsDenormalizer implements DenormalizerInterface, NormalizerInterface
 {

--- a/src/webauthn/src/Denormalizer/AuthenticatorDataDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/AuthenticatorDataDenormalizer.php
@@ -11,6 +11,8 @@ use CBOR\MapObject;
 use CBOR\NegativeIntegerObject;
 use CBOR\TextStringObject;
 use CBOR\UnsignedIntegerObject;
+use function chr;
+use function ord;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -21,8 +23,6 @@ use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
 use Webauthn\AuthenticatorData;
 use Webauthn\Exception\InvalidDataException;
 use Webauthn\StringStream;
-use function chr;
-use function ord;
 
 final class AuthenticatorDataDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface
 {

--- a/src/webauthn/src/Denormalizer/AuthenticatorResponseDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/AuthenticatorResponseDenormalizer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\Denormalizer;
 
+use function array_key_exists;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -11,7 +12,6 @@ use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\AuthenticatorResponse;
 use Webauthn\Exception\InvalidDataException;
-use function array_key_exists;
 
 final class AuthenticatorResponseDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface
 {

--- a/src/webauthn/src/Denormalizer/CollectedClientDataDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/CollectedClientDataDenormalizer.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Webauthn\Denormalizer;
 
+use const JSON_THROW_ON_ERROR;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Webauthn\CollectedClientData;
-use const JSON_THROW_ON_ERROR;
 
 final class CollectedClientDataDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface
 {

--- a/src/webauthn/src/Denormalizer/CredentialRecordDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/CredentialRecordDenormalizer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Webauthn\Denormalizer;
 
+use function array_key_exists;
+use function assert;
 use ParagonIE\ConstantTime\Base64UrlSafe;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
@@ -16,8 +18,6 @@ use Webauthn\CredentialRecord;
 use Webauthn\Exception\InvalidDataException;
 use Webauthn\TrustPath\TrustPath;
 use Webauthn\Util\Base64;
-use function array_key_exists;
-use function assert;
 
 /**
  * @final

--- a/src/webauthn/src/Denormalizer/ExtensionDescriptorDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/ExtensionDescriptorDenormalizer.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Webauthn\Denormalizer;
 
+use function array_key_exists;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Webauthn\MetadataService\Statement\ExtensionDescriptor;
-use function array_key_exists;
 
 final class ExtensionDescriptorDenormalizer implements DenormalizerInterface
 {

--- a/src/webauthn/src/Denormalizer/PublicKeyCredentialDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/PublicKeyCredentialDenormalizer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\Denormalizer;
 
+use function array_key_exists;
 use ParagonIE\ConstantTime\Base64UrlSafe;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
@@ -12,7 +13,6 @@ use Webauthn\AuthenticatorResponse;
 use Webauthn\Exception\InvalidDataException;
 use Webauthn\PublicKeyCredential;
 use Webauthn\Util\Base64;
-use function array_key_exists;
 
 final class PublicKeyCredentialDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface
 {

--- a/src/webauthn/src/Denormalizer/PublicKeyCredentialDescriptorNormalizer.php
+++ b/src/webauthn/src/Denormalizer/PublicKeyCredentialDescriptorNormalizer.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Webauthn\Denormalizer;
 
+use function assert;
+use function count;
 use ParagonIE\ConstantTime\Base64UrlSafe;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Webauthn\PublicKeyCredentialDescriptor;
-use function assert;
-use function count;
 
 final class PublicKeyCredentialDescriptorNormalizer implements NormalizerInterface, NormalizerAwareInterface
 {

--- a/src/webauthn/src/Denormalizer/PublicKeyCredentialOptionsDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/PublicKeyCredentialOptionsDenormalizer.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Webauthn\Denormalizer;
 
+use function array_key_exists;
+use function assert;
+use function count;
+use function in_array;
 use ParagonIE\ConstantTime\Base64UrlSafe;
 use Symfony\Component\Serializer\Exception\BadMethodCallException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
@@ -20,10 +24,6 @@ use Webauthn\PublicKeyCredentialParameters;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialRpEntity;
 use Webauthn\PublicKeyCredentialUserEntity;
-use function array_key_exists;
-use function assert;
-use function count;
-use function in_array;
 
 final class PublicKeyCredentialOptionsDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface, NormalizerInterface, NormalizerAwareInterface
 {

--- a/src/webauthn/src/Denormalizer/PublicKeyCredentialParametersDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/PublicKeyCredentialParametersDenormalizer.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Webauthn\Denormalizer;
 
+use function array_key_exists;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Webauthn\Exception\InvalidDataException;
 use Webauthn\PublicKeyCredentialParameters;
-use function array_key_exists;
 
 final class PublicKeyCredentialParametersDenormalizer implements DenormalizerInterface
 {

--- a/src/webauthn/src/Denormalizer/PublicKeyCredentialRpEntityDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/PublicKeyCredentialRpEntityDenormalizer.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Webauthn\Denormalizer;
 
+use function assert;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Webauthn\PublicKeyCredentialRpEntity;
-use function assert;
 
 final class PublicKeyCredentialRpEntityDenormalizer implements NormalizerInterface
 {

--- a/src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Webauthn\Denormalizer;
 
+use function array_key_exists;
+use function assert;
 use ParagonIE\ConstantTime\Base64UrlSafe;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
@@ -16,8 +18,6 @@ use Webauthn\Exception\InvalidDataException;
 use Webauthn\PublicKeyCredentialSource;
 use Webauthn\TrustPath\TrustPath;
 use Webauthn\Util\Base64;
-use function array_key_exists;
-use function assert;
 
 final class PublicKeyCredentialSourceDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface, NormalizerInterface, NormalizerAwareInterface
 {

--- a/src/webauthn/src/Denormalizer/PublicKeyCredentialUserEntityDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/PublicKeyCredentialUserEntityDenormalizer.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Webauthn\Denormalizer;
 
+use function array_key_exists;
+use function assert;
 use ParagonIE\ConstantTime\Base64UrlSafe;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Webauthn\PublicKeyCredentialUserEntity;
 use Webauthn\Util\Base64;
-use function array_key_exists;
-use function assert;
 
 final class PublicKeyCredentialUserEntityDenormalizer implements DenormalizerInterface, NormalizerInterface
 {

--- a/src/webauthn/src/Denormalizer/SignalAllAcceptedCredentialsDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/SignalAllAcceptedCredentialsDenormalizer.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Webauthn\Denormalizer;
 
+use function assert;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Webauthn\PublicKeyCredentialDescriptor;
 use Webauthn\Signal\AllAcceptedCredentials;
-use function assert;
 
 class SignalAllAcceptedCredentialsDenormalizer implements NormalizerInterface, NormalizerAwareInterface
 {

--- a/src/webauthn/src/Denormalizer/SignalCurrentUserDetailsDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/SignalCurrentUserDetailsDenormalizer.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Webauthn\Denormalizer;
 
+use function assert;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Webauthn\Signal\CurrentUserDetails;
-use function assert;
 
 class SignalCurrentUserDetailsDenormalizer implements NormalizerInterface, NormalizerAwareInterface
 {

--- a/src/webauthn/src/Denormalizer/SignalUnknownCredentialDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/SignalUnknownCredentialDenormalizer.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Webauthn\Denormalizer;
 
+use function assert;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Webauthn\Signal\UnknownCredential;
-use function assert;
 
 class SignalUnknownCredentialDenormalizer implements NormalizerInterface, NormalizerAwareInterface
 {

--- a/src/webauthn/src/Denormalizer/TrustPathDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/TrustPathDenormalizer.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Webauthn\Denormalizer;
 
+use function array_key_exists;
+use function assert;
+use function is_array;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Webauthn\Exception\InvalidTrustPathException;
 use Webauthn\TrustPath\CertificateTrustPath;
 use Webauthn\TrustPath\EmptyTrustPath;
 use Webauthn\TrustPath\TrustPath;
-use function array_key_exists;
-use function assert;
-use function is_array;
 
 final class TrustPathDenormalizer implements DenormalizerInterface, NormalizerInterface
 {

--- a/src/webauthn/src/Denormalizer/UrlNormalizer.php
+++ b/src/webauthn/src/Denormalizer/UrlNormalizer.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Webauthn\Denormalizer;
 
+use function assert;
+use const FILTER_VALIDATE_URL;
+use function filter_var;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Throwable;
 use Webauthn\Url;
-use function assert;
-use function filter_var;
-use const FILTER_VALIDATE_URL;
 
 /**
  * Normalizes Url objects to absolute HTTPS URLs.

--- a/src/webauthn/src/Denormalizer/VerificationMethodANDCombinationsDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/VerificationMethodANDCombinationsDenormalizer.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Webauthn\Denormalizer;
 
+use function assert;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Webauthn\MetadataService\Statement\VerificationMethodANDCombinations;
 use Webauthn\MetadataService\Statement\VerificationMethodDescriptor;
-use function assert;
 
 final class VerificationMethodANDCombinationsDenormalizer implements NormalizerInterface, NormalizerAwareInterface
 {

--- a/src/webauthn/src/Denormalizer/WebauthnSerializerFactory.php
+++ b/src/webauthn/src/Denormalizer/WebauthnSerializerFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Webauthn\Denormalizer;
 
 use RuntimeException;
+use function sprintf;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
@@ -16,7 +17,6 @@ use Symfony\Component\Serializer\Normalizer\UidNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerInterface;
 use Webauthn\AttestationStatement\AttestationStatementSupportManager;
-use function sprintf;
 
 final readonly class WebauthnSerializerFactory
 {

--- a/src/webauthn/src/Event/AuthenticatorAssertionResponseValidationFailedEvent.php
+++ b/src/webauthn/src/Event/AuthenticatorAssertionResponseValidationFailedEvent.php
@@ -5,17 +5,17 @@ declare(strict_types=1);
 namespace Webauthn\Event;
 
 use LogicException;
+use function sprintf;
 use Throwable;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
-use function sprintf;
 
 class AuthenticatorAssertionResponseValidationFailedEvent
 {
     public function __construct(
-        public readonly CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        public readonly CredentialRecord $credentialRecord,
         public readonly AuthenticatorAssertionResponse $authenticatorAssertionResponse,
         public readonly PublicKeyCredentialRequestOptions $publicKeyCredentialRequestOptions,
         public readonly string $host,
@@ -45,7 +45,7 @@ class AuthenticatorAssertionResponseValidationFailedEvent
             return $this->credentialRecord;
         }
 
-        return PublicKeyCredentialSource::create(
+        return new PublicKeyCredentialSource(
             $this->credentialRecord->publicKeyCredentialId,
             $this->credentialRecord->type,
             $this->credentialRecord->transports,

--- a/src/webauthn/src/Event/AuthenticatorAssertionResponseValidationSucceededEvent.php
+++ b/src/webauthn/src/Event/AuthenticatorAssertionResponseValidationSucceededEvent.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Webauthn\Event;
 
 use LogicException;
+use function sprintf;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
-use function sprintf;
 
 class AuthenticatorAssertionResponseValidationSucceededEvent
 {
@@ -18,7 +18,7 @@ class AuthenticatorAssertionResponseValidationSucceededEvent
         public readonly PublicKeyCredentialRequestOptions $publicKeyCredentialRequestOptions,
         public readonly string $host,
         public readonly ?string $userHandle,
-        public readonly CredentialRecord|PublicKeyCredentialSource $credentialRecord
+        public readonly CredentialRecord $credentialRecord
     ) {
     }
 
@@ -43,7 +43,7 @@ class AuthenticatorAssertionResponseValidationSucceededEvent
             return $this->credentialRecord;
         }
 
-        return PublicKeyCredentialSource::create(
+        return new PublicKeyCredentialSource(
             $this->credentialRecord->publicKeyCredentialId,
             $this->credentialRecord->type,
             $this->credentialRecord->transports,

--- a/src/webauthn/src/Event/AuthenticatorAttestationResponseValidationSucceededEvent.php
+++ b/src/webauthn/src/Event/AuthenticatorAttestationResponseValidationSucceededEvent.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Webauthn\Event;
 
 use LogicException;
+use function sprintf;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialSource;
-use function sprintf;
 
 class AuthenticatorAttestationResponseValidationSucceededEvent
 {
@@ -17,7 +17,7 @@ class AuthenticatorAttestationResponseValidationSucceededEvent
         public readonly AuthenticatorAttestationResponse $authenticatorAttestationResponse,
         public readonly PublicKeyCredentialCreationOptions $publicKeyCredentialCreationOptions,
         public readonly string $host,
-        public readonly CredentialRecord|PublicKeyCredentialSource $credentialRecord
+        public readonly CredentialRecord $credentialRecord
     ) {
     }
 
@@ -42,7 +42,7 @@ class AuthenticatorAttestationResponseValidationSucceededEvent
             return $this->credentialRecord;
         }
 
-        return PublicKeyCredentialSource::create(
+        return new PublicKeyCredentialSource(
             $this->credentialRecord->publicKeyCredentialId,
             $this->credentialRecord->type,
             $this->credentialRecord->transports,

--- a/src/webauthn/src/Event/BackupEligibilityChangedEvent.php
+++ b/src/webauthn/src/Event/BackupEligibilityChangedEvent.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Webauthn\Event;
 
 use LogicException;
+use function sprintf;
 use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredentialSource;
-use function sprintf;
 
 /**
  * Event dispatched when the backup eligibility flag (BE) changes.
@@ -18,7 +18,7 @@ use function sprintf;
 final readonly class BackupEligibilityChangedEvent implements WebauthnEvent
 {
     public function __construct(
-        public CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        public CredentialRecord $credentialRecord,
         public ?bool $previousValue,
         public ?bool $newValue
     ) {
@@ -45,7 +45,7 @@ final readonly class BackupEligibilityChangedEvent implements WebauthnEvent
             return $this->credentialRecord;
         }
 
-        return PublicKeyCredentialSource::create(
+        return new PublicKeyCredentialSource(
             $this->credentialRecord->publicKeyCredentialId,
             $this->credentialRecord->type,
             $this->credentialRecord->transports,

--- a/src/webauthn/src/Event/BackupStatusChangedEvent.php
+++ b/src/webauthn/src/Event/BackupStatusChangedEvent.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Webauthn\Event;
 
 use LogicException;
+use function sprintf;
 use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredentialSource;
-use function sprintf;
 
 /**
  * Event dispatched when the backup status flag (BS) changes.
@@ -19,7 +19,7 @@ use function sprintf;
 final readonly class BackupStatusChangedEvent implements WebauthnEvent
 {
     public function __construct(
-        public CredentialRecord|PublicKeyCredentialSource $credentialRecord,
+        public CredentialRecord $credentialRecord,
         public ?bool $previousValue,
         public ?bool $newValue
     ) {
@@ -46,7 +46,7 @@ final readonly class BackupStatusChangedEvent implements WebauthnEvent
             return $this->credentialRecord;
         }
 
-        return PublicKeyCredentialSource::create(
+        return new PublicKeyCredentialSource(
             $this->credentialRecord->publicKeyCredentialId,
             $this->credentialRecord->type,
             $this->credentialRecord->transports,

--- a/src/webauthn/src/MetadataService/CertificateChain/PhpCertificateChainValidator.php
+++ b/src/webauthn/src/MetadataService/CertificateChain/PhpCertificateChainValidator.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Webauthn\MetadataService\CertificateChain;
 
+use function count;
+use function in_array;
+use function parse_url;
+use const PHP_EOL;
+use const PHP_URL_SCHEME;
 use Psr\Clock\ClockInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use SpomkyLabs\Pki\ASN1\Type\UnspecifiedType;
@@ -11,6 +16,7 @@ use SpomkyLabs\Pki\CryptoEncoding\PEM;
 use SpomkyLabs\Pki\X509\Certificate\Certificate;
 use SpomkyLabs\Pki\X509\CertificationPath\CertificationPath;
 use SpomkyLabs\Pki\X509\CertificationPath\PathValidation\PathValidationConfig;
+use function sprintf;
 use Symfony\Component\Clock\NativeClock;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Throwable;
@@ -22,12 +28,6 @@ use Webauthn\Event\NullEventDispatcher;
 use Webauthn\Exception\CertificateChainException;
 use Webauthn\Exception\CertificateRevocationListException;
 use Webauthn\Exception\InvalidCertificateException;
-use function count;
-use function in_array;
-use function parse_url;
-use function sprintf;
-use const PHP_EOL;
-use const PHP_URL_SCHEME;
 
 final class PhpCertificateChainValidator implements CertificateChainValidator, CanDispatchEvents
 {

--- a/src/webauthn/src/MetadataService/Psr18HttpClient.php
+++ b/src/webauthn/src/MetadataService/Psr18HttpClient.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Webauthn\MetadataService;
 
+use function is_array;
+use const JSON_ERROR_NONE;
 use JsonException;
 use LogicException;
+use const PHP_QUERY_RFC3986;
 use Psr\Http\Client\ClientInterface as Psr18ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface as Psr17RequestFactoryInterface;
 use Psr\Http\Message\ResponseInterface as Psr17ResponseInterface;
@@ -13,9 +16,6 @@ use Psr\Http\Message\StreamFactoryInterface as Psr17StreamFactoryInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Symfony\Contracts\HttpClient\ResponseStreamInterface;
-use function is_array;
-use const JSON_ERROR_NONE;
-use const PHP_QUERY_RFC3986;
 
 class Psr18HttpClient implements HttpClientInterface
 {

--- a/src/webauthn/src/MetadataService/Service/DistantResourceMetadataService.php
+++ b/src/webauthn/src/MetadataService/Service/DistantResourceMetadataService.php
@@ -6,6 +6,7 @@ namespace Webauthn\MetadataService\Service;
 
 use ParagonIE\ConstantTime\Base64;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use function sprintf;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -17,7 +18,6 @@ use Webauthn\Event\NullEventDispatcher;
 use Webauthn\Exception\MetadataStatementLoadingException;
 use Webauthn\Exception\MissingMetadataStatementException;
 use Webauthn\MetadataService\Statement\MetadataStatement;
-use function sprintf;
 
 final class DistantResourceMetadataService implements MetadataService, CanDispatchEvents
 {

--- a/src/webauthn/src/MetadataService/Service/FidoAllianceCompliantMetadataService.php
+++ b/src/webauthn/src/MetadataService/Service/FidoAllianceCompliantMetadataService.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Webauthn\MetadataService\Service;
 
+use function array_key_exists;
+use function is_array;
 use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\KeyManagement\JWKFactory;
 use Jose\Component\Signature\Algorithm\ES256;
@@ -12,6 +14,7 @@ use Jose\Component\Signature\JWSVerifier;
 use Jose\Component\Signature\Serializer\CompactSerializer;
 use LogicException;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use function sprintf;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -27,9 +30,6 @@ use Webauthn\MetadataService\CertificateChain\CertificateChainValidator;
 use Webauthn\MetadataService\CertificateChain\CertificateToolbox;
 use Webauthn\MetadataService\Statement\MetadataStatement;
 use Webauthn\MetadataService\Statement\StatusReport;
-use function array_key_exists;
-use function is_array;
-use function sprintf;
 
 final class FidoAllianceCompliantMetadataService implements MetadataService, CanDispatchEvents
 {

--- a/src/webauthn/src/MetadataService/Service/FolderResourceMetadataService.php
+++ b/src/webauthn/src/MetadataService/Service/FolderResourceMetadataService.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 
 namespace Webauthn\MetadataService\Service;
 
+use function assert;
+use const DIRECTORY_SEPARATOR;
+use function file_get_contents;
 use InvalidArgumentException;
+use function is_array;
+use function sprintf;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\SerializerInterface;
 use Webauthn\AttestationStatement\AttestationStatementSupportManager;
 use Webauthn\Denormalizer\WebauthnSerializerFactory;
 use Webauthn\Exception\MetadataStatementLoadingException;
 use Webauthn\MetadataService\Statement\MetadataStatement;
-use function assert;
-use function file_get_contents;
-use function is_array;
-use function sprintf;
-use const DIRECTORY_SEPARATOR;
 
 final class FolderResourceMetadataService implements MetadataService
 {

--- a/src/webauthn/src/MetadataService/Service/InMemoryMetadataService.php
+++ b/src/webauthn/src/MetadataService/Service/InMemoryMetadataService.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Webauthn\MetadataService\Service;
 
+use function array_key_exists;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Webauthn\Event\CanDispatchEvents;
 use Webauthn\Event\MetadataStatementFound;
 use Webauthn\Event\NullEventDispatcher;
 use Webauthn\Exception\MissingMetadataStatementException;
 use Webauthn\MetadataService\Statement\MetadataStatement;
-use function array_key_exists;
 
 final class InMemoryMetadataService implements MetadataService, CanDispatchEvents
 {

--- a/src/webauthn/src/MetadataService/Service/JsonMetadataService.php
+++ b/src/webauthn/src/MetadataService/Service/JsonMetadataService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\MetadataService\Service;
 
+use function array_key_exists;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -14,7 +15,6 @@ use Webauthn\Event\MetadataStatementFound;
 use Webauthn\Event\NullEventDispatcher;
 use Webauthn\Exception\MissingMetadataStatementException;
 use Webauthn\MetadataService\Statement\MetadataStatement;
-use function array_key_exists;
 
 final class JsonMetadataService implements MetadataService, CanDispatchEvents
 {

--- a/src/webauthn/src/MetadataService/Service/LocalResourceMetadataService.php
+++ b/src/webauthn/src/MetadataService/Service/LocalResourceMetadataService.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Webauthn\MetadataService\Service;
 
+use function assert;
+use function file_get_contents;
 use ParagonIE\ConstantTime\Base64;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -16,8 +18,6 @@ use Webauthn\Event\NullEventDispatcher;
 use Webauthn\Exception\MetadataStatementLoadingException;
 use Webauthn\Exception\MissingMetadataStatementException;
 use Webauthn\MetadataService\Statement\MetadataStatement;
-use function assert;
-use function file_get_contents;
 
 final class LocalResourceMetadataService implements MetadataService, CanDispatchEvents
 {

--- a/src/webauthn/src/MetadataService/Service/MetadataBLOBPayloadEntry.php
+++ b/src/webauthn/src/MetadataService/Service/MetadataBLOBPayloadEntry.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Webauthn\MetadataService\Service;
 
+use function count;
+use function is_string;
 use Webauthn\Exception\MetadataStatementLoadingException;
 use Webauthn\MetadataService\Statement\BiometricStatusReport;
 use Webauthn\MetadataService\Statement\MetadataStatement;
 use Webauthn\MetadataService\Statement\StatusReport;
-use function count;
-use function is_string;
 
 class MetadataBLOBPayloadEntry
 {

--- a/src/webauthn/src/MetadataService/Statement/StatusReport.php
+++ b/src/webauthn/src/MetadataService/Statement/StatusReport.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Webauthn\MetadataService\Statement;
 
-use Webauthn\Exception\MetadataStatementLoadingException;
 use function in_array;
+use Webauthn\Exception\MetadataStatementLoadingException;
 
 readonly class StatusReport
 {

--- a/src/webauthn/src/PublicKeyCredentialCreationOptions.php
+++ b/src/webauthn/src/PublicKeyCredentialCreationOptions.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Webauthn;
 
+use function in_array;
 use InvalidArgumentException;
 use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
 use Webauthn\Exception\InvalidDataException;
-use function in_array;
 
 final class PublicKeyCredentialCreationOptions extends PublicKeyCredentialOptions
 {

--- a/src/webauthn/src/PublicKeyCredentialOptions.php
+++ b/src/webauthn/src/PublicKeyCredentialOptions.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Webauthn;
 
-use InvalidArgumentException;
-use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
 use function in_array;
+use InvalidArgumentException;
 use function is_string;
 use function sprintf;
+use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
 
 abstract class PublicKeyCredentialOptions
 {

--- a/src/webauthn/src/PublicKeyCredentialRequestOptions.php
+++ b/src/webauthn/src/PublicKeyCredentialRequestOptions.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Webauthn;
 
+use function in_array;
 use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
 use Webauthn\Exception\InvalidDataException;
-use function in_array;
 
 final class PublicKeyCredentialRequestOptions extends PublicKeyCredentialOptions
 {

--- a/src/webauthn/src/PublicKeyCredentialSource.php
+++ b/src/webauthn/src/PublicKeyCredentialSource.php
@@ -4,80 +4,11 @@ declare(strict_types=1);
 
 namespace Webauthn;
 
-use Symfony\Component\Uid\Uuid;
-use Webauthn\TrustPath\TrustPath;
-
 /**
  * @see https://www.w3.org/TR/webauthn/#iface-pkcredential
  *
  * @deprecated since 5.3, use CredentialRecord instead. Will be removed in 6.0.
  */
-class PublicKeyCredentialSource
+class PublicKeyCredentialSource extends CredentialRecord
 {
-    /**
-     * @param string[] $transports
-     * @param array<string, mixed>|null $otherUI
-     */
-    public function __construct(
-        public string $publicKeyCredentialId,
-        public string $type,
-        public array $transports,
-        public string $attestationType,
-        public TrustPath $trustPath,
-        public Uuid $aaguid,
-        public string $credentialPublicKey,
-        public string $userHandle,
-        public int $counter,
-        public ?array $otherUI = null,
-        public ?bool $backupEligible = null,
-        public ?bool $backupStatus = null,
-        public ?bool $uvInitialized = null,
-    ) {
-    }
-
-    /**
-     * @param string[] $transports
-     * @param array<string, mixed>|null $otherUI
-     */
-    public static function create(
-        string $publicKeyCredentialId,
-        string $type,
-        array $transports,
-        string $attestationType,
-        TrustPath $trustPath,
-        Uuid $aaguid,
-        string $credentialPublicKey,
-        string $userHandle,
-        int $counter,
-        ?array $otherUI = null,
-        ?bool $backupEligible = null,
-        ?bool $backupStatus = null,
-        ?bool $uvInitialized = null,
-    ): self {
-        return new self(
-            $publicKeyCredentialId,
-            $type,
-            $transports,
-            $attestationType,
-            $trustPath,
-            $aaguid,
-            $credentialPublicKey,
-            $userHandle,
-            $counter,
-            $otherUI,
-            $backupEligible,
-            $backupStatus,
-            $uvInitialized
-        );
-    }
-
-    public function getPublicKeyCredentialDescriptor(): PublicKeyCredentialDescriptor
-    {
-        return PublicKeyCredentialDescriptor::create($this->type, $this->publicKeyCredentialId, $this->transports);
-    }
-
-    public function getAttestedCredentialData(): AttestedCredentialData
-    {
-        return AttestedCredentialData::create($this->aaguid, $this->publicKeyCredentialId, $this->credentialPublicKey);
-    }
 }

--- a/src/webauthn/src/PublicKeyCredentialUserEntity.php
+++ b/src/webauthn/src/PublicKeyCredentialUserEntity.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Webauthn;
 
-use Webauthn\Exception\InvalidDataException;
 use function strlen;
+use Webauthn\Exception\InvalidDataException;
 
 class PublicKeyCredentialUserEntity extends PublicKeyCredentialEntity
 {

--- a/src/webauthn/src/SimpleFakeCredentialGenerator.php
+++ b/src/webauthn/src/SimpleFakeCredentialGenerator.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Webauthn;
 
-use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Component\HttpFoundation\Request;
 use function count;
 use function is_int;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 final readonly class SimpleFakeCredentialGenerator implements FakeCredentialGenerator
 {

--- a/src/webauthn/src/StringStream.php
+++ b/src/webauthn/src/StringStream.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Webauthn;
 
-use CBOR\Stream;
-use Webauthn\Exception\InvalidDataException;
 use function assert;
+use CBOR\Stream;
 use function fclose;
 use function fopen;
 use function fread;
@@ -14,6 +13,7 @@ use function fwrite;
 use function rewind;
 use function sprintf;
 use function strlen;
+use Webauthn\Exception\InvalidDataException;
 
 final class StringStream implements Stream
 {

--- a/src/webauthn/src/Util/CredentialRecordConverter.php
+++ b/src/webauthn/src/Util/CredentialRecordConverter.php
@@ -16,16 +16,25 @@ use Webauthn\PublicKeyCredentialSource;
 final class CredentialRecordConverter
 {
     /**
-     * Converts a PublicKeyCredentialSource to a CredentialRecord.
+     * Converts a CredentialRecord (or subclass) to a pure CredentialRecord.
      *
      * Since PublicKeyCredentialSource extends CredentialRecord, this method
-     * simply returns a new CredentialRecord instance with the same data.
+     * can accept either type. If the input is already a pure CredentialRecord,
+     * it is returned as-is. Otherwise, a new CredentialRecord is created.
      *
-     * @param PublicKeyCredentialSource $source The source credential to convert
+     * @param CredentialRecord $source The source credential to convert
      * @return CredentialRecord The converted credential record
      */
-    public static function toCredentialRecord(PublicKeyCredentialSource $source): CredentialRecord
+    public static function toCredentialRecord(CredentialRecord $source): CredentialRecord
     {
+        // Since PublicKeyCredentialSource now extends CredentialRecord,
+        // any PublicKeyCredentialSource is already a CredentialRecord.
+        // If it's already a pure CredentialRecord (not a subclass), return as-is.
+        // Otherwise, create a new CredentialRecord to "strip" the subclass.
+        if ($source::class === CredentialRecord::class) {
+            return $source;
+        }
+
         return CredentialRecord::create(
             $source->publicKeyCredentialId,
             $source->type,
@@ -56,7 +65,12 @@ final class CredentialRecordConverter
      */
     public static function toPublicKeyCredentialSource(CredentialRecord $record): PublicKeyCredentialSource
     {
-        return PublicKeyCredentialSource::create(
+        // If already a PublicKeyCredentialSource, return as-is
+        if ($record instanceof PublicKeyCredentialSource) {
+            return $record;
+        }
+
+        return new PublicKeyCredentialSource(
             $record->publicKeyCredentialId,
             $record->type,
             $record->transports,
@@ -74,9 +88,9 @@ final class CredentialRecordConverter
     }
 
     /**
-     * Converts an array of PublicKeyCredentialSource instances to CredentialRecord instances.
+     * Converts an array of CredentialRecord (or subclass) instances to pure CredentialRecord instances.
      *
-     * @param PublicKeyCredentialSource[] $sources Array of credential sources
+     * @param CredentialRecord[] $sources Array of credential records
      * @return CredentialRecord[] Array of credential records
      */
     public static function toCredentialRecords(array $sources): array

--- a/tests/framework/ComposerJsonTest.php
+++ b/tests/framework/ComposerJsonTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Webauthn\Tests;
 
 use DirectoryIterator;
+use const JSON_THROW_ON_ERROR;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Traversable;
 use function sprintf;
-use const JSON_THROW_ON_ERROR;
+use Traversable;
 
 /**
  * @internal

--- a/tests/framework/MockedPublicKeyCredentialSourceTrait.php
+++ b/tests/framework/MockedPublicKeyCredentialSourceTrait.php
@@ -22,7 +22,7 @@ trait MockedPublicKeyCredentialSourceTrait
         string $attestationType = 'none',
         ?TrustPath $trustPath = null
     ): PublicKeyCredentialSource {
-        return PublicKeyCredentialSource::create(
+        return new PublicKeyCredentialSource(
             $id,
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
             $transport,

--- a/tests/library/AbstractTestCase.php
+++ b/tests/library/AbstractTestCase.php
@@ -14,6 +14,7 @@ use Cose\Algorithm\Signature\RSA\RS256;
 use Cose\Algorithm\Signature\RSA\RS384;
 use Cose\Algorithm\Signature\RSA\RS512;
 use PHPUnit\Framework\TestCase;
+use function sprintf;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -39,7 +40,6 @@ use Webauthn\MetadataService\Service\LocalResourceMetadataService;
 use Webauthn\Tests\Bundle\Functional\MockClock;
 use Webauthn\Tests\Functional\MetadataStatementRepository;
 use Webauthn\Tests\Functional\StatusReportRepository;
-use function sprintf;
 
 abstract class AbstractTestCase extends TestCase
 {

--- a/tests/library/Functional/ValidatorCompatibilityTest.php
+++ b/tests/library/Functional/ValidatorCompatibilityTest.php
@@ -113,7 +113,7 @@ final class ValidatorCompatibilityTest extends AbstractTestCase
         static::assertInstanceOf(AuthenticatorAssertionResponse::class, $publicKeyCredential->response);
 
         // Create a PublicKeyCredentialSource (deprecated but should still work)
-        $publicKeyCredentialSource = PublicKeyCredentialSource::create(
+        $publicKeyCredentialSource = new PublicKeyCredentialSource(
             base64_decode(
                 'eHouz/Zi7+BmByHjJ/tx9h4a1WZsK4IzUmgGjkhyOodPGAyUqUp/B9yUkflXY3yHWsNtsrgCXQ3HjAIFUeZB+w==',
                 true
@@ -141,9 +141,9 @@ final class ValidatorCompatibilityTest extends AbstractTestCase
             'foo'
         );
 
-        // Validator returns the same type that was passed in
+        // Validator returns CredentialRecord; PKCS extends CR so it's both
         static::assertInstanceOf(PublicKeyCredentialSource::class, $updatedPkcs);
-        static::assertNotInstanceOf(CredentialRecord::class, $updatedPkcs);
+        static::assertInstanceOf(CredentialRecord::class, $updatedPkcs);
         static::assertSame(123, $updatedPkcs->counter);
     }
 
@@ -163,7 +163,7 @@ final class ValidatorCompatibilityTest extends AbstractTestCase
             10
         );
 
-        $pkcs = PublicKeyCredentialSource::create(
+        $pkcs = new PublicKeyCredentialSource(
             'test-id-2',
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
             [],
@@ -178,8 +178,8 @@ final class ValidatorCompatibilityTest extends AbstractTestCase
         // Both types should work with ceremony steps
         static::assertInstanceOf(CredentialRecord::class, $credentialRecord);
         static::assertInstanceOf(PublicKeyCredentialSource::class, $pkcs);
-        // PKCS and CR are independent classes
-        static::assertNotInstanceOf(CredentialRecord::class, $pkcs);
+        // PKCS extends CredentialRecord
+        static::assertInstanceOf(CredentialRecord::class, $pkcs);
         static::assertNotInstanceOf(PublicKeyCredentialSource::class, $credentialRecord);
     }
 
@@ -200,7 +200,7 @@ final class ValidatorCompatibilityTest extends AbstractTestCase
             10
         );
 
-        $pkcs = PublicKeyCredentialSource::create(
+        $pkcs = new PublicKeyCredentialSource(
             'test-id-2',
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
             [],

--- a/tests/library/Unit/CredentialRecordConverterTest.php
+++ b/tests/library/Unit/CredentialRecordConverterTest.php
@@ -28,7 +28,7 @@ final class CredentialRecordConverterTest extends AbstractTestCase
         $publicKey = 'test-public-key';
         $transports = ['usb', 'nfc'];
 
-        $pkcs = PublicKeyCredentialSource::create(
+        $pkcs = new PublicKeyCredentialSource(
             $credentialId,
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
             $transports,
@@ -117,7 +117,7 @@ final class CredentialRecordConverterTest extends AbstractTestCase
     #[Test]
     public function canConvertArrayOfPublicKeyCredentialSourcesToCredentialRecords(): void
     {
-        $pkcs1 = PublicKeyCredentialSource::create(
+        $pkcs1 = new PublicKeyCredentialSource(
             'id1',
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
             [],
@@ -129,7 +129,7 @@ final class CredentialRecordConverterTest extends AbstractTestCase
             1
         );
 
-        $pkcs2 = PublicKeyCredentialSource::create(
+        $pkcs2 = new PublicKeyCredentialSource(
             'id2',
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
             [],
@@ -203,7 +203,7 @@ final class CredentialRecordConverterTest extends AbstractTestCase
         ];
 
         // Create PKCS -> convert to CR -> convert back to PKCS
-        $originalPkcs = PublicKeyCredentialSource::create(
+        $originalPkcs = new PublicKeyCredentialSource(
             $credentialId,
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
             $transports,
@@ -240,7 +240,7 @@ final class CredentialRecordConverterTest extends AbstractTestCase
     #[Test]
     public function conversionHandlesNullValues(): void
     {
-        $pkcs = PublicKeyCredentialSource::create(
+        $pkcs = new PublicKeyCredentialSource(
             'id',
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
             [],

--- a/tests/library/Unit/CredentialRecordTest.php
+++ b/tests/library/Unit/CredentialRecordTest.php
@@ -95,7 +95,7 @@ final class CredentialRecordTest extends AbstractTestCase
     }
 
     #[Test]
-    public function publicKeyCredentialSourceHasSameStructureAsCredentialRecord(): void
+    public function publicKeyCredentialSourceExtendsCredentialRecord(): void
     {
         $credentialId = 'credential-id';
         $userHandle = 'user-handle';
@@ -103,7 +103,7 @@ final class CredentialRecordTest extends AbstractTestCase
         $aaguid = Uuid::v4();
         $publicKey = 'public-key';
 
-        $pkcs = PublicKeyCredentialSource::create(
+        $pkcs = new PublicKeyCredentialSource(
             $credentialId,
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
             [],
@@ -115,11 +115,11 @@ final class CredentialRecordTest extends AbstractTestCase
             $counter
         );
 
-        // PublicKeyCredentialSource is a separate class, not extending CredentialRecord
+        // PublicKeyCredentialSource extends CredentialRecord
         static::assertInstanceOf(PublicKeyCredentialSource::class, $pkcs);
-        static::assertNotInstanceOf(CredentialRecord::class, $pkcs);
+        static::assertInstanceOf(CredentialRecord::class, $pkcs);
 
-        // But it has the same properties
+        // It has the same properties (inherited from CredentialRecord)
         static::assertSame($credentialId, $pkcs->publicKeyCredentialId);
         static::assertSame($userHandle, $pkcs->userHandle);
         static::assertSame($counter, $pkcs->counter);

--- a/tests/library/Unit/PublicKeyCredentialSourceTest.php
+++ b/tests/library/Unit/PublicKeyCredentialSourceTest.php
@@ -39,7 +39,7 @@ final class PublicKeyCredentialSourceTest extends AbstractTestCase
     public function publicKeyCredentialSourceCanBeSerialized(): void
     {
         // Given
-        $source = PublicKeyCredentialSource::create(
+        $source = new PublicKeyCredentialSource(
             'publicKeyCredentialId',
             'type',
             ['transport1', 'transport2'],

--- a/tests/library/Unit/RepositoryCompatibilityTest.php
+++ b/tests/library/Unit/RepositoryCompatibilityTest.php
@@ -28,14 +28,13 @@ final class RepositoryCompatibilityTest extends AbstractTestCase
         $repository = new class() implements PublicKeyCredentialSourceRepositoryInterface, CanSaveCredentialSource {
             private array $storage = [];
 
-            public function saveCredentialSource(CredentialRecord|PublicKeyCredentialSource $credentialRecord): void
+            public function saveCredentialSource(CredentialRecord $credentialRecord): void
             {
                 $this->storage[$credentialRecord->publicKeyCredentialId] = $credentialRecord;
             }
 
-            public function findOneByCredentialId(
-                string $publicKeyCredentialId
-            ): CredentialRecord|PublicKeyCredentialSource|null {
+            public function findOneByCredentialId(string $publicKeyCredentialId): ?CredentialRecord
+            {
                 return $this->storage[$publicKeyCredentialId] ?? null;
             }
 
@@ -75,14 +74,13 @@ final class RepositoryCompatibilityTest extends AbstractTestCase
         $repository = new class() implements PublicKeyCredentialSourceRepositoryInterface, CanSaveCredentialSource {
             private array $storage = [];
 
-            public function saveCredentialSource(CredentialRecord|PublicKeyCredentialSource $credentialRecord): void
+            public function saveCredentialSource(CredentialRecord $credentialRecord): void
             {
                 $this->storage[$credentialRecord->publicKeyCredentialId] = $credentialRecord;
             }
 
-            public function findOneByCredentialId(
-                string $publicKeyCredentialId
-            ): CredentialRecord|PublicKeyCredentialSource|null {
+            public function findOneByCredentialId(string $publicKeyCredentialId): ?CredentialRecord
+            {
                 return $this->storage[$publicKeyCredentialId] ?? null;
             }
 
@@ -95,7 +93,7 @@ final class RepositoryCompatibilityTest extends AbstractTestCase
             }
         };
 
-        $pkcs = PublicKeyCredentialSource::create(
+        $pkcs = new PublicKeyCredentialSource(
             'test-id-2',
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
             [],
@@ -107,7 +105,7 @@ final class RepositoryCompatibilityTest extends AbstractTestCase
             10
         );
 
-        // Should be able to save a PublicKeyCredentialSource
+        // Should be able to save a PublicKeyCredentialSource (extends CredentialRecord)
         $repository->saveCredentialSource($pkcs);
 
         // Should be able to retrieve it
@@ -122,14 +120,13 @@ final class RepositoryCompatibilityTest extends AbstractTestCase
         $repository = new class() implements CredentialRecordRepositoryInterface, CanSaveCredentialRecord {
             private array $storage = [];
 
-            public function saveCredentialSource(CredentialRecord|PublicKeyCredentialSource $credentialRecord): void
+            public function saveCredentialSource(CredentialRecord $credentialRecord): void
             {
                 $this->storage[$credentialRecord->publicKeyCredentialId] = $credentialRecord;
             }
 
-            public function findOneByCredentialId(
-                string $publicKeyCredentialId
-            ): CredentialRecord|PublicKeyCredentialSource|null {
+            public function findOneByCredentialId(string $publicKeyCredentialId): ?CredentialRecord
+            {
                 return $this->storage[$publicKeyCredentialId] ?? null;
             }
 
@@ -154,7 +151,7 @@ final class RepositoryCompatibilityTest extends AbstractTestCase
             10
         );
 
-        $pkcs = PublicKeyCredentialSource::create(
+        $pkcs = new PublicKeyCredentialSource(
             'pkcs-id',
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
             [],
@@ -166,7 +163,7 @@ final class RepositoryCompatibilityTest extends AbstractTestCase
             20
         );
 
-        // Should handle both types
+        // Should handle both types (PKCS extends CR)
         $repository->saveCredentialSource($credentialRecord);
         $repository->saveCredentialSource($pkcs);
 
@@ -175,6 +172,8 @@ final class RepositoryCompatibilityTest extends AbstractTestCase
 
         static::assertInstanceOf(CredentialRecord::class, $retrievedCr);
         static::assertInstanceOf(PublicKeyCredentialSource::class, $retrievedPkcs);
+        // PKCS now extends CR
+        static::assertInstanceOf(CredentialRecord::class, $retrievedPkcs);
     }
 
     #[Test]
@@ -195,7 +194,7 @@ final class RepositoryCompatibilityTest extends AbstractTestCase
             10
         );
 
-        $pkcs = PublicKeyCredentialSource::create(
+        $pkcs = new PublicKeyCredentialSource(
             'pkcs-1',
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
             [],
@@ -214,15 +213,15 @@ final class RepositoryCompatibilityTest extends AbstractTestCase
         static::assertCount(2, $storage);
         static::assertInstanceOf(CredentialRecord::class, $storage[0]);
         static::assertInstanceOf(PublicKeyCredentialSource::class, $storage[1]);
-        // PKCS and CR are independent classes
-        static::assertNotInstanceOf(CredentialRecord::class, $storage[1]);
+        // PKCS extends CredentialRecord, so it's also a CredentialRecord
+        static::assertInstanceOf(CredentialRecord::class, $storage[1]);
         static::assertNotInstanceOf(PublicKeyCredentialSource::class, $storage[0]);
     }
 
     #[Test]
-    public function publicKeyCredentialSourceIsIndependentFromCredentialRecord(): void
+    public function publicKeyCredentialSourceExtendsCredentialRecord(): void
     {
-        $pkcs = PublicKeyCredentialSource::create(
+        $pkcs = new PublicKeyCredentialSource(
             'test-id',
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
             [],
@@ -246,22 +245,22 @@ final class RepositoryCompatibilityTest extends AbstractTestCase
             20
         );
 
-        // The two classes are independent
+        // PublicKeyCredentialSource now extends CredentialRecord
         static::assertInstanceOf(PublicKeyCredentialSource::class, $pkcs);
-        static::assertNotInstanceOf(CredentialRecord::class, $pkcs);
+        static::assertInstanceOf(CredentialRecord::class, $pkcs);
 
         static::assertInstanceOf(CredentialRecord::class, $cr);
         static::assertNotInstanceOf(PublicKeyCredentialSource::class, $cr);
     }
 
     #[Test]
-    public function bothRepositoryInterfacesAcceptUnionTypes(): void
+    public function bothRepositoryInterfacesAcceptCredentialRecord(): void
     {
         // This test verifies that the type signatures are compatible
+        // PublicKeyCredentialSourceRepositoryInterface extends CredentialRecordRepositoryInterface
         $pkcsRepo = new class() implements PublicKeyCredentialSourceRepositoryInterface {
-            public function findOneByCredentialId(
-                string $publicKeyCredentialId
-            ): CredentialRecord|PublicKeyCredentialSource|null {
+            public function findOneByCredentialId(string $publicKeyCredentialId): ?CredentialRecord
+            {
                 return null;
             }
 
@@ -272,9 +271,8 @@ final class RepositoryCompatibilityTest extends AbstractTestCase
         };
 
         $crRepo = new class() implements CredentialRecordRepositoryInterface {
-            public function findOneByCredentialId(
-                string $publicKeyCredentialId
-            ): CredentialRecord|PublicKeyCredentialSource|null {
+            public function findOneByCredentialId(string $publicKeyCredentialId): ?CredentialRecord
+            {
                 return null;
             }
 
@@ -286,5 +284,7 @@ final class RepositoryCompatibilityTest extends AbstractTestCase
 
         static::assertInstanceOf(PublicKeyCredentialSourceRepositoryInterface::class, $pkcsRepo);
         static::assertInstanceOf(CredentialRecordRepositoryInterface::class, $crRepo);
+        // PKCS interface extends CR interface
+        static::assertInstanceOf(CredentialRecordRepositoryInterface::class, $pkcsRepo);
     }
 }

--- a/tests/library/Unit/SerializerTest.php
+++ b/tests/library/Unit/SerializerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\Tests\Unit;
 
+use const JSON_THROW_ON_ERROR;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Serializer\Encoder\JsonEncode;
@@ -21,7 +22,6 @@ use Webauthn\Tests\AbstractTestCase;
 use Webauthn\TrustPath\CertificateTrustPath;
 use Webauthn\TrustPath\EmptyTrustPath;
 use Webauthn\TrustPath\TrustPath;
-use const JSON_THROW_ON_ERROR;
 
 /**
  * @internal

--- a/tests/symfony/functional/Attestation/AdditionalAuthenticatorTest.php
+++ b/tests/symfony/functional/Attestation/AdditionalAuthenticatorTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Webauthn\Tests\Bundle\Functional\Attestation;
 
+use function base64_decode;
 use Cose\Algorithms;
+use function count;
 use InvalidArgumentException;
+use const JSON_THROW_ON_ERROR;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -24,9 +27,6 @@ use Webauthn\Tests\Bundle\Functional\CustomSessionStorage;
 use Webauthn\Tests\Bundle\Functional\PublicKeyCredentialSourceRepository;
 use Webauthn\Tests\Bundle\Functional\User;
 use Webauthn\Tests\Bundle\Functional\WebauthnTestCase;
-use function base64_decode;
-use function count;
-use const JSON_THROW_ON_ERROR;
 
 /**
  * @internal

--- a/tests/symfony/functional/Attestation/AttestationTest.php
+++ b/tests/symfony/functional/Attestation/AttestationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Webauthn\Tests\Bundle\Functional\Attestation;
 
 use PHPUnit\Framework\Attributes\Test;
+use function strlen;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Serializer\SerializerInterface;
 use Webauthn\AttestationStatement\AttestationStatement;
@@ -21,7 +22,6 @@ use Webauthn\Tests\Bundle\Functional\PublicKeyCredentialSourceRepository;
 use Webauthn\Tests\MockedRequestTrait;
 use Webauthn\TrustPath\CertificateTrustPath;
 use Webauthn\TrustPath\EmptyTrustPath;
-use function strlen;
 
 /**
  * @internal

--- a/tests/symfony/functional/Firewall/LegacySecuredAreaTest.php
+++ b/tests/symfony/functional/Firewall/LegacySecuredAreaTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Webauthn\Tests\Bundle\Functional\Firewall;
 
 use Ergebnis\PHPUnit\SlowTestDetector\Attribute\MaximumDuration;
+use const JSON_THROW_ON_ERROR;
 use ParagonIE\ConstantTime\Base64UrlSafe;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\HttpFoundation\Request;
@@ -15,7 +16,6 @@ use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialUserEntity;
 use Webauthn\Tests\Bundle\Functional\CustomSessionStorage;
 use Webauthn\Tests\Bundle\Functional\WebauthnTestCase;
-use const JSON_THROW_ON_ERROR;
 
 /**
  * @internal

--- a/tests/symfony/functional/Firewall/RegistrationAreaTest.php
+++ b/tests/symfony/functional/Firewall/RegistrationAreaTest.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Webauthn\Tests\Bundle\Functional\Firewall;
 
+use function base64_decode;
 use Cose\Algorithms;
+use function json_decode;
+use function json_encode;
+use const JSON_THROW_ON_ERROR;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\HttpFoundation\Request;
 use Webauthn\Bundle\Security\Storage\Item;
@@ -17,10 +21,6 @@ use Webauthn\Tests\Bundle\Functional\PublicKeyCredentialSourceRepository;
 use Webauthn\Tests\Bundle\Functional\PublicKeyCredentialUserEntityRepository;
 use Webauthn\Tests\Bundle\Functional\User;
 use Webauthn\Tests\Bundle\Functional\WebauthnTestCase;
-use function base64_decode;
-use function json_decode;
-use function json_encode;
-use const JSON_THROW_ON_ERROR;
 
 /**
  * @internal

--- a/tests/symfony/functional/MockClientCallback.php
+++ b/tests/symfony/functional/MockClientCallback.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Webauthn\Tests\Bundle\Functional;
 
 use RuntimeException;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 use function sprintf;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * @internal

--- a/tests/symfony/functional/PublicKeyCredentialSourceRepository.php
+++ b/tests/symfony/functional/PublicKeyCredentialSourceRepository.php
@@ -21,7 +21,7 @@ final readonly class PublicKeyCredentialSourceRepository implements PublicKeyCre
     public function __construct(
         private CacheItemPoolInterface $cacheItemPool
     ) {
-        $publicKeyCredentialSource1 = PublicKeyCredentialSource::create(
+        $publicKeyCredentialSource1 = new PublicKeyCredentialSource(
             base64_decode(
                 'eHouz/Zi7+BmByHjJ/tx9h4a1WZsK4IzUmgGjkhyOodPGAyUqUp/B9yUkflXY3yHWsNtsrgCXQ3HjAIFUeZB+w==',
                 true
@@ -39,7 +39,7 @@ final readonly class PublicKeyCredentialSourceRepository implements PublicKeyCre
             100
         );
         $this->saveCredentialSource($publicKeyCredentialSource1);
-        $publicKeyCredentialSource2 = PublicKeyCredentialSource::create(
+        $publicKeyCredentialSource2 = new PublicKeyCredentialSource(
             base64_decode(
                 'Ac8zKrpVWv9UCwxY1FyMqkESz2lV4CNwTk2+Hp19LgKbvh5uQ2/i6AMbTbTz1zcNapCEeiLJPlAAVM4L7AIow6I=',
                 true
@@ -64,9 +64,8 @@ final readonly class PublicKeyCredentialSourceRepository implements PublicKeyCre
         $this->cacheItemPool->deleteItem('pks-' . Base64UrlSafe::encodeUnpadded($publicKeyCredentialId));
     }
 
-    public function findOneByCredentialId(
-        string $publicKeyCredentialId
-    ): CredentialRecord|PublicKeyCredentialSource|null {
+    public function findOneByCredentialId(string $publicKeyCredentialId): ?CredentialRecord
+    {
         $item = $this->cacheItemPool->getItem('pks-' . Base64UrlSafe::encodeUnpadded($publicKeyCredentialId));
         if (! $item->isHit()) {
             return null;
@@ -92,7 +91,7 @@ final readonly class PublicKeyCredentialSourceRepository implements PublicKeyCre
         $this->cacheItemPool->clear();
     }
 
-    public function saveCredentialSource(CredentialRecord|PublicKeyCredentialSource $credentialRecord): void
+    public function saveCredentialSource(CredentialRecord $credentialRecord): void
     {
         $item = $this->cacheItemPool->getItem(
             'pks-' . Base64UrlSafe::encodeUnpadded($credentialRecord->publicKeyCredentialId)

--- a/tests/symfony/functional/Repository/RepositoryFunctionalTest.php
+++ b/tests/symfony/functional/Repository/RepositoryFunctionalTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\Tests\Bundle\Functional\Repository;
 
+use function count;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -17,7 +18,6 @@ use Webauthn\PublicKeyCredentialUserEntity;
 use Webauthn\Tests\Bundle\Functional\CredentialRecordRepository;
 use Webauthn\Tests\Bundle\Functional\PublicKeyCredentialSourceRepository;
 use Webauthn\TrustPath\EmptyTrustPath;
-use function count;
 
 /**
  * Functional tests for repository implementations in the Symfony bundle.
@@ -39,7 +39,7 @@ final class RepositoryFunctionalTest extends KernelTestCase
         // Given
         $repository = new PublicKeyCredentialSourceRepository($this->cache);
 
-        $publicKeyCredentialSource = PublicKeyCredentialSource::create(
+        $publicKeyCredentialSource = new PublicKeyCredentialSource(
             base64_decode('test123', true),
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
             [],
@@ -55,7 +55,8 @@ final class RepositoryFunctionalTest extends KernelTestCase
         $repository->saveCredentialSource($publicKeyCredentialSource);
         $retrieved = $repository->findOneByCredentialId(base64_decode('test123', true));
 
-        // Then
+        // Then - PublicKeyCredentialSource extends CredentialRecord, so it's both
+        static::assertInstanceOf(CredentialRecord::class, $retrieved);
         static::assertInstanceOf(PublicKeyCredentialSource::class, $retrieved);
         static::assertSame('test-user', $retrieved->userHandle);
         static::assertSame(100, $retrieved->counter);
@@ -123,7 +124,7 @@ final class RepositoryFunctionalTest extends KernelTestCase
         // Given
         $repository = new CredentialRecordRepository($this->cache);
 
-        $publicKeyCredentialSource = PublicKeyCredentialSource::create(
+        $publicKeyCredentialSource = new PublicKeyCredentialSource(
             base64_decode('pkcs999', true),
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
             [],
@@ -139,7 +140,8 @@ final class RepositoryFunctionalTest extends KernelTestCase
         $repository->saveCredentialSource($publicKeyCredentialSource);
         $retrieved = $repository->findOneByCredentialId(base64_decode('pkcs999', true));
 
-        // Then
+        // Then - PublicKeyCredentialSource extends CredentialRecord, so it's both
+        static::assertInstanceOf(CredentialRecord::class, $retrieved);
         static::assertInstanceOf(PublicKeyCredentialSource::class, $retrieved);
         static::assertSame('test-user-4', $retrieved->userHandle);
         static::assertSame(400, $retrieved->counter);
@@ -165,7 +167,7 @@ final class RepositoryFunctionalTest extends KernelTestCase
             100
         );
 
-        $publicKeyCredentialSource = PublicKeyCredentialSource::create(
+        $publicKeyCredentialSource = new PublicKeyCredentialSource(
             'multi2',
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
             [],
@@ -184,14 +186,15 @@ final class RepositoryFunctionalTest extends KernelTestCase
         $userEntity = PublicKeyCredentialUserEntity::create($userId, $userId, 'Multi User');
         $allCredentials = $repository->findAllForUserEntity($userEntity);
 
-        // Then - should retrieve both types
+        // Then - should retrieve both types (all are CredentialRecord, some may also be PublicKeyCredentialSource)
         static::assertGreaterThanOrEqual(2, count($allCredentials));
 
         $hasCredentialRecord = false;
         $hasPublicKeyCredentialSource = false;
 
         foreach ($allCredentials as $credential) {
-            if ($credential instanceof CredentialRecord && $credential->publicKeyCredentialId === 'multi1') {
+            static::assertInstanceOf(CredentialRecord::class, $credential);
+            if ($credential->publicKeyCredentialId === 'multi1') {
                 $hasCredentialRecord = true;
             }
             if ($credential instanceof PublicKeyCredentialSource && $credential->publicKeyCredentialId === 'multi2') {

--- a/tests/symfony/functional/SingleFileService.php
+++ b/tests/symfony/functional/SingleFileService.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Webauthn\Tests\Bundle\Functional;
 
+use function array_key_exists;
 use InvalidArgumentException;
+use function sprintf;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Serializer\SerializerInterface;
 use Webauthn\MetadataService\Service\MetadataService;
 use Webauthn\MetadataService\Statement\MetadataStatement;
-use function array_key_exists;
-use function sprintf;
 
 final class SingleFileService implements MetadataService
 {

--- a/tests/symfony/functional/UserProvider.php
+++ b/tests/symfony/functional/UserProvider.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Webauthn\Tests\Bundle\Functional;
 
+use function sprintf;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
-use function sprintf;
 
 final readonly class UserProvider implements UserProviderInterface
 {

--- a/tests/symfony/unit/Repository/RepositoryImplementationsTest.php
+++ b/tests/symfony/unit/Repository/RepositoryImplementationsTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use ReflectionClass;
 use ReflectionMethod;
-use ReflectionUnionType;
+use ReflectionNamedType;
 use Symfony\Component\Uid\Uuid;
 use Webauthn\Bundle\Repository\CanSaveCredentialRecord;
 use Webauthn\Bundle\Repository\CanSaveCredentialSource;
@@ -26,7 +26,7 @@ use Webauthn\TrustPath\EmptyTrustPath;
 
 /**
  * Tests for bundle repository implementations to ensure they properly handle both
- * CredentialRecord and PublicKeyCredentialSource types.
+ * CredentialRecord and PublicKeyCredentialSource types (via inheritance).
  *
  * @internal
  */
@@ -53,38 +53,32 @@ final class RepositoryImplementationsTest extends TestCase
     }
 
     #[Test]
-    public function dummyCredentialRecordRepositoryReturnsCorrectUnionType(): void
+    public function dummyCredentialRecordRepositoryReturnsCredentialRecord(): void
     {
         // Given
         $repository = new DummyCredentialRecordRepository(new NullLogger());
 
-        // Then - verify the return type is the correct union type
+        // Then - verify the return type is CredentialRecord (nullable)
         $reflection = new ReflectionMethod($repository, 'findOneByCredentialId');
         $returnType = $reflection->getReturnType();
 
-        static::assertInstanceOf(ReflectionUnionType::class, $returnType);
-
-        $types = array_map(fn ($type) => $type->getName(), $returnType->getTypes());
-        static::assertContains(CredentialRecord::class, $types);
-        static::assertContains(PublicKeyCredentialSource::class, $types);
+        static::assertInstanceOf(ReflectionNamedType::class, $returnType);
+        static::assertSame(CredentialRecord::class, $returnType->getName());
         static::assertTrue($returnType->allowsNull());
     }
 
     #[Test]
-    public function dummyPublicKeyCredentialSourceRepositoryReturnsCorrectUnionType(): void
+    public function dummyPublicKeyCredentialSourceRepositoryReturnsCredentialRecord(): void
     {
         // Given
         $repository = new DummyPublicKeyCredentialSourceRepository(new NullLogger());
 
-        // Then - verify the return type is the correct union type
+        // Then - verify the return type is CredentialRecord (nullable)
         $reflection = new ReflectionMethod($repository, 'findOneByCredentialId');
         $returnType = $reflection->getReturnType();
 
-        static::assertInstanceOf(ReflectionUnionType::class, $returnType);
-
-        $types = array_map(fn ($type) => $type->getName(), $returnType->getTypes());
-        static::assertContains(CredentialRecord::class, $types);
-        static::assertContains(PublicKeyCredentialSource::class, $types);
+        static::assertInstanceOf(ReflectionNamedType::class, $returnType);
+        static::assertSame(CredentialRecord::class, $returnType->getName());
         static::assertTrue($returnType->allowsNull());
     }
 
@@ -100,41 +94,35 @@ final class RepositoryImplementationsTest extends TestCase
     }
 
     #[Test]
-    public function doctrineCredentialSourceRepositoryAcceptsUnionTypeInSaveMethod(): void
+    public function doctrineCredentialSourceRepositoryAcceptsCredentialRecordInSaveMethod(): void
     {
         // Given - use reflection to check method signature
         $reflection = new ReflectionMethod(DoctrineCredentialSourceRepository::class, 'saveCredentialSource');
         $parameters = $reflection->getParameters();
 
-        // Then - verify the parameter type accepts union type
+        // Then - verify the parameter type accepts CredentialRecord
         static::assertCount(1, $parameters);
         $paramType = $parameters[0]->getType();
 
-        static::assertInstanceOf(ReflectionUnionType::class, $paramType);
-
-        $types = array_map(fn ($type) => $type->getName(), $paramType->getTypes());
-        static::assertContains(CredentialRecord::class, $types);
-        static::assertContains(PublicKeyCredentialSource::class, $types);
+        static::assertInstanceOf(ReflectionNamedType::class, $paramType);
+        static::assertSame(CredentialRecord::class, $paramType->getName());
     }
 
     #[Test]
-    public function doctrineCredentialSourceRepositoryReturnsCorrectUnionType(): void
+    public function doctrineCredentialSourceRepositoryReturnsCredentialRecord(): void
     {
         // Given - use reflection to check method signature
         $reflection = new ReflectionMethod(DoctrineCredentialSourceRepository::class, 'findOneByCredentialId');
         $returnType = $reflection->getReturnType();
 
-        // Then - verify the return type is the correct union type
-        static::assertInstanceOf(ReflectionUnionType::class, $returnType);
-
-        $types = array_map(fn ($type) => $type->getName(), $returnType->getTypes());
-        static::assertContains(CredentialRecord::class, $types);
-        static::assertContains(PublicKeyCredentialSource::class, $types);
+        // Then - verify the return type is CredentialRecord (nullable)
+        static::assertInstanceOf(ReflectionNamedType::class, $returnType);
+        static::assertSame(CredentialRecord::class, $returnType->getName());
         static::assertTrue($returnType->allowsNull());
     }
 
     #[Test]
-    public function canSaveCredentialRecordInterfaceAcceptsUnionType(): void
+    public function canSaveCredentialRecordInterfaceAcceptsCredentialRecord(): void
     {
         // This test verifies that the interface itself has the correct signature
         $reflection = new ReflectionMethod(CanSaveCredentialRecord::class, 'saveCredentialSource');
@@ -143,61 +131,47 @@ final class RepositoryImplementationsTest extends TestCase
         static::assertCount(1, $parameters);
         $paramType = $parameters[0]->getType();
 
-        static::assertInstanceOf(ReflectionUnionType::class, $paramType);
-
-        $types = array_map(fn ($type) => $type->getName(), $paramType->getTypes());
-        static::assertContains(CredentialRecord::class, $types);
-        static::assertContains(PublicKeyCredentialSource::class, $types);
+        static::assertInstanceOf(ReflectionNamedType::class, $paramType);
+        static::assertSame(CredentialRecord::class, $paramType->getName());
     }
 
     #[Test]
-    public function canSaveCredentialSourceInterfaceAcceptsUnionType(): void
+    public function canSaveCredentialSourceInterfaceExtendsCanSaveCredentialRecord(): void
     {
-        // This test verifies that the deprecated interface has the correct signature
-        $reflection = new ReflectionMethod(CanSaveCredentialSource::class, 'saveCredentialSource');
-        $parameters = $reflection->getParameters();
+        // This test verifies that the deprecated interface extends the new one
+        $reflection = new ReflectionClass(CanSaveCredentialSource::class);
 
-        static::assertCount(1, $parameters);
-        $paramType = $parameters[0]->getType();
-
-        static::assertInstanceOf(ReflectionUnionType::class, $paramType);
-
-        $types = array_map(fn ($type) => $type->getName(), $paramType->getTypes());
-        static::assertContains(CredentialRecord::class, $types);
-        static::assertContains(PublicKeyCredentialSource::class, $types);
+        static::assertTrue($reflection->implementsInterface(CanSaveCredentialRecord::class));
     }
 
     #[Test]
-    public function credentialRecordRepositoryInterfaceReturnsUnionType(): void
+    public function credentialRecordRepositoryInterfaceReturnsCredentialRecord(): void
     {
-        // Verify findOneByCredentialId returns union type
+        // Verify findOneByCredentialId returns CredentialRecord (nullable)
         $reflection = new ReflectionMethod(CredentialRecordRepositoryInterface::class, 'findOneByCredentialId');
         $returnType = $reflection->getReturnType();
 
-        static::assertInstanceOf(ReflectionUnionType::class, $returnType);
-
-        $types = array_map(fn ($type) => $type->getName(), $returnType->getTypes());
-        static::assertContains(CredentialRecord::class, $types);
-        static::assertContains(PublicKeyCredentialSource::class, $types);
+        static::assertInstanceOf(ReflectionNamedType::class, $returnType);
+        static::assertSame(CredentialRecord::class, $returnType->getName());
         static::assertTrue($returnType->allowsNull());
     }
 
     #[Test]
-    public function publicKeyCredentialSourceRepositoryInterfaceReturnsUnionType(): void
+    public function publicKeyCredentialSourceRepositoryInterfaceExtendsCredentialRecordRepositoryInterface(): void
     {
-        // Verify findOneByCredentialId returns union type
-        $reflection = new ReflectionMethod(
-            PublicKeyCredentialSourceRepositoryInterface::class,
-            'findOneByCredentialId'
-        );
-        $returnType = $reflection->getReturnType();
+        // Verify the deprecated interface extends the new one
+        $reflection = new ReflectionClass(PublicKeyCredentialSourceRepositoryInterface::class);
 
-        static::assertInstanceOf(ReflectionUnionType::class, $returnType);
+        static::assertTrue($reflection->implementsInterface(CredentialRecordRepositoryInterface::class));
+    }
 
-        $types = array_map(fn ($type) => $type->getName(), $returnType->getTypes());
-        static::assertContains(CredentialRecord::class, $types);
-        static::assertContains(PublicKeyCredentialSource::class, $types);
-        static::assertTrue($returnType->allowsNull());
+    #[Test]
+    public function publicKeyCredentialSourceExtendsCredentialRecord(): void
+    {
+        // Verify inheritance relationship
+        $reflection = new ReflectionClass(PublicKeyCredentialSource::class);
+
+        static::assertTrue($reflection->isSubclassOf(CredentialRecord::class));
     }
 
     #[Test]
@@ -212,14 +186,13 @@ final class RepositoryImplementationsTest extends TestCase
             ) {
             }
 
-            public function saveCredentialSource(CredentialRecord|PublicKeyCredentialSource $credentialRecord): void
+            public function saveCredentialSource(CredentialRecord $credentialRecord): void
             {
                 $this->storage[$credentialRecord->publicKeyCredentialId] = $credentialRecord;
             }
 
-            public function findOneByCredentialId(
-                string $publicKeyCredentialId
-            ): CredentialRecord|PublicKeyCredentialSource|null {
+            public function findOneByCredentialId(string $publicKeyCredentialId): ?CredentialRecord
+            {
                 return $this->storage[$publicKeyCredentialId] ?? null;
             }
 
@@ -244,7 +217,7 @@ final class RepositoryImplementationsTest extends TestCase
             10
         );
 
-        $publicKeyCredentialSource = PublicKeyCredentialSource::create(
+        $publicKeyCredentialSource = new PublicKeyCredentialSource(
             'pkcs-id',
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
             [],
@@ -256,15 +229,17 @@ final class RepositoryImplementationsTest extends TestCase
             20
         );
 
-        // When - saving both types
+        // When - saving both types (PublicKeyCredentialSource extends CredentialRecord)
         $repository->saveCredentialSource($credentialRecord);
         $repository->saveCredentialSource($publicKeyCredentialSource);
 
-        // Then - both can be retrieved
+        // Then - both can be retrieved as CredentialRecord
         $retrievedCr = $repository->findOneByCredentialId('cr-id');
         $retrievedPkcs = $repository->findOneByCredentialId('pkcs-id');
 
         static::assertInstanceOf(CredentialRecord::class, $retrievedCr);
+        static::assertInstanceOf(CredentialRecord::class, $retrievedPkcs);
+        // PublicKeyCredentialSource is still a PublicKeyCredentialSource (inheritance)
         static::assertInstanceOf(PublicKeyCredentialSource::class, $retrievedPkcs);
         static::assertSame('user-1', $retrievedCr->userHandle);
         static::assertSame('user-1', $retrievedPkcs->userHandle);


### PR DESCRIPTION
## Summary

This PR improves backward compatibility by making `PublicKeyCredentialSource` extend `CredentialRecord` instead of using union types throughout the codebase.

**Key changes:**
- `PublicKeyCredentialSource` is now an empty class extending `CredentialRecord` (still deprecated)
- Repository interfaces use `CredentialRecord` instead of union types (`CredentialRecord|PublicKeyCredentialSource`)
- Deprecated interfaces (`PublicKeyCredentialSourceRepositoryInterface`, `CanSaveCredentialSource`) now extend their new counterparts
- All ceremony steps and validators updated to use `CredentialRecord` only
- `CredentialRecordConverter` utility updated to handle inheritance

## Motivation

This resolves the concern raised in discussion #803 by @jasonvarga. With this change, downstream packages can simply type-hint `CredentialRecord` and it will automatically accept both `CredentialRecord` and `PublicKeyCredentialSource` instances thanks to inheritance.

**Before:** Code needed union types `CredentialRecord|PublicKeyCredentialSource` to support both types.

**After:** Code can use `CredentialRecord` and PHP's inheritance handles the rest.

## Test plan

- [x] All 265 PHPUnit tests pass
- [x] PHPStan analysis passes
- [x] ECS coding standards pass
- [x] Rector checks pass