### PR TITLE
fix: enforce HTTPS scheme check in CheckAllowedOrigins fallback path

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,18 +13,6 @@ parameters:
 			path: src/stimulus/src/WebauthnStimulusBundle.php
 
 		-
-			rawMessage: 'Since web-auth/webauthn-lib 5.2.0: The parameter "$optionStorage" is deprecated since 5.2.0 and will be removed in 6.0.0. Please set "null" and use the global option storage instead..'
-			identifier: todoBy.sfDeprecation
-			count: 2
-			path: src/symfony/src/Controller/AssertionControllerFactory.php
-
-		-
-			rawMessage: 'Since web-auth/webauthn-lib 5.2.0: The parameter "$optionStorage" is deprecated since 5.2.0 and will be removed in 6.0.0. Please set "null" and use the global option storage instead..'
-			identifier: todoBy.sfDeprecation
-			count: 2
-			path: src/symfony/src/Controller/AttestationControllerFactory.php
-
-		-
 			rawMessage: 'Method Webauthn\Bundle\CredentialOptionsBuilder\PublicKeyCredentialCreationOptionsBuilder::getFromRequest() invoked with 3 parameters, 2 required.'
 			identifier: arguments.count
 			count: 1
@@ -2180,12 +2168,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/webauthn/src/MetadataService/Statement/MetadataStatement.php
-
-		-
-			rawMessage: 'Since web-auth/webauthn-lib 5.1.0: The parameter "$icon" is deprecated since 5.1.0 and will be removed in 6.0.0. This value has no effect. Please set "null" instead..'
-			identifier: todoBy.sfDeprecation
-			count: 1
-			path: src/webauthn/src/PublicKeyCredentialEntity.php
 
 		-
 			rawMessage: 'Parameter #1 $extensions of static method Webauthn\AuthenticationExtensions\AuthenticationExtensions::create() expects array<Webauthn\AuthenticationExtensions\AuthenticationExtension>, array<Webauthn\AuthenticationExtensions\AuthenticationExtensions> given.'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1612,7 +1612,7 @@ parameters:
 			path: src/webauthn/src/Denormalizer/AuthenticationExtensionNormalizer.php
 
 		-
-			rawMessage: 'Parameter #1 $extensions of static method Webauthn\AuthenticationExtensions\AuthenticationExtensions::create() expects array<Webauthn\AuthenticationExtensions\AuthenticationExtension>, array given.'
+			rawMessage: 'Parameter #1 $extensions of static method Webauthn\AuthenticationExtensions\AuthenticationExtensions::create() expects array<Webauthn\AuthenticationExtensions\AuthenticationExtension>, array<mixed> given.'
 			identifier: argument.type
 			count: 1
 			path: src/webauthn/src/Denormalizer/AuthenticationExtensionsDenormalizer.php

--- a/src/webauthn/src/CeremonyStep/CeremonyStepManagerFactory.php
+++ b/src/webauthn/src/CeremonyStep/CeremonyStepManagerFactory.php
@@ -135,7 +135,11 @@ final class CeremonyStepManagerFactory
             new CheckChallenge(),
             $this->allowedOrigins === null ? new CheckOrigin(
                 $this->securedRelyingPartyId ?? []
-            ) : new CheckAllowedOrigins($this->allowedOrigins, $this->allowSubdomains, $this->securedRelyingPartyId ?? []),
+            ) : new CheckAllowedOrigins(
+                $this->allowedOrigins,
+                $this->allowSubdomains,
+                $this->securedRelyingPartyId ?? []
+            ),
             new CheckTopOrigin($this->topOriginValidator),
             new CheckRelyingPartyIdIdHash(),
             new CheckUserWasPresent(),
@@ -160,7 +164,11 @@ final class CeremonyStepManagerFactory
             new CheckChallenge(),
             $this->allowedOrigins === null ? new CheckOrigin(
                 $this->securedRelyingPartyId ?? []
-            ) : new CheckAllowedOrigins($this->allowedOrigins, $this->allowSubdomains, $this->securedRelyingPartyId ?? []),
+            ) : new CheckAllowedOrigins(
+                $this->allowedOrigins,
+                $this->allowSubdomains,
+                $this->securedRelyingPartyId ?? []
+            ),
             new CheckTopOrigin(),
             new CheckRelyingPartyIdIdHash(),
             new CheckUserWasPresent(),

