### PR TITLE
fix: pass topOriginValidator to CheckTopOrigin in requestCeremony()

### DIFF
--- a/src/webauthn/src/CeremonyStep/CeremonyStepManagerFactory.php
+++ b/src/webauthn/src/CeremonyStep/CeremonyStepManagerFactory.php
@@ -169,7 +169,7 @@ final class CeremonyStepManagerFactory
                 $this->allowSubdomains,
                 $this->securedRelyingPartyId ?? []
             ),
-            new CheckTopOrigin(),
+            new CheckTopOrigin($this->topOriginValidator),
             new CheckRelyingPartyIdIdHash(),
             new CheckUserWasPresent(),
             new CheckUserVerification(),

--- a/src/webauthn/src/CeremonyStep/CheckTopOrigin.php
+++ b/src/webauthn/src/CeremonyStep/CheckTopOrigin.php
@@ -33,9 +33,8 @@ class CheckTopOrigin implements CeremonyStep
             throw AuthenticatorResponseVerificationException::create('The response is not cross-origin.');
         }
         if ($this->topOriginValidator === null) {
-            (new HostTopOriginValidator($host))->validate($topOrigin);
-        } else {
-            $this->topOriginValidator->validate($topOrigin);
+            return;
         }
+        $this->topOriginValidator->validate($topOrigin);
     }
 }


### PR DESCRIPTION
## Summary

- The custom `TopOriginValidator` set via `enableTopOriginValidator()` was passed to `CheckTopOrigin` in `creationCeremony()` but **not** in `requestCeremony()`. Fixed by passing `$this->topOriginValidator` in both ceremonies.
- `enableTopOriginValidator()` was misleading: top origin validation was **always** active via a fallback `HostTopOriginValidator`, making the method name suggest it "enables" something that was already on. Now, when no `TopOriginValidator` is configured, the top origin check is skipped entirely. Calling `enableTopOriginValidator()` truly enables the validation.

Fixes #816

## Test plan

- [ ] Verify that without calling `enableTopOriginValidator()`, top origin validation is skipped (no strict host comparison)
- [ ] Verify that calling `enableTopOriginValidator()` with a custom validator activates validation for both creation and request ceremonies
- [ ] Verify cross-origin iframe authentication works when `topOrigin` differs from `host` and no top origin validator is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)