### PR TITLE
docs: add @throws phpdoc annotations to denormalizers

### DIFF
--- a/.ci-tools/ecs.php
+++ b/.ci-tools/ecs.php
@@ -13,6 +13,7 @@ use PhpCsFixer\Fixer\Import\OrderedImportsFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\CombineConsecutiveIssetsFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\CombineConsecutiveUnsetsFixer;
 use PhpCsFixer\Fixer\Phpdoc\AlignMultilineCommentFixer;
+use PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer;
 use PhpCsFixer\Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocOrderFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocTrimConsecutiveBlankLineSeparationFixer;
@@ -83,6 +84,9 @@ return static function (ECSConfig $config): void {
         'import_classes' => true,
         'import_constants' => true,
         'import_functions' => true,
+    ]);
+    $config->ruleWithConfiguration(GeneralPhpdocAnnotationRemoveFixer::class, [
+        'annotations' => ['author', 'package', 'group', 'covers', 'category'],
     ]);
 
     $config->skip([

--- a/src/webauthn/src/Denormalizer/AttestationObjectDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/AttestationObjectDenormalizer.php
@@ -19,6 +19,9 @@ final class AttestationObjectDenormalizer implements DenormalizerInterface, Deno
 {
     use DenormalizerAwareTrait;
 
+    /**
+     * @throws InvalidDataException
+     */
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         $stream = new StringStream($data);

--- a/src/webauthn/src/Denormalizer/AttestationStatementDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/AttestationStatementDenormalizer.php
@@ -7,6 +7,7 @@ namespace Webauthn\Denormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Webauthn\AttestationStatement\AttestationStatement;
 use Webauthn\AttestationStatement\AttestationStatementSupportManager;
+use Webauthn\Exception\InvalidDataException;
 
 final readonly class AttestationStatementDenormalizer implements DenormalizerInterface
 {
@@ -15,6 +16,9 @@ final readonly class AttestationStatementDenormalizer implements DenormalizerInt
     ) {
     }
 
+    /**
+     * @throws InvalidDataException
+     */
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         $attestationStatementSupport = $this->attestationStatementSupportManager->get($data['fmt']);

--- a/src/webauthn/src/Denormalizer/AuthenticatorAssertionResponseDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/AuthenticatorAssertionResponseDenormalizer.php
@@ -12,12 +12,16 @@ use Webauthn\AttestationStatement\AttestationObject;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorData;
 use Webauthn\CollectedClientData;
+use Webauthn\Exception\InvalidDataException;
 use Webauthn\Util\Base64;
 
 final class AuthenticatorAssertionResponseDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
 
+    /**
+     * @throws InvalidDataException
+     */
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         $data['authenticatorData'] = Base64::decode($data['authenticatorData']);

--- a/src/webauthn/src/Denormalizer/AuthenticatorAttestationResponseDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/AuthenticatorAttestationResponseDenormalizer.php
@@ -11,12 +11,16 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Webauthn\AttestationStatement\AttestationObject;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\CollectedClientData;
+use Webauthn\Exception\InvalidDataException;
 use Webauthn\Util\Base64;
 
 final class AuthenticatorAttestationResponseDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
 
+    /**
+     * @throws InvalidDataException
+     */
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         $data['clientDataJSON'] = Base64UrlSafe::decodeNoPadding($data['clientDataJSON']);

--- a/src/webauthn/src/Denormalizer/AuthenticatorDataDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/AuthenticatorDataDenormalizer.php
@@ -35,6 +35,9 @@ final class AuthenticatorDataDenormalizer implements DenormalizerInterface, Deno
         $this->decoder = Decoder::create();
     }
 
+    /**
+     * @throws InvalidDataException
+     */
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         $authData = $this->fixIncorrectEdDSAKey($data);

--- a/src/webauthn/src/Denormalizer/AuthenticatorResponseDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/AuthenticatorResponseDenormalizer.php
@@ -17,6 +17,9 @@ final class AuthenticatorResponseDenormalizer implements DenormalizerInterface, 
 {
     use DenormalizerAwareTrait;
 
+    /**
+     * @throws InvalidDataException
+     */
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         $realType = match (true) {

--- a/src/webauthn/src/Denormalizer/CollectedClientDataDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/CollectedClientDataDenormalizer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Webauthn\Denormalizer;
 
 use const JSON_THROW_ON_ERROR;
+use JsonException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -14,6 +15,9 @@ final class CollectedClientDataDenormalizer implements DenormalizerInterface, De
 {
     use DenormalizerAwareTrait;
 
+    /**
+     * @throws JsonException
+     */
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         return CollectedClientData::create($data, json_decode((string) $data, true, flags: JSON_THROW_ON_ERROR));

--- a/src/webauthn/src/Denormalizer/CredentialRecordDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/CredentialRecordDenormalizer.php
@@ -27,6 +27,9 @@ class CredentialRecordDenormalizer implements DenormalizerInterface, Denormalize
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
 
+    /**
+     * @throws InvalidDataException
+     */
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         $keys = ['publicKeyCredentialId', 'credentialPublicKey', 'userHandle'];

--- a/src/webauthn/src/Denormalizer/PublicKeyCredentialDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/PublicKeyCredentialDenormalizer.php
@@ -18,6 +18,9 @@ final class PublicKeyCredentialDenormalizer implements DenormalizerInterface, De
 {
     use DenormalizerAwareTrait;
 
+    /**
+     * @throws InvalidDataException
+     */
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         if (! array_key_exists('id', $data)) {

--- a/src/webauthn/src/Denormalizer/PublicKeyCredentialOptionsDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/PublicKeyCredentialOptionsDenormalizer.php
@@ -30,6 +30,9 @@ final class PublicKeyCredentialOptionsDenormalizer implements DenormalizerInterf
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
 
+    /**
+     * @throws BadMethodCallException
+     */
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         if (array_key_exists('challenge', $data)) {

--- a/src/webauthn/src/Denormalizer/PublicKeyCredentialParametersDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/PublicKeyCredentialParametersDenormalizer.php
@@ -11,6 +11,9 @@ use Webauthn\PublicKeyCredentialParameters;
 
 final class PublicKeyCredentialParametersDenormalizer implements DenormalizerInterface
 {
+    /**
+     * @throws InvalidDataException
+     */
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         if (! array_key_exists('type', $data) || ! array_key_exists('alg', $data)) {

--- a/src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/PublicKeyCredentialSourceDenormalizer.php
@@ -24,6 +24,9 @@ final class PublicKeyCredentialSourceDenormalizer implements DenormalizerInterfa
     use NormalizerAwareTrait;
     use DenormalizerAwareTrait;
 
+    /**
+     * @throws InvalidDataException
+     */
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         $keys = ['publicKeyCredentialId', 'credentialPublicKey', 'userHandle'];

--- a/src/webauthn/src/Denormalizer/PublicKeyCredentialUserEntityDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/PublicKeyCredentialUserEntityDenormalizer.php
@@ -9,11 +9,15 @@ use function assert;
 use ParagonIE\ConstantTime\Base64UrlSafe;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Webauthn\Exception\InvalidDataException;
 use Webauthn\PublicKeyCredentialUserEntity;
 use Webauthn\Util\Base64;
 
 final class PublicKeyCredentialUserEntityDenormalizer implements DenormalizerInterface, NormalizerInterface
 {
+    /**
+     * @throws InvalidDataException
+     */
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         if (! array_key_exists('id', $data)) {

--- a/src/webauthn/src/Denormalizer/TrustPathDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/TrustPathDenormalizer.php
@@ -16,6 +16,9 @@ use Webauthn\TrustPath\TrustPath;
 
 final class TrustPathDenormalizer implements DenormalizerInterface, NormalizerInterface
 {
+    /**
+     * @throws InvalidTrustPathException
+     */
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
         return match (true) {


### PR DESCRIPTION
## Summary

- Add `@throws` phpdoc annotations to all denormalizer `denormalize()` methods that can throw exceptions
- Update ECS configuration to preserve `@throws` annotations (previously stripped by `GeneralPhpdocAnnotationRemoveFixer` from the Symplify set)

Closes #779

## Changes

**14 denormalizers** now document their thrown exceptions:
- `InvalidDataException` — 11 denormalizers (attestation, authentication, credential record, etc.)
- `InvalidTrustPathException` — `TrustPathDenormalizer`
- `BadMethodCallException` — `PublicKeyCredentialOptionsDenormalizer`
- `JsonException` — `CollectedClientDataDenormalizer`

**ECS config** (`ecs.php`): Override `GeneralPhpdocAnnotationRemoveFixer` to remove `@throws` from the annotation removal list while keeping the other annotations (`@author`, `@package`, `@group`, `@covers`, `@category`).

## Test plan

- [x] `castor phpstan` passes
- [x] `castor ecs` passes
- [x] `castor phpunit` passes (273 tests, 1162 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)