--- a/src/webauthn/src/CeremonyStep/CeremonyStepManagerFactory.php
+++ b/src/webauthn/src/CeremonyStep/CeremonyStepManagerFactory.php
@@ -135,7 +135,7 @@ final class CeremonyStepManagerFactory
             new CheckChallenge(),
             $this->allowedOrigins === null ? new CheckOrigin(
                 $this->securedRelyingPartyId ?? []
-            ) : new CheckAllowedOrigins($this->allowedOrigins, $this->allowSubdomains),
+            ) : new CheckAllowedOrigins($this->allowedOrigins, $this->allowSubdomains, $this->securedRelyingPartyId ?? []),
             new CheckTopOrigin($this->topOriginValidator),
             new CheckRelyingPartyIdIdHash(),
             new CheckUserWasPresent(),
@@ -160,7 +160,7 @@ final class CeremonyStepManagerFactory
             new CheckChallenge(),
             $this->allowedOrigins === null ? new CheckOrigin(
                 $this->securedRelyingPartyId ?? []
-            ) : new CheckAllowedOrigins($this->allowedOrigins, $this->allowSubdomains),
+            ) : new CheckAllowedOrigins($this->allowedOrigins, $this->allowSubdomains, $this->securedRelyingPartyId ?? []),
             new CheckTopOrigin(),
             new CheckRelyingPartyIdIdHash(),
             new CheckUserWasPresent(),

--- a/src/webauthn/src/CeremonyStep/CheckAllowedOrigins.php
+++ b/src/webauthn/src/CeremonyStep/CheckAllowedOrigins.php
@@ -38,10 +38,12 @@ final readonly class CheckAllowedOrigins implements CeremonyStep
 
     /**
      * @param string[] $allowedOrigins
+     * @param string[] $securedRelyingPartyId RP IDs that are allowed to use HTTP (e.g. localhost for development)
      */
     public function __construct(
         array $allowedOrigins,
-        private bool $allowSubdomains = false
+        private bool $allowSubdomains = false,
+        private array $securedRelyingPartyId = [],
     ) {
         $fullOrigins = [];
         $hostOrigins = [];
@@ -113,6 +115,13 @@ final readonly class CheckAllowedOrigins implements CeremonyStep
 
         $rpId = $publicKeyCredentialOptions->rpId ?? $publicKeyCredentialOptions->rp->id ?? $host;
         $facetId = $this->getFacetId($rpId, $publicKeyCredentialOptions->extensions, $authData->extensions);
+
+        if (! in_array($facetId, $this->securedRelyingPartyId, true)) {
+            $scheme = $parsedOrigin['scheme'] ?? '';
+            $scheme === 'https' || throw AuthenticatorResponseVerificationException::create(
+                'Invalid scheme. HTTPS required.'
+            );
+        }
         $facetId !== '' || throw AuthenticatorResponseVerificationException::create(
             'Invalid origin. Unable to determine the facet ID.'
         );
@@ -126,11 +135,7 @@ final readonly class CheckAllowedOrigins implements CeremonyStep
         if (! $this->allowSubdomains && $isSubDomains) {
             throw AuthenticatorResponseVerificationException::create('Invalid origin. Subdomains are not allowed.');
         }
-
-        $scheme = $parsedOrigin['scheme'] ?? '';
-        $scheme === 'https' || throw AuthenticatorResponseVerificationException::create(
-            'Invalid scheme. HTTPS required.'
-        );
+        throw AuthenticatorResponseVerificationException::create('Invalid origin.');
     }
 
     /**


### PR DESCRIPTION
## Summary

- Move HTTPS scheme check before host comparison in the fallback path (no allowed origins configured) of `CheckAllowedOrigins`, where it was previously unreachable dead code
- Add `$securedRelyingPartyId` parameter to `CheckAllowedOrigins` to allow exempting specific RP IDs from HTTPS enforcement (e.g. `localhost` in development)
- Add a final `throw` when neither host nor subdomain matches, replacing the former dead code path