### PR TITLE
fix: normalize host-only allowed origins to https:// scheme

### DIFF
--- a/src/webauthn/src/CeremonyStep/CheckAllowedOrigins.php
+++ b/src/webauthn/src/CeremonyStep/CheckAllowedOrigins.php
@@ -23,18 +23,11 @@ use function substr;
 final readonly class CheckAllowedOrigins implements CeremonyStep
 {
     /**
-     * Full origin entries (scheme://host[:port]) from allowed origins that include a scheme.
+     * Full origin entries (scheme://host[:port]) from allowed origins.
      *
      * @var string[]
      */
     private array $fullOrigins;
-
-    /**
-     * Host-only entries from allowed origins without a scheme (backward compatibility).
-     *
-     * @var string[]
-     */
-    private array $hostOrigins;
 
     /**
      * @param string[] $allowedOrigins
@@ -46,19 +39,19 @@ final readonly class CheckAllowedOrigins implements CeremonyStep
         private array $securedRelyingPartyId = [],
     ) {
         $fullOrigins = [];
-        $hostOrigins = [];
         foreach ($allowedOrigins as $allowedOrigin) {
             $parsed = parse_url($allowedOrigin);
             $parsed !== false || throw new InvalidArgumentException(sprintf('Invalid origin: %s', $allowedOrigin));
             if (isset($parsed['scheme'], $parsed['host'])) {
                 $fullOrigins[] = self::buildOrigin($parsed['scheme'], $parsed['host'], $parsed['port'] ?? null);
             } else {
-                $hostOrigins[] = $parsed['host'] ?? $allowedOrigin;
+                // Host-only entries are normalized to https:// since WebAuthn requires TLS
+                $host = $parsed['host'] ?? $allowedOrigin;
+                $fullOrigins[] = self::buildOrigin('https', $host, null);
             }
         }
 
         $this->fullOrigins = array_unique($fullOrigins);
-        $this->hostOrigins = array_unique($hostOrigins);
     }
 
     public function process(
@@ -77,7 +70,7 @@ final readonly class CheckAllowedOrigins implements CeremonyStep
         );
         $originHost = $parsedOrigin['host'] ?? $C->origin;
 
-        $hasAllowedOrigins = count($this->fullOrigins) !== 0 || count($this->hostOrigins) !== 0;
+        $hasAllowedOrigins = count($this->fullOrigins) !== 0;
 
         if ($hasAllowedOrigins) {
             // Full origin match (scheme + host + port)
@@ -92,15 +85,8 @@ final readonly class CheckAllowedOrigins implements CeremonyStep
                 }
             }
 
-            // Host-only match (backward compatibility for entries without scheme)
-            if (in_array($originHost, $this->hostOrigins, true)) {
-                return;
-            }
-
             // Subdomain matching
-            $isFullOriginSubdomain = $this->isSubdomainOfFullOrigins($parsedOrigin);
-            $isHostSubdomain = $this->isSubdomain($this->hostOrigins, $originHost);
-            $isSubDomain = $isFullOriginSubdomain || $isHostSubdomain;
+            $isSubDomain = $this->isSubdomainOfFullOrigins($parsedOrigin);
 
             if ($this->allowSubdomains && $isSubDomain) {
                 return;
@@ -215,16 +201,4 @@ final readonly class CheckAllowedOrigins implements CeremonyStep
         return (is_string($appId) && $wasUsed === true) ? $appId : $rpId;
     }
 
-    /**
-     * @param string[] $origins
-     */
-    private function isSubdomain(array $origins, string $domain): bool
-    {
-        foreach ($origins as $allowedOrigin) {
-            if ($this->isSubdomainOf($domain, $allowedOrigin)) {
-                return true;
-            }
-        }
-        return false;
-    }
 }

--- a/src/webauthn/src/CeremonyStep/CheckAllowedOrigins.php
+++ b/src/webauthn/src/CeremonyStep/CheckAllowedOrigins.php
@@ -200,5 +200,4 @@ final readonly class CheckAllowedOrigins implements CeremonyStep
 
         return (is_string($appId) && $wasUsed === true) ? $appId : $rpId;
     }
-
 }


### PR DESCRIPTION
## Summary

- Host-only entries in `allowed_origins` (e.g. `example.com` without scheme) were matched only against the incoming origin's host, bypassing scheme and port validation. This allowed origins like `https://example.com:8443` or `https://example.com:9999` to pass validation when only `example.com` was configured.
- Since WebAuthn requires TLS, host-only entries are now normalized to `https://{host}` in the constructor and go through the full origin match (scheme + host + port), closing this bypass.
- The `$hostOrigins` property and `isSubdomain()` helper method are removed as they are no longer needed.

Fixes #817

## Test plan

- [x] Existing tests pass — host-only entries like `spomky-labs.com` with `allowSubdomains=true` still correctly match subdomains via full origin matching
- [ ] Verify that `example.com` in allowed_origins only matches `https://example.com` (not `https://example.com:8443` or `http://example.com`)
- [ ] Verify that `http://localhost` explicitly configured still works for development

🤖 Generated with [Claude Code](https://claude.com/claude-code)