### PR TITLE
fix: derive compound attestation type from nested types

### DIFF
--- a/src/webauthn/src/AttestationStatement/CompoundAttestationStatementSupport.php
+++ b/src/webauthn/src/AttestationStatement/CompoundAttestationStatementSupport.php
@@ -34,6 +34,14 @@ final class CompoundAttestationStatementSupport implements AttestationStatementS
 {
     use AttestationStatementSupportManagerAwareTrait;
 
+    private const ATTESTATION_TYPE_TRUST_ORDER = [
+        AttestationStatement::TYPE_ATTCA,
+        AttestationStatement::TYPE_ANONCA,
+        AttestationStatement::TYPE_BASIC,
+        AttestationStatement::TYPE_SELF,
+        AttestationStatement::TYPE_NONE,
+    ];
+
     private EventDispatcherInterface $dispatcher;
 
     private ?float $ratio = 1.0;
@@ -118,11 +126,12 @@ final class CompoundAttestationStatementSupport implements AttestationStatementS
 
         /** @var string $compoundFmt */
         $compoundFmt = $attestation['fmt'];
+        $attestationType = $this->deriveAttestationType($loadedAttestations);
         // Create a compound attestation statement with compound trust path
         $attestationStatement = AttestationStatement::create(
             $compoundFmt,
             $loadedAttestations,
-            AttestationStatement::TYPE_BASIC,
+            $attestationType,
             EmptyTrustPath::create()
         );
 
@@ -169,6 +178,28 @@ final class CompoundAttestationStatementSupport implements AttestationStatementS
             return $countValid >= $this->minimum;
         }
         return $countValid / $total >= $this->ratio;
+    }
+
+    /**
+     * Derives the compound attestation type from the nested attestation types
+     * by selecting the weakest (least trusted) type among them.
+     *
+     * @param array<AttestationStatement> $loadedAttestations
+     */
+    private function deriveAttestationType(array $loadedAttestations): string
+    {
+        $weakest = 0;
+        foreach ($loadedAttestations as $stmt) {
+            $index = array_search($stmt->type, self::ATTESTATION_TYPE_TRUST_ORDER, true);
+            if ($index === false) {
+                return AttestationStatement::TYPE_NONE;
+            }
+            if ($index > $weakest) {
+                $weakest = $index;
+            }
+        }
+
+        return self::ATTESTATION_TYPE_TRUST_ORDER[$weakest];
     }
 
     private function checkRules(?float $ratio, ?int $minimum): void

--- a/tests/library/Unit/AttestationStatement/CompoundAttestationStatementSupportTest.php
+++ b/tests/library/Unit/AttestationStatement/CompoundAttestationStatementSupportTest.php
@@ -6,6 +6,7 @@ namespace Webauthn\Tests\Unit\AttestationStatement;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Webauthn\AttestationStatement\AttestationStatement;
 use Webauthn\AttestationStatement\AttestationStatementSupportManager;
 use Webauthn\AttestationStatement\CompoundAttestationStatementSupport;
 use Webauthn\AttestationStatement\NoneAttestationStatementSupport;
@@ -194,6 +195,35 @@ final class CompoundAttestationStatementSupportTest extends TestCase
 
         // When
         $support->load($attestation);
+    }
+
+    #[Test]
+    public function loadingCompoundAttestationDerivesTypeFromNestedAttestations(): void
+    {
+        // Given
+        $manager = new AttestationStatementSupportManager([]);
+        $support = new CompoundAttestationStatementSupport();
+        $support->setAttestationStatementSupportManager($manager);
+
+        $attestation = [
+            'fmt' => 'compound',
+            'attStmt' => [
+                [
+                    'fmt' => 'none',
+                    'attStmt' => [],
+                ],
+                [
+                    'fmt' => 'none',
+                    'attStmt' => [],
+                ],
+            ],
+        ];
+
+        // When
+        $result = $support->load($attestation);
+
+        // Then — all nested are TYPE_NONE, so compound should derive TYPE_NONE
+        static::assertSame(AttestationStatement::TYPE_NONE, $result->type);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- Derive the compound attestation type from nested attestation types instead of hardcoding `TYPE_BASIC`
- Uses the weakest (least trusted) type among all nested attestations, preventing trust level overestimation
- Trust order (strongest to weakest): `attca` > `anonca` > `basic` > `self` > `none`

## Context
Addresses GHSA-7rg8-jq97-qcwr: the `attestationType` label on compound attestation statements was hardcoded to `TYPE_BASIC` regardless of the nested attestation types. This could misrepresent the trust level when sub-attestations have lower trust.

## Test plan
- [x] Added test verifying type derivation from nested attestations
- [x] All existing CompoundAttestationStatementSupport tests pass (9/9)
- [x] ECS, Rector, PHPStan pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)