### PR TITLE
fix: merge up CVE fix (GHSA-f7pm-6hr8-7ggm) from 5.2.x

### DIFF
--- a/src/webauthn/src/CeremonyStep/CheckAllowedOrigins.php
+++ b/src/webauthn/src/CeremonyStep/CheckAllowedOrigins.php
@@ -23,9 +23,18 @@ use Webauthn\PublicKeyCredentialSource;
 final readonly class CheckAllowedOrigins implements CeremonyStep
 {
     /**
+     * Full origin entries (scheme://host[:port]) from allowed origins that include a scheme.
+     *
      * @var string[]
      */
-    private array $allowedOrigins;
+    private array $fullOrigins;
+
+    /**
+     * Host-only entries from allowed origins without a scheme (backward compatibility).
+     *
+     * @var string[]
+     */
+    private array $hostOrigins;
 
     /**
      * @param string[] $allowedOrigins
@@ -34,15 +43,20 @@ final readonly class CheckAllowedOrigins implements CeremonyStep
         array $allowedOrigins,
         private bool $allowSubdomains = false
     ) {
+        $fullOrigins = [];
+        $hostOrigins = [];
         foreach ($allowedOrigins as $allowedOrigin) {
-            $parsedAllowedOrigin = parse_url($allowedOrigin);
-            $parsedAllowedOrigin !== false || throw new InvalidArgumentException(sprintf(
-                'Invalid origin: %s',
-                $allowedOrigin
-            ));
+            $parsed = parse_url($allowedOrigin);
+            $parsed !== false || throw new InvalidArgumentException(sprintf('Invalid origin: %s', $allowedOrigin));
+            if (isset($parsed['scheme'], $parsed['host'])) {
+                $fullOrigins[] = self::buildOrigin($parsed['scheme'], $parsed['host'], $parsed['port'] ?? null);
+            } else {
+                $hostOrigins[] = $parsed['host'] ?? $allowedOrigin;
+            }
         }
 
-        $this->allowedOrigins = array_unique($allowedOrigins);
+        $this->fullOrigins = array_unique($fullOrigins);
+        $this->hostOrigins = array_unique($hostOrigins);
     }
 
     public function process(
@@ -63,29 +77,43 @@ final readonly class CheckAllowedOrigins implements CeremonyStep
         $authData = $authenticatorResponse instanceof AuthenticatorAssertionResponse ? $authenticatorResponse->authenticatorData : $authenticatorResponse->attestationObject->authData;
         $C = $authenticatorResponse->clientDataJSON;
 
-        $parsedRelyingPartyId = parse_url($C->origin);
-        $clientDataRpId = $parsedRelyingPartyId['host'] ?? '';
-        if ($clientDataRpId === '') {
-            $clientDataRpId = $C->origin;
-        }
-        is_array($parsedRelyingPartyId) || throw AuthenticatorResponseVerificationException::create(
+        $parsedOrigin = parse_url($C->origin);
+        is_array($parsedOrigin) || throw AuthenticatorResponseVerificationException::create(
             'Invalid origin. Unable to parse the origin.'
         );
-        if (in_array($C->origin, $this->allowedOrigins, true)) {
-            return;
-        }
-        $allowedHosts = array_map(
-            static fn (string $origin): string => parse_url($origin, PHP_URL_HOST) ?? $origin,
-            $this->allowedOrigins
-        );
-        $isSubDomain = $this->isSubdomain($allowedHosts, $clientDataRpId);
-        if ($this->allowSubdomains && $isSubDomain) {
-            return;
-        }
-        if (! $this->allowSubdomains && $isSubDomain) {
-            throw AuthenticatorResponseVerificationException::create('Invalid origin. Subdomains are not allowed.');
-        }
-        if (count($this->allowedOrigins) !== 0) {
+        $originHost = $parsedOrigin['host'] ?? $C->origin;
+
+        $hasAllowedOrigins = count($this->fullOrigins) !== 0 || count($this->hostOrigins) !== 0;
+
+        if ($hasAllowedOrigins) {
+            // Full origin match (scheme + host + port)
+            if (isset($parsedOrigin['scheme'], $parsedOrigin['host'])) {
+                $normalizedOrigin = self::buildOrigin(
+                    $parsedOrigin['scheme'],
+                    $parsedOrigin['host'],
+                    $parsedOrigin['port'] ?? null
+                );
+                if (in_array($normalizedOrigin, $this->fullOrigins, true)) {
+                    return;
+                }
+            }
+
+            // Host-only match (backward compatibility for entries without scheme)
+            if (in_array($originHost, $this->hostOrigins, true)) {
+                return;
+            }
+
+            // Subdomain matching
+            $isFullOriginSubdomain = $this->isSubdomainOfFullOrigins($parsedOrigin);
+            $isHostSubdomain = $this->isSubdomain($this->hostOrigins, $originHost);
+            $isSubDomain = $isFullOriginSubdomain || $isHostSubdomain;
+
+            if ($this->allowSubdomains && $isSubDomain) {
+                return;
+            }
+            if (! $this->allowSubdomains && $isSubDomain) {
+                throw AuthenticatorResponseVerificationException::create('Invalid origin. Subdomains are not allowed.');
+            }
             throw AuthenticatorResponseVerificationException::create(
                 'Invalid origin. Not in the list of allowed origins.'
             );
@@ -96,10 +124,10 @@ final readonly class CheckAllowedOrigins implements CeremonyStep
         $facetId !== '' || throw AuthenticatorResponseVerificationException::create(
             'Invalid origin. Unable to determine the facet ID.'
         );
-        if ($clientDataRpId === $facetId) {
+        if ($originHost === $facetId) {
             return;
         }
-        $isSubDomains = $this->isSubdomainOf($clientDataRpId, $facetId);
+        $isSubDomains = $this->isSubdomainOf($originHost, $facetId);
         if ($this->allowSubdomains && $isSubDomains) {
             return;
         }
@@ -107,10 +135,63 @@ final readonly class CheckAllowedOrigins implements CeremonyStep
             throw AuthenticatorResponseVerificationException::create('Invalid origin. Subdomains are not allowed.');
         }
 
-        $scheme = $parsedRelyingPartyId['scheme'] ?? '';
+        $scheme = $parsedOrigin['scheme'] ?? '';
         $scheme === 'https' || throw AuthenticatorResponseVerificationException::create(
             'Invalid scheme. HTTPS required.'
         );
+    }
+
+    /**
+     * @param array<string, mixed> $parsedOrigin Parsed origin from parse_url()
+     */
+    private function isSubdomainOfFullOrigins(array $parsedOrigin): bool
+    {
+        if (! isset($parsedOrigin['scheme'], $parsedOrigin['host'])) {
+            return false;
+        }
+        /** @var string $originScheme */
+        $originScheme = $parsedOrigin['scheme'];
+        /** @var string $originHost */
+        $originHost = $parsedOrigin['host'];
+        $originPort = $parsedOrigin['port'] ?? null;
+
+        foreach ($this->fullOrigins as $fullOrigin) {
+            $parsedAllowed = parse_url($fullOrigin);
+            if (! is_array($parsedAllowed) || ! isset($parsedAllowed['scheme'], $parsedAllowed['host'])) {
+                continue;
+            }
+            /** @var string $allowedScheme */
+            $allowedScheme = $parsedAllowed['scheme'];
+            /** @var string $allowedHost */
+            $allowedHost = $parsedAllowed['host'];
+            if ($originScheme !== $allowedScheme) {
+                continue;
+            }
+            $allowedPort = $parsedAllowed['port'] ?? null;
+            if ($originPort !== $allowedPort) {
+                continue;
+            }
+            if ($this->isSubdomainOf($originHost, $allowedHost)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function buildOrigin(string $scheme, string $host, ?int $port): string
+    {
+        if ($port === null) {
+            return sprintf('%s://%s', $scheme, $host);
+        }
+        $defaultPorts = [
+            'https' => 443,
+            'http' => 80,
+        ];
+        if (isset($defaultPorts[$scheme]) && $port === $defaultPorts[$scheme]) {
+            return sprintf('%s://%s', $scheme, $host);
+        }
+        return sprintf('%s://%s:%d', $scheme, $host, $port);
     }
 
     private function isSubdomainOf(string $subdomain, string $domain): bool

--- a/tests/library/AbstractTestCase.php
+++ b/tests/library/AbstractTestCase.php
@@ -105,6 +105,7 @@ abstract class AbstractTestCase extends TestCase
             $this->ceremonyStepManagerFactory->setAllowedOrigins([
                 'http://localhost',
                 'https://localhost',
+                'https://localhost:8443',
                 'https://dev.dontneeda.pw',
                 'https://spomky-webauthn.herokuapp.com',
                 'https://tuleap-web.tuleap-aio-dev.docker',

--- a/tests/library/Functional/CheckAllowedOriginsTest.php
+++ b/tests/library/Functional/CheckAllowedOriginsTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Webauthn\Tests\Functional;
 
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Uid\Uuid;
 use Webauthn\CeremonyStep\CheckAllowedOrigins;

--- a/tests/symfony/config/config.yml
+++ b/tests/symfony/config/config.yml
@@ -122,6 +122,7 @@ webauthn:
   options_storage: 'Webauthn\Tests\Bundle\Functional\CustomSessionStorage'
   allowed_origins:
     - 'https://localhost'
+    - 'https://localhost:8443'
     - 'https://bar.acme'
     - 'https://webauthn.spomky-labs.com'
     - 'https://spomky-webauthn.herokuapp.com'

--- a/tests/symfony/functional/Firewall/AllowedOriginsTest.php
+++ b/tests/symfony/functional/Firewall/AllowedOriginsTest.php
@@ -27,7 +27,7 @@ final class AllowedOriginsTest extends WebauthnTestCase
         //Then
         static::assertResponseIsSuccessful();
         static::assertSame(
-            '{"origins":["https:\/\/localhost","https:\/\/bar.acme","https:\/\/webauthn.spomky-labs.com","https:\/\/spomky-webauthn.herokuapp.com"]}',
+            '{"origins":["https:\/\/localhost","https:\/\/localhost:8443","https:\/\/bar.acme","https:\/\/webauthn.spomky-labs.com","https:\/\/spomky-webauthn.herokuapp.com"]}',
             $client->getResponse()
                 ->getContent()
         );


### PR DESCRIPTION
## Summary

- Ports the robust origin validation fix from 5.2.4 to 5.3.x
- Replaces the simpler fix (from the private fork merge) with the full implementation:
  - Full origin comparison (scheme + host + port) as required by WebAuthn Level 2 spec
  - Default port normalization (443 for HTTPS, 80 for HTTP)
  - Backward-compatible host-only matching for entries without scheme
  - Scheme+port-aware subdomain matching via `isSubdomainOfFullOrigins()`
  - PHPStan-clean `@var` annotations for `parse_url()` return values

## Test plan

- [x] All 11 `CheckAllowedOriginsTest` tests pass (including CVE PoC tests)
- [x] All 12 Symfony `AllowedOriginsTest` tests pass
- [x] PHPStan clean on `CheckAllowedOrigins.php`

Related: [GHSA-f7pm-6hr8-7ggm](https://github.com/web-auth/webauthn-framework/security/advisories/GHSA-f7pm-6hr8-7ggm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)