### PR TITLE
fix: complete CredentialRecord migration and restore 5.2.x BC (#827, #832, #833)

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -2,57 +2,21 @@ parameters:
 	ignoreErrors:
 		-
 			rawMessage: '''
-				Parameter $publicKeyCredentialSourceRepository of method Webauthn\Bundle\Controller\AssertionControllerFactory::__construct() has typehint with deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
+				Call to method fromCredentialRecord() of deprecated class Webauthn\PublicKeyCredentialSource:
+				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
 			'''
-			identifier: parameter.deprecatedInterface
+			identifier: staticMethod.deprecatedClass
 			count: 1
-			path: ../src/symfony/src/Controller/AssertionControllerFactory.php
+			path: ../src/symfony/src/Controller/AttestationResponseController.php
 
 		-
 			rawMessage: '''
-				Property $publicKeyCredentialSourceRepository references deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface in its type:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
+				Call to method saveCredentialSource() of deprecated interface Webauthn\Bundle\Repository\CanSaveCredentialSource:
+				since 5.3, use CanSaveCredentialRecord instead. Will be removed in 6.0.
 			'''
-			identifier: property.deprecatedInterface
+			identifier: method.deprecatedInterface
 			count: 1
-			path: ../src/symfony/src/Controller/AssertionControllerFactory.php
-
-		-
-			rawMessage: '''
-				Parameter $publicKeyCredentialSourceRepository of method Webauthn\Bundle\Controller\AssertionResponseController::__construct() has typehint with deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedInterface
-			count: 1
-			path: ../src/symfony/src/Controller/AssertionResponseController.php
-
-		-
-			rawMessage: '''
-				Property $publicKeyCredentialSourceRepository references deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface in its type:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedInterface
-			count: 1
-			path: ../src/symfony/src/Controller/AssertionResponseController.php
-
-		-
-			rawMessage: '''
-				Parameter $publicKeyCredentialSourceRepository of method Webauthn\Bundle\Controller\AttestationControllerFactory::__construct() has typehint with deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedInterface
-			count: 1
-			path: ../src/symfony/src/Controller/AttestationControllerFactory.php
-
-		-
-			rawMessage: '''
-				Property $publicKeyCredentialSourceRepository references deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface in its type:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedInterface
-			count: 1
-			path: ../src/symfony/src/Controller/AttestationControllerFactory.php
+			path: ../src/symfony/src/Controller/AttestationResponseController.php
 
 		-
 			rawMessage: '''
@@ -60,62 +24,8 @@ parameters:
 				since 5.3, use CanSaveCredentialRecord instead. Will be removed in 6.0.
 			'''
 			identifier: instanceof.deprecatedInterface
-			count: 1
+			count: 2
 			path: ../src/symfony/src/Controller/AttestationResponseController.php
-
-		-
-			rawMessage: '''
-				Parameter $credentialSourceRepository of method Webauthn\Bundle\Controller\AttestationResponseController::__construct() has typehint with deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedInterface
-			count: 1
-			path: ../src/symfony/src/Controller/AttestationResponseController.php
-
-		-
-			rawMessage: '''
-				Property $credentialSourceRepository references deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface in its type:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedInterface
-			count: 1
-			path: ../src/symfony/src/Controller/AttestationResponseController.php
-
-		-
-			rawMessage: '''
-				Parameter $credentialSourceRepository of method Webauthn\Bundle\CredentialOptionsBuilder\ProfileBasedCreationOptionsBuilder::__construct() has typehint with deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedInterface
-			count: 1
-			path: ../src/symfony/src/CredentialOptionsBuilder/ProfileBasedCreationOptionsBuilder.php
-
-		-
-			rawMessage: '''
-				Property $credentialSourceRepository references deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface in its type:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedInterface
-			count: 1
-			path: ../src/symfony/src/CredentialOptionsBuilder/ProfileBasedCreationOptionsBuilder.php
-
-		-
-			rawMessage: '''
-				Parameter $credentialSourceRepository of method Webauthn\Bundle\CredentialOptionsBuilder\ProfileBasedRequestOptionsBuilder::__construct() has typehint with deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedInterface
-			count: 1
-			path: ../src/symfony/src/CredentialOptionsBuilder/ProfileBasedRequestOptionsBuilder.php
-
-		-
-			rawMessage: '''
-				Property $credentialSourceRepository references deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface in its type:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedInterface
-			count: 1
-			path: ../src/symfony/src/CredentialOptionsBuilder/ProfileBasedRequestOptionsBuilder.php
 
 		-
 			rawMessage: '''
@@ -125,15 +35,6 @@ parameters:
 			identifier: method.deprecated
 			count: 1
 			path: ../src/symfony/src/DependencyInjection/Compiler/CeremonyStepManagerFactoryCompilerPass.php
-
-		-
-			rawMessage: '''
-				Access to constant on deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
-			'''
-			identifier: classConstant.deprecatedInterface
-			count: 2
-			path: ../src/symfony/src/DependencyInjection/Factory/Security/WebauthnFactory.php
 
 		-
 			rawMessage: 'Parameter #3 $config (array{secured_rp_ids: array<string>, success_handler: string, failure_handler: string, options_storage: string|null, authentication: array{enabled: bool, profile: string, options_builder: string|null, options_handler: string, routes: array{host: string|null, options_method: string, options_path: string, result_method: string, result_path: string|null}}, registration: array{enabled: bool, profile: string, options_builder: string|null, options_handler: string, hide_existing_credentials: bool, routes: array{host: string|null, options_method: string, options_path: string, result_method: string, result_path: string|null}}}) of method Webauthn\Bundle\DependencyInjection\Factory\Security\WebauthnFactory::createAuthenticator() should be contravariant with parameter $config (array<string, mixed>) of method Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface::createAuthenticator()'
@@ -147,7 +48,7 @@ parameters:
 				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
 			'''
 			identifier: classConstant.deprecatedInterface
-			count: 3
+			count: 1
 			path: ../src/symfony/src/DependencyInjection/WebauthnExtension.php
 
 		-
@@ -158,15 +59,6 @@ parameters:
 			identifier: class.implementsDeprecatedInterface
 			count: 1
 			path: ../src/symfony/src/Repository/DummyPublicKeyCredentialSourceRepository.php
-
-		-
-			rawMessage: '''
-				Access to constant on deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
-			'''
-			identifier: classConstant.deprecatedInterface
-			count: 1
-			path: ../src/symfony/src/Resources/config/security.php
 
 		-
 			rawMessage: 'Parameter #1 $data (array{Webauthn\PublicKeyCredentialUserEntity, Webauthn\PublicKeyCredentialDescriptor, Webauthn\PublicKeyCredentialOptions, bool, bool, bool, bool, int, ...}) of method Webauthn\Bundle\Security\Authentication\Token\WebauthnToken::__unserialize() should be contravariant with parameter $data (array) of method Symfony\Component\Security\Core\Authentication\Token\AbstractToken::__unserialize()'
@@ -200,29 +92,29 @@ parameters:
 
 		-
 			rawMessage: '''
+				Call to method fromCredentialRecord() of deprecated class Webauthn\PublicKeyCredentialSource:
+				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
+			'''
+			identifier: staticMethod.deprecatedClass
+			count: 1
+			path: ../src/symfony/src/Security/Authentication/WebauthnBadgeListener.php
+
+		-
+			rawMessage: '''
+				Call to method saveCredentialSource() of deprecated interface Webauthn\Bundle\Repository\CanSaveCredentialSource:
+				since 5.3, use CanSaveCredentialRecord instead. Will be removed in 6.0.
+			'''
+			identifier: method.deprecatedInterface
+			count: 1
+			path: ../src/symfony/src/Security/Authentication/WebauthnBadgeListener.php
+
+		-
+			rawMessage: '''
 				Instanceof references deprecated interface Webauthn\Bundle\Repository\CanSaveCredentialSource:
 				since 5.3, use CanSaveCredentialRecord instead. Will be removed in 6.0.
 			'''
 			identifier: instanceof.deprecatedInterface
 			count: 2
-			path: ../src/symfony/src/Security/Authentication/WebauthnBadgeListener.php
-
-		-
-			rawMessage: '''
-				Parameter $publicKeyCredentialSourceRepository of method Webauthn\Bundle\Security\Authentication\WebauthnBadgeListener::__construct() has typehint with deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedInterface
-			count: 1
-			path: ../src/symfony/src/Security/Authentication/WebauthnBadgeListener.php
-
-		-
-			rawMessage: '''
-				Property $publicKeyCredentialSourceRepository references deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface in its type:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedInterface
-			count: 1
 			path: ../src/symfony/src/Security/Authentication/WebauthnBadgeListener.php
 
 		-
@@ -242,29 +134,29 @@ parameters:
 
 		-
 			rawMessage: '''
+				Call to method fromCredentialRecord() of deprecated class Webauthn\PublicKeyCredentialSource:
+				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
+			'''
+			identifier: staticMethod.deprecatedClass
+			count: 1
+			path: ../src/symfony/src/Security/Http/Authenticator/WebauthnAuthenticator.php
+
+		-
+			rawMessage: '''
+				Call to method saveCredentialSource() of deprecated interface Webauthn\Bundle\Repository\CanSaveCredentialSource:
+				since 5.3, use CanSaveCredentialRecord instead. Will be removed in 6.0.
+			'''
+			identifier: method.deprecatedInterface
+			count: 1
+			path: ../src/symfony/src/Security/Http/Authenticator/WebauthnAuthenticator.php
+
+		-
+			rawMessage: '''
 				Instanceof references deprecated interface Webauthn\Bundle\Repository\CanSaveCredentialSource:
 				since 5.3, use CanSaveCredentialRecord instead. Will be removed in 6.0.
 			'''
 			identifier: instanceof.deprecatedInterface
 			count: 2
-			path: ../src/symfony/src/Security/Http/Authenticator/WebauthnAuthenticator.php
-
-		-
-			rawMessage: '''
-				Parameter $publicKeyCredentialSourceRepository of method Webauthn\Bundle\Security\Http\Authenticator\WebauthnAuthenticator::__construct() has typehint with deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
-			'''
-			identifier: parameter.deprecatedInterface
-			count: 1
-			path: ../src/symfony/src/Security/Http/Authenticator/WebauthnAuthenticator.php
-
-		-
-			rawMessage: '''
-				Property $publicKeyCredentialSourceRepository references deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface in its type:
-				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
-			'''
-			identifier: property.deprecatedInterface
-			count: 1
 			path: ../src/symfony/src/Security/Http/Authenticator/WebauthnAuthenticator.php
 
 		-
@@ -281,6 +173,12 @@ parameters:
 			identifier: instanceof.deprecatedClass
 			count: 1
 			path: ../src/webauthn/src/AuthenticatorAssertionResponseValidator.php
+
+		-
+			rawMessage: 'Parameter #1 $codepoint of function chr expects int<0, 255>, int given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/webauthn/src/AuthenticatorDataLoader.php
 
 		-
 			rawMessage: '''
@@ -479,6 +377,12 @@ parameters:
 			identifier: instanceof.deprecatedClass
 			count: 1
 			path: ../src/webauthn/src/Counter/ThrowExceptionIfInvalid.php
+
+		-
+			rawMessage: 'Parameter #1 $codepoint of function chr expects int<0, 255>, int given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/webauthn/src/Denormalizer/AuthenticatorDataDenormalizer.php
 
 		-
 			rawMessage: '''

--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -175,12 +175,6 @@ parameters:
 			path: ../src/webauthn/src/AuthenticatorAssertionResponseValidator.php
 
 		-
-			rawMessage: 'Parameter #1 $codepoint of function chr expects int<0, 255>, int given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/webauthn/src/AuthenticatorDataLoader.php
-
-		-
 			rawMessage: '''
 				Instanceof references deprecated class Webauthn\PublicKeyCredentialSource:
 				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
@@ -377,12 +371,6 @@ parameters:
 			identifier: instanceof.deprecatedClass
 			count: 1
 			path: ../src/webauthn/src/Counter/ThrowExceptionIfInvalid.php
-
-		-
-			rawMessage: 'Parameter #1 $codepoint of function chr expects int<0, 255>, int given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/webauthn/src/Denormalizer/AuthenticatorDataDenormalizer.php
 
 		-
 			rawMessage: '''

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 * text=auto
 
 /CLAUDE.md export-ignore
+/.claude export-ignore
 /.ci-tools export-ignore
 /.github export-ignore
 /bin export-ignore

--- a/src/symfony/src/Controller/AssertionControllerFactory.php
+++ b/src/symfony/src/Controller/AssertionControllerFactory.php
@@ -10,7 +10,7 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerI
 use Symfony\Component\Serializer\SerializerInterface;
 use Webauthn\AuthenticatorAssertionResponseValidator;
 use Webauthn\Bundle\CredentialOptionsBuilder\PublicKeyCredentialRequestOptionsBuilder;
-use Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface;
+use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
 use Webauthn\Bundle\Security\Handler\FailureHandler;
 use Webauthn\Bundle\Security\Handler\RequestOptionsHandler;
 use Webauthn\Bundle\Security\Handler\SuccessHandler;
@@ -25,7 +25,7 @@ final class AssertionControllerFactory implements CanLogData
         private readonly SerializerInterface $serializer,
         private readonly OptionsStorage $optionStorage,
         private readonly AuthenticatorAssertionResponseValidator $authenticatorAssertionResponseValidator,
-        private readonly PublicKeyCredentialSourceRepositoryInterface $publicKeyCredentialSourceRepository,
+        private readonly CredentialRecordRepositoryInterface $publicKeyCredentialSourceRepository,
     ) {
         $this->logger = new NullLogger();
     }

--- a/src/symfony/src/Controller/AssertionResponseController.php
+++ b/src/symfony/src/Controller/AssertionResponseController.php
@@ -14,7 +14,7 @@ use Symfony\Component\Serializer\SerializerInterface;
 use Throwable;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAssertionResponseValidator;
-use Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface;
+use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
 use Webauthn\Bundle\Security\Handler\FailureHandler;
 use Webauthn\Bundle\Security\Handler\SuccessHandler;
 use Webauthn\Bundle\Security\Storage\OptionsStorage;
@@ -31,7 +31,7 @@ final readonly class AssertionResponseController
         private OptionsStorage $optionsStorage,
         private SuccessHandler $successHandler,
         private FailureHandler|AuthenticationFailureHandlerInterface $failureHandler,
-        private PublicKeyCredentialSourceRepositoryInterface $publicKeyCredentialSourceRepository
+        private CredentialRecordRepositoryInterface $publicKeyCredentialSourceRepository
     ) {
     }
 

--- a/src/symfony/src/Controller/AttestationControllerFactory.php
+++ b/src/symfony/src/Controller/AttestationControllerFactory.php
@@ -8,7 +8,7 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerI
 use Symfony\Component\Serializer\SerializerInterface;
 use Webauthn\AuthenticatorAttestationResponseValidator;
 use Webauthn\Bundle\CredentialOptionsBuilder\PublicKeyCredentialCreationOptionsBuilder;
-use Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface;
+use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
 use Webauthn\Bundle\Security\Guesser\UserEntityGuesser;
 use Webauthn\Bundle\Security\Handler\CreationOptionsHandler;
 use Webauthn\Bundle\Security\Handler\FailureHandler;
@@ -21,7 +21,7 @@ final readonly class AttestationControllerFactory
         private OptionsStorage $optionStorage,
         private SerializerInterface $serializer,
         private AuthenticatorAttestationResponseValidator $attestationResponseValidator,
-        private PublicKeyCredentialSourceRepositoryInterface $publicKeyCredentialSourceRepository
+        private CredentialRecordRepositoryInterface $publicKeyCredentialSourceRepository
     ) {
     }
 

--- a/src/symfony/src/Controller/AttestationResponseController.php
+++ b/src/symfony/src/Controller/AttestationResponseController.php
@@ -15,13 +15,15 @@ use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\AuthenticatorAttestationResponseValidator;
 use Webauthn\Bundle\Exception\HttpNotImplementedException;
 use Webauthn\Bundle\Exception\MissingFeatureException;
+use Webauthn\Bundle\Repository\CanSaveCredentialRecord;
 use Webauthn\Bundle\Repository\CanSaveCredentialSource;
-use Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface;
+use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
 use Webauthn\Bundle\Security\Handler\FailureHandler;
 use Webauthn\Bundle\Security\Handler\SuccessHandler;
 use Webauthn\Bundle\Security\Storage\OptionsStorage;
 use Webauthn\PublicKeyCredential;
 use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialSource;
 use Webauthn\PublicKeyCredentialUserEntity;
 
 final readonly class AttestationResponseController
@@ -29,7 +31,7 @@ final readonly class AttestationResponseController
     public function __construct(
         private SerializerInterface $publicKeyCredentialLoader,
         private AuthenticatorAttestationResponseValidator $attestationResponseValidator,
-        private PublicKeyCredentialSourceRepositoryInterface $credentialSourceRepository,
+        private CredentialRecordRepositoryInterface $credentialSourceRepository,
         private OptionsStorage $optionStorage,
         private SuccessHandler $successHandler,
         private FailureHandler|AuthenticationFailureHandlerInterface $failureHandler,
@@ -39,7 +41,8 @@ final readonly class AttestationResponseController
     public function __invoke(Request $request): Response
     {
         try {
-            if (! $this->credentialSourceRepository instanceof CanSaveCredentialSource) {
+            if (! $this->credentialSourceRepository instanceof CanSaveCredentialRecord
+                && ! $this->credentialSourceRepository instanceof CanSaveCredentialSource) {
                 throw MissingFeatureException::create('Unable to register the credential.');
             }
             $format = $request->getContentTypeFormat();
@@ -73,7 +76,13 @@ final readonly class AttestationResponseController
             ) !== null) {
                 throw new BadRequestHttpException('The credentials already exists');
             }
-            $this->credentialSourceRepository->saveCredentialSource($credentialSource);
+            if ($this->credentialSourceRepository instanceof CanSaveCredentialRecord) {
+                $this->credentialSourceRepository->saveCredentialRecord($credentialSource);
+            } elseif ($this->credentialSourceRepository instanceof CanSaveCredentialSource) {
+                $this->credentialSourceRepository->saveCredentialSource(
+                    PublicKeyCredentialSource::fromCredentialRecord($credentialSource)
+                );
+            }
             return $this->successHandler->onSuccess($request);
         } catch (Throwable $throwable) {
             if ($throwable instanceof MissingFeatureException) {

--- a/src/symfony/src/CredentialOptionsBuilder/ProfileBasedCreationOptionsBuilder.php
+++ b/src/symfony/src/CredentialOptionsBuilder/ProfileBasedCreationOptionsBuilder.php
@@ -17,7 +17,7 @@ use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
 use Webauthn\AuthenticatorSelectionCriteria;
 use Webauthn\Bundle\Dto\PublicKeyCredentialCreationOptionsRequest;
 use Webauthn\Bundle\Policy\ClientOverridePolicy;
-use Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface;
+use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
 use Webauthn\Bundle\Service\PublicKeyCredentialCreationOptionsFactory;
 use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredentialCreationOptions;
@@ -29,7 +29,7 @@ final readonly class ProfileBasedCreationOptionsBuilder implements PublicKeyCred
     public function __construct(
         private SerializerInterface $serializer,
         private ValidatorInterface $validator,
-        private PublicKeyCredentialSourceRepositoryInterface $credentialSourceRepository,
+        private CredentialRecordRepositoryInterface $credentialSourceRepository,
         private PublicKeyCredentialCreationOptionsFactory $publicKeyCredentialCreationOptionsFactory,
         private string $profile,
         private ClientOverridePolicy $overridePolicy = new ClientOverridePolicy(),

--- a/src/symfony/src/CredentialOptionsBuilder/ProfileBasedRequestOptionsBuilder.php
+++ b/src/symfony/src/CredentialOptionsBuilder/ProfileBasedRequestOptionsBuilder.php
@@ -16,7 +16,7 @@ use Webauthn\AuthenticationExtensions\AuthenticationExtension;
 use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
 use Webauthn\Bundle\Dto\ServerPublicKeyCredentialRequestOptionsRequest;
 use Webauthn\Bundle\Policy\ClientOverridePolicy;
-use Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface;
+use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
 use Webauthn\Bundle\Repository\PublicKeyCredentialUserEntityRepositoryInterface;
 use Webauthn\Bundle\Service\PublicKeyCredentialRequestOptionsFactory;
 use Webauthn\CredentialRecord;
@@ -31,7 +31,7 @@ final readonly class ProfileBasedRequestOptionsBuilder implements PublicKeyCrede
         private SerializerInterface $serializer,
         private ValidatorInterface $validator,
         private PublicKeyCredentialUserEntityRepositoryInterface $userEntityRepository,
-        private PublicKeyCredentialSourceRepositoryInterface $credentialSourceRepository,
+        private CredentialRecordRepositoryInterface $credentialSourceRepository,
         private PublicKeyCredentialRequestOptionsFactory $publicKeyCredentialRequestOptionsFactory,
         private string $profile,
         private null|FakeCredentialGenerator $fakeCredentialGenerator = null,

--- a/src/symfony/src/DependencyInjection/Factory/Security/WebauthnFactory.php
+++ b/src/symfony/src/DependencyInjection/Factory/Security/WebauthnFactory.php
@@ -28,7 +28,7 @@ use Webauthn\Bundle\CredentialOptionsBuilder\ProfileBasedCreationOptionsBuilder;
 use Webauthn\Bundle\CredentialOptionsBuilder\ProfileBasedRequestOptionsBuilder;
 use Webauthn\Bundle\DependencyInjection\Compiler\DynamicRouteCompilerPass;
 use Webauthn\Bundle\Policy\ClientOverridePolicy;
-use Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface;
+use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
 use Webauthn\Bundle\Repository\PublicKeyCredentialUserEntityRepositoryInterface;
 use Webauthn\Bundle\Security\Guesser\RequestBodyUserEntityGuesser;
 use Webauthn\Bundle\Security\Handler\DefaultCreationOptionsHandler;
@@ -493,7 +493,7 @@ final readonly class WebauthnFactory implements FirewallListenerFactoryInterface
                 new Reference(SerializerInterface::class),
                 new Reference(ValidatorInterface::class),
                 new Reference(PublicKeyCredentialUserEntityRepositoryInterface::class),
-                new Reference(PublicKeyCredentialSourceRepositoryInterface::class),
+                new Reference(CredentialRecordRepositoryInterface::class),
                 new Reference(PublicKeyCredentialRequestOptionsFactory::class),
                 $config['profile'],
                 new Reference(FakeCredentialGenerator::class, ContainerInterface::NULL_ON_INVALID_REFERENCE),
@@ -521,7 +521,7 @@ final readonly class WebauthnFactory implements FirewallListenerFactoryInterface
             ->setArguments([
                 new Reference(SerializerInterface::class),
                 new Reference(ValidatorInterface::class),
-                new Reference(PublicKeyCredentialSourceRepositoryInterface::class),
+                new Reference(CredentialRecordRepositoryInterface::class),
                 new Reference(PublicKeyCredentialCreationOptionsFactory::class),
                 $config['profile'],
                 new Reference(ClientOverridePolicy::class),

--- a/src/symfony/src/DependencyInjection/WebauthnExtension.php
+++ b/src/symfony/src/DependencyInjection/WebauthnExtension.php
@@ -42,6 +42,7 @@ use Webauthn\Bundle\DependencyInjection\Compiler\ExtensionOutputCheckerCompilerP
 use Webauthn\Bundle\DependencyInjection\Compiler\LoggerSetterCompilerPass;
 use Webauthn\Bundle\Doctrine\Type as DbalType;
 use Webauthn\Bundle\Policy\ClientOverridePolicy;
+use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
 use Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface;
 use Webauthn\Bundle\Repository\PublicKeyCredentialUserEntityRepositoryInterface;
 use Webauthn\Bundle\Security\Storage\OptionsStorage;
@@ -102,6 +103,9 @@ final class WebauthnExtension extends Extension implements PrependExtensionInter
         $container->setAlias('webauthn.logger', $config['logger']);
 
         $container->setAlias(FakeCredentialGenerator::class, $config['fake_credential_generator']);
+        $container->setAlias(CredentialRecordRepositoryInterface::class, $config['credential_repository']);
+        // @deprecated Will be removed in 6.0.0. Kept for BC: code still type-hinting the legacy interface
+        // resolves to the same service when the configured repository implements it.
         $container->setAlias(PublicKeyCredentialSourceRepositoryInterface::class, $config['credential_repository']);
         $container->setAlias(PublicKeyCredentialUserEntityRepositoryInterface::class, $config['user_repository']);
 
@@ -201,7 +205,7 @@ final class WebauthnExtension extends Extension implements PrependExtensionInter
                     ->setArguments([
                         new Reference(SerializerInterface::class),
                         new Reference(ValidatorInterface::class),
-                        new Reference(PublicKeyCredentialSourceRepositoryInterface::class),
+                        new Reference(CredentialRecordRepositoryInterface::class),
                         new Reference(PublicKeyCredentialCreationOptionsFactory::class),
                         $creationConfig['profile'],
                         new Reference(ClientOverridePolicy::class),
@@ -294,7 +298,7 @@ final class WebauthnExtension extends Extension implements PrependExtensionInter
                         new Reference(SerializerInterface::class),
                         new Reference(ValidatorInterface::class),
                         new Reference(PublicKeyCredentialUserEntityRepositoryInterface::class),
-                        new Reference(PublicKeyCredentialSourceRepositoryInterface::class),
+                        new Reference(CredentialRecordRepositoryInterface::class),
                         new Reference(PublicKeyCredentialRequestOptionsFactory::class),
                         $requestConfig['profile'],
                         new Reference(FakeCredentialGenerator::class, ContainerInterface::NULL_ON_INVALID_REFERENCE),

--- a/src/symfony/src/Repository/CanSaveCredentialRecord.php
+++ b/src/symfony/src/Repository/CanSaveCredentialRecord.php
@@ -11,5 +11,5 @@ use Webauthn\CredentialRecord;
  */
 interface CanSaveCredentialRecord
 {
-    public function saveCredentialSource(CredentialRecord $credentialRecord): void;
+    public function saveCredentialRecord(CredentialRecord $credentialRecord): void;
 }

--- a/src/symfony/src/Repository/CanSaveCredentialSource.php
+++ b/src/symfony/src/Repository/CanSaveCredentialSource.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\Repository;
 
+use Webauthn\PublicKeyCredentialSource;
+
 /**
  * @deprecated since 5.3, use CanSaveCredentialRecord instead. Will be removed in 6.0.
  */
-interface CanSaveCredentialSource extends CanSaveCredentialRecord
+interface CanSaveCredentialSource
 {
+    public function saveCredentialSource(PublicKeyCredentialSource $publicKeyCredentialSource): void;
 }

--- a/src/symfony/src/Repository/DoctrineCredentialSourceRepository.php
+++ b/src/symfony/src/Repository/DoctrineCredentialSourceRepository.php
@@ -9,6 +9,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use InvalidArgumentException;
 use function sprintf;
 use Webauthn\CredentialRecord;
+use Webauthn\PublicKeyCredentialSource;
 use Webauthn\PublicKeyCredentialUserEntity;
 
 /**
@@ -17,7 +18,7 @@ use Webauthn\PublicKeyCredentialUserEntity;
  *
  * @deprecated since 5.2.0, to be removed in 6.0.0. Please create your own doctrine-based repository.
  */
-class DoctrineCredentialSourceRepository extends ServiceEntityRepository implements PublicKeyCredentialSourceRepositoryInterface, CanSaveCredentialSource
+class DoctrineCredentialSourceRepository extends ServiceEntityRepository implements PublicKeyCredentialSourceRepositoryInterface, CanSaveCredentialRecord, CanSaveCredentialSource
 {
     /**
      * @var class-string
@@ -40,12 +41,24 @@ class DoctrineCredentialSourceRepository extends ServiceEntityRepository impleme
         parent::__construct($registry, $class);
     }
 
-    public function saveCredentialSource(CredentialRecord $credentialRecord): void
+    public function saveCredentialRecord(CredentialRecord $credentialRecord): void
     {
-        $this->getEntityManager()
-            ->persist($credentialRecord);
-        $this->getEntityManager()
-            ->flush();
+        // Route PublicKeyCredentialSource through the legacy saveCredentialSource()
+        // so that user subclasses overriding it (5.2.x style) keep being invoked.
+        // BC promise: legacy override is honored until 6.0.
+        if ($credentialRecord instanceof PublicKeyCredentialSource) {
+            $this->saveCredentialSource($credentialRecord);
+            return;
+        }
+        $this->persistCredentialRecord($credentialRecord);
+    }
+
+    /**
+     * @deprecated since 5.3, use saveCredentialRecord() instead. Will be removed in 6.0.
+     */
+    public function saveCredentialSource(PublicKeyCredentialSource $publicKeyCredentialSource): void
+    {
+        $this->persistCredentialRecord($publicKeyCredentialSource);
     }
 
     /**
@@ -76,5 +89,13 @@ class DoctrineCredentialSourceRepository extends ServiceEntityRepository impleme
             ->setMaxResults(1)
             ->getQuery()
             ->getOneOrNullResult();
+    }
+
+    private function persistCredentialRecord(CredentialRecord $credentialRecord): void
+    {
+        $this->getEntityManager()
+            ->persist($credentialRecord);
+        $this->getEntityManager()
+            ->flush();
     }
 }

--- a/src/symfony/src/Resources/config/security.php
+++ b/src/symfony/src/Resources/config/security.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use Symfony\Component\Serializer\SerializerInterface;
 use Webauthn\Bundle\DependencyInjection\Factory\Security\WebauthnFactory;
-use Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface;
+use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
 use Webauthn\Bundle\Repository\PublicKeyCredentialUserEntityRepositoryInterface;
 use Webauthn\Bundle\Security\Authentication\WebauthnBadgeListener;
 use Webauthn\Bundle\Security\Authorization\Voter\IsUserPresentVoter;
@@ -48,7 +48,7 @@ return static function (ContainerConfigurator $container): void {
             abstract_arg('Success handler'),
             abstract_arg('Failure handler'),
             abstract_arg('Options Storage'),
-            service(PublicKeyCredentialSourceRepositoryInterface::class),
+            service(CredentialRecordRepositoryInterface::class),
             service(PublicKeyCredentialUserEntityRepositoryInterface::class),
             service(SerializerInterface::class),
             abstract_arg('Authenticator Assertion Response Validator'),
@@ -61,5 +61,7 @@ return static function (ContainerConfigurator $container): void {
 
     $service->set(CurrentUserEntityGuesser::class);
     $service->set(RequestBodyUserEntityGuesser::class);
-    $service->set(WebauthnBadgeListener::class);
+    $service->set(WebauthnBadgeListener::class)
+        ->arg('$userProvider', service('security.user_providers'))
+    ;
 };

--- a/src/symfony/src/Security/Authentication/WebauthnBadgeListener.php
+++ b/src/symfony/src/Security/Authentication/WebauthnBadgeListener.php
@@ -16,15 +16,18 @@ use Webauthn\AuthenticatorAssertionResponseValidator;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\AuthenticatorAttestationResponseValidator;
 use Webauthn\Bundle\Repository\CanRegisterUserEntity;
+use Webauthn\Bundle\Repository\CanSaveCredentialRecord;
 use Webauthn\Bundle\Repository\CanSaveCredentialSource;
-use Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface;
+use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
 use Webauthn\Bundle\Repository\PublicKeyCredentialUserEntityRepositoryInterface;
 use Webauthn\Bundle\Security\Storage\OptionsStorage;
+use Webauthn\CredentialRecord;
 use Webauthn\Exception\InvalidDataException;
 use Webauthn\Exception\UnsupportedFeatureException;
 use Webauthn\PublicKeyCredential;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\PublicKeyCredentialSource;
 use Webauthn\PublicKeyCredentialUserEntity;
 
 final readonly class WebauthnBadgeListener
@@ -36,7 +39,7 @@ final readonly class WebauthnBadgeListener
         private OptionsStorage $optionsStorage,
         private SerializerInterface $publicKeyCredentialLoader,
         private PublicKeyCredentialUserEntityRepositoryInterface $credentialUserEntityRepository,
-        private PublicKeyCredentialSourceRepositoryInterface $publicKeyCredentialSourceRepository,
+        private CredentialRecordRepositoryInterface $publicKeyCredentialSourceRepository,
         private AuthenticatorAssertionResponseValidator $assertionResponseValidator,
         private AuthenticatorAttestationResponseValidator $attestationResponseValidator,
         private UserProviderInterface $userProvider,
@@ -118,9 +121,7 @@ final readonly class WebauthnBadgeListener
         if (! $userEntity instanceof PublicKeyCredentialUserEntity) {
             throw InvalidDataException::create($userEntity, 'Invalid user entity');
         }
-        if ($this->publicKeyCredentialSourceRepository instanceof CanSaveCredentialSource) {
-            $this->publicKeyCredentialSourceRepository->saveCredentialSource($publicKeyCredentialSource);
-        }
+        $this->saveCredential($publicKeyCredentialSource);
 
         $badge->markResolved(
             $response,
@@ -139,7 +140,8 @@ final readonly class WebauthnBadgeListener
         if (! $this->credentialUserEntityRepository instanceof CanRegisterUserEntity) {
             throw UnsupportedFeatureException::create('The user entity repository does not support registration.');
         }
-        if (! $this->publicKeyCredentialSourceRepository instanceof CanSaveCredentialSource) {
+        if (! $this->publicKeyCredentialSourceRepository instanceof CanSaveCredentialRecord
+            && ! $this->publicKeyCredentialSourceRepository instanceof CanSaveCredentialSource) {
             throw UnsupportedFeatureException::create(
                 'The credential source repository does not support registration.'
             );
@@ -161,7 +163,7 @@ final readonly class WebauthnBadgeListener
             throw InvalidDataException::create($publicKeyCredentialSource, 'The credentials already exists');
         }
         $this->credentialUserEntityRepository->saveUserEntity($userEntity);
-        $this->publicKeyCredentialSourceRepository->saveCredentialSource($publicKeyCredentialSource);
+        $this->saveCredential($publicKeyCredentialSource);
 
         $badge->markResolved(
             $response,
@@ -169,5 +171,18 @@ final readonly class WebauthnBadgeListener
             $userEntity,
             $publicKeyCredentialSource,
         );
+    }
+
+    private function saveCredential(CredentialRecord $credentialRecord): void
+    {
+        if ($this->publicKeyCredentialSourceRepository instanceof CanSaveCredentialRecord) {
+            $this->publicKeyCredentialSourceRepository->saveCredentialRecord($credentialRecord);
+            return;
+        }
+        if ($this->publicKeyCredentialSourceRepository instanceof CanSaveCredentialSource) {
+            $this->publicKeyCredentialSourceRepository->saveCredentialSource(
+                PublicKeyCredentialSource::fromCredentialRecord($credentialRecord)
+            );
+        }
     }
 }

--- a/src/symfony/src/Security/Http/Authenticator/WebauthnAuthenticator.php
+++ b/src/symfony/src/Security/Http/Authenticator/WebauthnAuthenticator.php
@@ -30,19 +30,22 @@ use Webauthn\Bundle\Exception\HttpNotImplementedException;
 use Webauthn\Bundle\Exception\MissingFeatureException;
 use Webauthn\Bundle\Exception\MissingUserEntityException;
 use Webauthn\Bundle\Repository\CanRegisterUserEntity;
+use Webauthn\Bundle\Repository\CanSaveCredentialRecord;
 use Webauthn\Bundle\Repository\CanSaveCredentialSource;
-use Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface;
+use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
 use Webauthn\Bundle\Repository\PublicKeyCredentialUserEntityRepositoryInterface;
 use Webauthn\Bundle\Security\Authentication\Token\WebauthnToken;
 use Webauthn\Bundle\Security\Http\Authenticator\Passport\Credentials\WebauthnCredentials;
 use Webauthn\Bundle\Security\Storage\OptionsStorage;
 use Webauthn\Bundle\Security\WebauthnFirewallConfig;
+use Webauthn\CredentialRecord;
 use Webauthn\Exception\AuthenticatorResponseVerificationException;
 use Webauthn\Exception\InvalidDataException;
 use Webauthn\MetadataService\CanLogData;
 use Webauthn\PublicKeyCredential;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\PublicKeyCredentialSource;
 use Webauthn\PublicKeyCredentialUserEntity;
 
 final class WebauthnAuthenticator implements AuthenticatorInterface, InteractiveAuthenticatorInterface, CanLogData
@@ -58,7 +61,7 @@ final class WebauthnAuthenticator implements AuthenticatorInterface, Interactive
         private readonly AuthenticationSuccessHandlerInterface $successHandler,
         private readonly AuthenticationFailureHandlerInterface $failureHandler,
         private readonly OptionsStorage $optionsStorage,
-        private readonly PublicKeyCredentialSourceRepositoryInterface $publicKeyCredentialSourceRepository,
+        private readonly CredentialRecordRepositoryInterface $publicKeyCredentialSourceRepository,
         private readonly PublicKeyCredentialUserEntityRepositoryInterface $credentialUserEntityRepository,
         private readonly SerializerInterface $publicKeyCredentialLoader,
         private readonly AuthenticatorAssertionResponseValidator $assertionResponseValidator,
@@ -199,9 +202,7 @@ final class WebauthnAuthenticator implements AuthenticatorInterface, Interactive
                 $request->getHost(),
                 $userEntity?->id
             );
-            if ($this->publicKeyCredentialSourceRepository instanceof CanSaveCredentialSource) {
-                $this->publicKeyCredentialSourceRepository->saveCredentialSource($publicKeyCredentialSource);
-            }
+            $this->saveCredential($publicKeyCredentialSource);
             $userEntity = $this->credentialUserEntityRepository->findOneByUserHandle(
                 $publicKeyCredentialSource->userHandle
             );
@@ -229,7 +230,8 @@ final class WebauthnAuthenticator implements AuthenticatorInterface, Interactive
             if (! $this->credentialUserEntityRepository instanceof CanRegisterUserEntity) {
                 throw MissingFeatureException::create('Unable to register the user.');
             }
-            if (! $this->publicKeyCredentialSourceRepository instanceof CanSaveCredentialSource) {
+            if (! $this->publicKeyCredentialSourceRepository instanceof CanSaveCredentialRecord
+                && ! $this->publicKeyCredentialSourceRepository instanceof CanSaveCredentialSource) {
                 throw MissingFeatureException::create('Unable to register the credential.');
             }
             $format = $request->getContentTypeFormat();
@@ -270,7 +272,7 @@ final class WebauthnAuthenticator implements AuthenticatorInterface, Interactive
                 throw InvalidDataException::create($credentialSource, 'The credentials already exists');
             }
             $this->credentialUserEntityRepository->saveUserEntity($userEntity);
-            $this->publicKeyCredentialSourceRepository->saveCredentialSource($credentialSource);
+            $this->saveCredential($credentialSource);
             $credentials = new WebauthnCredentials(
                 $response,
                 $publicKeyCredentialCreationOptions,
@@ -285,6 +287,19 @@ final class WebauthnAuthenticator implements AuthenticatorInterface, Interactive
                 throw new HttpNotImplementedException($e->getMessage(), $e);
             }
             throw new AuthenticationException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    private function saveCredential(CredentialRecord $credentialRecord): void
+    {
+        if ($this->publicKeyCredentialSourceRepository instanceof CanSaveCredentialRecord) {
+            $this->publicKeyCredentialSourceRepository->saveCredentialRecord($credentialRecord);
+            return;
+        }
+        if ($this->publicKeyCredentialSourceRepository instanceof CanSaveCredentialSource) {
+            $this->publicKeyCredentialSourceRepository->saveCredentialSource(
+                PublicKeyCredentialSource::fromCredentialRecord($credentialRecord)
+            );
         }
     }
 }

--- a/src/webauthn/src/PublicKeyCredentialSource.php
+++ b/src/webauthn/src/PublicKeyCredentialSource.php
@@ -11,4 +11,31 @@ namespace Webauthn;
  */
 class PublicKeyCredentialSource extends CredentialRecord
 {
+    /**
+     * @internal Bridge for legacy CanSaveCredentialSource repositories.
+     *           Wraps a CredentialRecord into a PublicKeyCredentialSource without copying additional state
+     *           (PublicKeyCredentialSource has no own properties).
+     */
+    public static function fromCredentialRecord(CredentialRecord $credentialRecord): self
+    {
+        if ($credentialRecord instanceof self) {
+            return $credentialRecord;
+        }
+
+        return new self(
+            $credentialRecord->publicKeyCredentialId,
+            $credentialRecord->type,
+            $credentialRecord->transports,
+            $credentialRecord->attestationType,
+            $credentialRecord->trustPath,
+            $credentialRecord->aaguid,
+            $credentialRecord->credentialPublicKey,
+            $credentialRecord->userHandle,
+            $credentialRecord->counter,
+            $credentialRecord->otherUI,
+            $credentialRecord->backupEligible,
+            $credentialRecord->backupStatus,
+            $credentialRecord->uvInitialized,
+        );
+    }
 }

--- a/tests/library/Unit/RepositoryCompatibilityTest.php
+++ b/tests/library/Unit/RepositoryCompatibilityTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Webauthn\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
 use Symfony\Component\Uid\Uuid;
 use Webauthn\Bundle\Repository\CanSaveCredentialRecord;
 use Webauthn\Bundle\Repository\CanSaveCredentialSource;
@@ -23,14 +24,19 @@ use Webauthn\TrustPath\EmptyTrustPath;
 final class RepositoryCompatibilityTest extends AbstractTestCase
 {
     #[Test]
-    public function publicKeyCredentialSourceRepositoryCanHandleCredentialRecord(): void
+    public function legacyRepositoryStoresPublicKeyCredentialSource(): void
     {
+        // 5.2.x-style repository: implements only the deprecated interfaces and only accepts
+        // PublicKeyCredentialSource — that signature must keep working under the BC promise.
         $repository = new class() implements PublicKeyCredentialSourceRepositoryInterface, CanSaveCredentialSource {
+            /**
+             * @var array<string, PublicKeyCredentialSource>
+             */
             private array $storage = [];
 
-            public function saveCredentialSource(CredentialRecord $credentialRecord): void
+            public function saveCredentialSource(PublicKeyCredentialSource $publicKeyCredentialSource): void
             {
-                $this->storage[$credentialRecord->publicKeyCredentialId] = $credentialRecord;
+                $this->storage[$publicKeyCredentialSource->publicKeyCredentialId] = $publicKeyCredentialSource;
             }
 
             public function findOneByCredentialId(string $publicKeyCredentialId): ?CredentialRecord
@@ -42,59 +48,13 @@ final class RepositoryCompatibilityTest extends AbstractTestCase
             {
                 return array_filter(
                     $this->storage,
-                    fn ($credential) => $credential->userHandle === $publicKeyCredentialUserEntity->id
-                );
-            }
-        };
-
-        $credentialRecord = CredentialRecord::create(
-            'test-id',
-            PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
-            [],
-            'none',
-            EmptyTrustPath::create(),
-            Uuid::v4(),
-            'public-key',
-            'user-handle',
-            10
-        );
-
-        // Should be able to save a CredentialRecord
-        $repository->saveCredentialSource($credentialRecord);
-
-        // Should be able to retrieve it
-        $retrieved = $repository->findOneByCredentialId('test-id');
-        static::assertInstanceOf(CredentialRecord::class, $retrieved);
-        static::assertSame('test-id', $retrieved->publicKeyCredentialId);
-    }
-
-    #[Test]
-    public function publicKeyCredentialSourceRepositoryCanHandlePublicKeyCredentialSource(): void
-    {
-        $repository = new class() implements PublicKeyCredentialSourceRepositoryInterface, CanSaveCredentialSource {
-            private array $storage = [];
-
-            public function saveCredentialSource(CredentialRecord $credentialRecord): void
-            {
-                $this->storage[$credentialRecord->publicKeyCredentialId] = $credentialRecord;
-            }
-
-            public function findOneByCredentialId(string $publicKeyCredentialId): ?CredentialRecord
-            {
-                return $this->storage[$publicKeyCredentialId] ?? null;
-            }
-
-            public function findAllForUserEntity(PublicKeyCredentialUserEntity $publicKeyCredentialUserEntity): array
-            {
-                return array_filter(
-                    $this->storage,
-                    fn ($credential) => $credential->userHandle === $publicKeyCredentialUserEntity->id
+                    static fn (CredentialRecord $credential): bool => $credential->userHandle === $publicKeyCredentialUserEntity->id
                 );
             }
         };
 
         $pkcs = new PublicKeyCredentialSource(
-            'test-id-2',
+            'legacy-id',
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
             [],
             'none',
@@ -105,22 +65,25 @@ final class RepositoryCompatibilityTest extends AbstractTestCase
             10
         );
 
-        // Should be able to save a PublicKeyCredentialSource (extends CredentialRecord)
         $repository->saveCredentialSource($pkcs);
 
-        // Should be able to retrieve it
-        $retrieved = $repository->findOneByCredentialId('test-id-2');
+        $retrieved = $repository->findOneByCredentialId('legacy-id');
         static::assertInstanceOf(PublicKeyCredentialSource::class, $retrieved);
-        static::assertSame('test-id-2', $retrieved->publicKeyCredentialId);
+        static::assertSame('legacy-id', $retrieved->publicKeyCredentialId);
     }
 
     #[Test]
-    public function credentialRecordRepositoryCanHandleBothTypes(): void
+    public function newRepositoryStoresAnyCredentialRecord(): void
     {
+        // New 5.3 repository: implements only the new interfaces with the new method name,
+        // and accepts both raw CredentialRecord and PublicKeyCredentialSource (since PKCS extends CR).
         $repository = new class() implements CredentialRecordRepositoryInterface, CanSaveCredentialRecord {
+            /**
+             * @var array<string, CredentialRecord>
+             */
             private array $storage = [];
 
-            public function saveCredentialSource(CredentialRecord $credentialRecord): void
+            public function saveCredentialRecord(CredentialRecord $credentialRecord): void
             {
                 $this->storage[$credentialRecord->publicKeyCredentialId] = $credentialRecord;
             }
@@ -134,7 +97,7 @@ final class RepositoryCompatibilityTest extends AbstractTestCase
             {
                 return array_filter(
                     $this->storage,
-                    fn ($credential) => $credential->userHandle === $publicKeyCredentialUserEntity->id
+                    static fn (CredentialRecord $credential): bool => $credential->userHandle === $publicKeyCredentialUserEntity->id
                 );
             }
         };
@@ -163,59 +126,11 @@ final class RepositoryCompatibilityTest extends AbstractTestCase
             20
         );
 
-        // Should handle both types (PKCS extends CR)
-        $repository->saveCredentialSource($credentialRecord);
-        $repository->saveCredentialSource($pkcs);
+        $repository->saveCredentialRecord($credentialRecord);
+        $repository->saveCredentialRecord($pkcs);
 
-        $retrievedCr = $repository->findOneByCredentialId('cr-id');
-        $retrievedPkcs = $repository->findOneByCredentialId('pkcs-id');
-
-        static::assertInstanceOf(CredentialRecord::class, $retrievedCr);
-        static::assertInstanceOf(PublicKeyCredentialSource::class, $retrievedPkcs);
-        // PKCS now extends CR
-        static::assertInstanceOf(CredentialRecord::class, $retrievedPkcs);
-    }
-
-    #[Test]
-    public function repositoryImplementationCanStoreBothTypesInSameStorage(): void
-    {
-        // This test verifies that a single repository can handle both types
-        $storage = [];
-
-        $credentialRecord = CredentialRecord::create(
-            'cr-1',
-            PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
-            [],
-            'none',
-            EmptyTrustPath::create(),
-            Uuid::v4(),
-            'key-1',
-            'user-handle',
-            10
-        );
-
-        $pkcs = new PublicKeyCredentialSource(
-            'pkcs-1',
-            PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
-            [],
-            'none',
-            EmptyTrustPath::create(),
-            Uuid::v4(),
-            'key-2',
-            'user-handle',
-            20
-        );
-
-        // Both types can be stored in the same array
-        $storage[] = $credentialRecord;
-        $storage[] = $pkcs;
-
-        static::assertCount(2, $storage);
-        static::assertInstanceOf(CredentialRecord::class, $storage[0]);
-        static::assertInstanceOf(PublicKeyCredentialSource::class, $storage[1]);
-        // PKCS extends CredentialRecord, so it's also a CredentialRecord
-        static::assertInstanceOf(CredentialRecord::class, $storage[1]);
-        static::assertNotInstanceOf(PublicKeyCredentialSource::class, $storage[0]);
+        static::assertInstanceOf(CredentialRecord::class, $repository->findOneByCredentialId('cr-id'));
+        static::assertInstanceOf(PublicKeyCredentialSource::class, $repository->findOneByCredentialId('pkcs-id'));
     }
 
     #[Test]
@@ -232,7 +147,6 @@ final class RepositoryCompatibilityTest extends AbstractTestCase
             'user-handle',
             10
         );
-
         $cr = CredentialRecord::create(
             'test-id-2',
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
@@ -245,19 +159,15 @@ final class RepositoryCompatibilityTest extends AbstractTestCase
             20
         );
 
-        // PublicKeyCredentialSource now extends CredentialRecord
-        static::assertInstanceOf(PublicKeyCredentialSource::class, $pkcs);
         static::assertInstanceOf(CredentialRecord::class, $pkcs);
-
-        static::assertInstanceOf(CredentialRecord::class, $cr);
         static::assertNotInstanceOf(PublicKeyCredentialSource::class, $cr);
     }
 
     #[Test]
-    public function bothRepositoryInterfacesAcceptCredentialRecord(): void
+    public function deprecatedRepositoryInterfaceExtendsNewOne(): void
     {
-        // This test verifies that the type signatures are compatible
-        // PublicKeyCredentialSourceRepositoryInterface extends CredentialRecordRepositoryInterface
+        // Composer-level guarantee: a 5.2 repository injected where the bundle now requires
+        // CredentialRecordRepositoryInterface still satisfies the type-hint.
         $pkcsRepo = new class() implements PublicKeyCredentialSourceRepositoryInterface {
             public function findOneByCredentialId(string $publicKeyCredentialId): ?CredentialRecord
             {
@@ -270,21 +180,17 @@ final class RepositoryCompatibilityTest extends AbstractTestCase
             }
         };
 
-        $crRepo = new class() implements CredentialRecordRepositoryInterface {
-            public function findOneByCredentialId(string $publicKeyCredentialId): ?CredentialRecord
-            {
-                return null;
-            }
-
-            public function findAllForUserEntity(PublicKeyCredentialUserEntity $publicKeyCredentialUserEntity): array
-            {
-                return [];
-            }
-        };
-
-        static::assertInstanceOf(PublicKeyCredentialSourceRepositoryInterface::class, $pkcsRepo);
-        static::assertInstanceOf(CredentialRecordRepositoryInterface::class, $crRepo);
-        // PKCS interface extends CR interface
         static::assertInstanceOf(CredentialRecordRepositoryInterface::class, $pkcsRepo);
+    }
+
+    #[Test]
+    public function deprecatedSaverInterfaceIsIndependentFromNewOne(): void
+    {
+        // Implementing CanSaveCredentialSource alone must NOT force implementing the new
+        // CanSaveCredentialRecord — that was the LSP trap fixed for issue #832.
+        static::assertFalse(
+            (new ReflectionClass(CanSaveCredentialSource::class))
+                ->implementsInterface(CanSaveCredentialRecord::class)
+        );
     }
 }

--- a/tests/symfony/functional/CredentialRecordRepository.php
+++ b/tests/symfony/functional/CredentialRecordRepository.php
@@ -8,15 +8,18 @@ use ParagonIE\ConstantTime\Base64UrlSafe;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Uid\Uuid;
 use Webauthn\AttestationStatement\AttestationStatement;
-use Webauthn\Bundle\Repository\CanSaveCredentialSource;
+use Webauthn\Bundle\Repository\CanSaveCredentialRecord;
 use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
 use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredentialDescriptor;
-use Webauthn\PublicKeyCredentialSource;
 use Webauthn\PublicKeyCredentialUserEntity;
 use Webauthn\TrustPath\EmptyTrustPath;
 
-final readonly class CredentialRecordRepository implements CredentialRecordRepositoryInterface, CanSaveCredentialSource
+/**
+ * 5.3 forward-compatible repository: implements only the new interfaces, with
+ * saveCredentialRecord(CredentialRecord) — used to verify issue #827 is fixed.
+ */
+final readonly class CredentialRecordRepository implements CredentialRecordRepositoryInterface, CanSaveCredentialRecord
 {
     public function __construct(
         private CacheItemPoolInterface $cacheItemPool
@@ -38,7 +41,7 @@ final readonly class CredentialRecordRepository implements CredentialRecordRepos
             'foo',
             100
         );
-        $this->saveCredentialSource($credentialRecord1);
+        $this->saveCredentialRecord($credentialRecord1);
         $credentialRecord2 = CredentialRecord::create(
             base64_decode(
                 'Ac8zKrpVWv9UCwxY1FyMqkESz2lV4CNwTk2+Hp19LgKbvh5uQ2/i6AMbTbTz1zcNapCEeiLJPlAAVM4L7AIow6I=',
@@ -56,7 +59,7 @@ final readonly class CredentialRecordRepository implements CredentialRecordRepos
             '929fba2f-2361-4bc6-a917-bb76aa14c7f9',
             100
         );
-        $this->saveCredentialSource($credentialRecord2);
+        $this->saveCredentialRecord($credentialRecord2);
     }
 
     public function ensureCredentialNotExist(string $publicKeyCredentialId): void
@@ -64,9 +67,8 @@ final readonly class CredentialRecordRepository implements CredentialRecordRepos
         $this->cacheItemPool->deleteItem('pks-' . Base64UrlSafe::encodeUnpadded($publicKeyCredentialId));
     }
 
-    public function findOneByCredentialId(
-        string $publicKeyCredentialId
-    ): CredentialRecord|PublicKeyCredentialSource|null {
+    public function findOneByCredentialId(string $publicKeyCredentialId): ?CredentialRecord
+    {
         $item = $this->cacheItemPool->getItem('pks-' . Base64UrlSafe::encodeUnpadded($publicKeyCredentialId));
         if (! $item->isHit()) {
             return null;
@@ -92,7 +94,7 @@ final readonly class CredentialRecordRepository implements CredentialRecordRepos
         $this->cacheItemPool->clear();
     }
 
-    public function saveCredentialSource(CredentialRecord|PublicKeyCredentialSource $credentialRecord): void
+    public function saveCredentialRecord(CredentialRecord $credentialRecord): void
     {
         $item = $this->cacheItemPool->getItem(
             'pks-' . Base64UrlSafe::encodeUnpadded($credentialRecord->publicKeyCredentialId)

--- a/tests/symfony/functional/PublicKeyCredentialSourceRepository.php
+++ b/tests/symfony/functional/PublicKeyCredentialSourceRepository.php
@@ -16,6 +16,11 @@ use Webauthn\PublicKeyCredentialSource;
 use Webauthn\PublicKeyCredentialUserEntity;
 use Webauthn\TrustPath\EmptyTrustPath;
 
+/**
+ * 5.2.x-style legacy repository used to verify the BC bridge in the bundle.
+ * Implements only the deprecated interfaces and uses the deprecated saveCredentialSource(PublicKeyCredentialSource)
+ * signature to mimic what existing user code looks like.
+ */
 final readonly class PublicKeyCredentialSourceRepository implements PublicKeyCredentialSourceRepositoryInterface, CanSaveCredentialSource
 {
     public function __construct(
@@ -91,22 +96,22 @@ final readonly class PublicKeyCredentialSourceRepository implements PublicKeyCre
         $this->cacheItemPool->clear();
     }
 
-    public function saveCredentialSource(CredentialRecord $credentialRecord): void
+    public function saveCredentialSource(PublicKeyCredentialSource $publicKeyCredentialSource): void
     {
         $item = $this->cacheItemPool->getItem(
-            'pks-' . Base64UrlSafe::encodeUnpadded($credentialRecord->publicKeyCredentialId)
+            'pks-' . Base64UrlSafe::encodeUnpadded($publicKeyCredentialSource->publicKeyCredentialId)
         );
-        $item->set($credentialRecord);
+        $item->set($publicKeyCredentialSource);
         $this->cacheItemPool->save($item);
 
         $item = $this->cacheItemPool->getItem(
-            'user-pks-' . Base64UrlSafe::encodeUnpadded($credentialRecord->userHandle)
+            'user-pks-' . Base64UrlSafe::encodeUnpadded($publicKeyCredentialSource->userHandle)
         );
         $pks = [];
         if ($item->isHit()) {
             $pks = $item->get();
         }
-        $pks[] = $credentialRecord;
+        $pks[] = $publicKeyCredentialSource;
         $item->set($pks);
         $this->cacheItemPool->save($item);
     }

--- a/tests/symfony/functional/Repository/RepositoryFunctionalTest.php
+++ b/tests/symfony/functional/Repository/RepositoryFunctionalTest.php
@@ -63,12 +63,13 @@ final class RepositoryFunctionalTest extends KernelTestCase
     }
 
     #[Test]
-    public function publicKeyCredentialSourceRepositoryCanSaveAndRetrieveCredentialRecord(): void
+    public function publicKeyCredentialSourceRepositoryCanSaveAndRetrievePublicKeyCredentialSourceWrapper(): void
     {
-        // Given
+        // Legacy CanSaveCredentialSource repositories only accept PublicKeyCredentialSource,
+        // not arbitrary CredentialRecord — that is the BC contract restored for issue #832.
         $repository = new PublicKeyCredentialSourceRepository($this->cache);
 
-        $credentialRecord = CredentialRecord::create(
+        $publicKeyCredentialSource = new PublicKeyCredentialSource(
             base64_decode('test456', true),
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
             [],
@@ -80,12 +81,11 @@ final class RepositoryFunctionalTest extends KernelTestCase
             200
         );
 
-        // When
-        $repository->saveCredentialSource($credentialRecord);
+        $repository->saveCredentialSource($publicKeyCredentialSource);
         $retrieved = $repository->findOneByCredentialId(base64_decode('test456', true));
 
-        // Then
         static::assertInstanceOf(CredentialRecord::class, $retrieved);
+        static::assertInstanceOf(PublicKeyCredentialSource::class, $retrieved);
         static::assertSame('test-user-2', $retrieved->userHandle);
         static::assertSame(200, $retrieved->counter);
     }
@@ -109,7 +109,7 @@ final class RepositoryFunctionalTest extends KernelTestCase
         );
 
         // When
-        $repository->saveCredentialSource($credentialRecord);
+        $repository->saveCredentialRecord($credentialRecord);
         $retrieved = $repository->findOneByCredentialId('cr789');
 
         // Then
@@ -137,7 +137,7 @@ final class RepositoryFunctionalTest extends KernelTestCase
         );
 
         // When
-        $repository->saveCredentialSource($publicKeyCredentialSource);
+        $repository->saveCredentialRecord($publicKeyCredentialSource);
         $retrieved = $repository->findOneByCredentialId(base64_decode('pkcs999', true));
 
         // Then - PublicKeyCredentialSource extends CredentialRecord, so it's both
@@ -150,8 +150,9 @@ final class RepositoryFunctionalTest extends KernelTestCase
     #[Test]
     public function repositoryCanStoreBothTypesAndRetrieveThemForSameUser(): void
     {
-        // Given
-        $repository = new PublicKeyCredentialSourceRepository($this->cache);
+        // Mixed types are only meaningful on a CanSaveCredentialRecord-style repository:
+        // a legacy CanSaveCredentialSource repository contractually only accepts PublicKeyCredentialSource.
+        $repository = new CredentialRecordRepository($this->cache);
 
         $userId = 'multi-user';
 
@@ -179,9 +180,8 @@ final class RepositoryFunctionalTest extends KernelTestCase
             200
         );
 
-        // When
-        $repository->saveCredentialSource($credentialRecord);
-        $repository->saveCredentialSource($publicKeyCredentialSource);
+        $repository->saveCredentialRecord($credentialRecord);
+        $repository->saveCredentialRecord($publicKeyCredentialSource);
 
         $userEntity = PublicKeyCredentialUserEntity::create($userId, $userId, 'Multi User');
         $allCredentials = $repository->findAllForUserEntity($userEntity);
@@ -237,8 +237,7 @@ final class RepositoryFunctionalTest extends KernelTestCase
     #[Test]
     public function repositoryCanUpdateExistingCredential(): void
     {
-        // Given
-        $repository = new PublicKeyCredentialSourceRepository($this->cache);
+        $repository = new CredentialRecordRepository($this->cache);
 
         $credentialId = 'update-test';
 
@@ -254,9 +253,8 @@ final class RepositoryFunctionalTest extends KernelTestCase
             100
         );
 
-        $repository->saveCredentialSource($original);
+        $repository->saveCredentialRecord($original);
 
-        // When - save updated version with different counter
         $updated = CredentialRecord::create(
             $credentialId,
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
@@ -266,14 +264,13 @@ final class RepositoryFunctionalTest extends KernelTestCase
             Uuid::fromBinary(base64_decode('AAAAAAAAAAAAAAAAAAAAAA==', true)),
             'originalkey',
             'update-user',
-            150  // Updated counter
+            150
         );
 
-        $repository->saveCredentialSource($updated);
+        $repository->saveCredentialRecord($updated);
 
         $retrieved = $repository->findOneByCredentialId($credentialId);
 
-        // Then - should have updated counter
         static::assertInstanceOf(CredentialRecord::class, $retrieved);
         static::assertSame(150, $retrieved->counter);
     }

--- a/tests/symfony/unit/Repository/Issue827RegressionTest.php
+++ b/tests/symfony/unit/Repository/Issue827RegressionTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Bundle\Unit\Repository;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionNamedType;
+use function sprintf;
+use Webauthn\Bundle\Controller\AssertionControllerFactory;
+use Webauthn\Bundle\Controller\AssertionResponseController;
+use Webauthn\Bundle\Controller\AttestationControllerFactory;
+use Webauthn\Bundle\Controller\AttestationResponseController;
+use Webauthn\Bundle\CredentialOptionsBuilder\ProfileBasedCreationOptionsBuilder;
+use Webauthn\Bundle\CredentialOptionsBuilder\ProfileBasedRequestOptionsBuilder;
+use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
+use Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface;
+use Webauthn\Bundle\Security\Authentication\WebauthnBadgeListener;
+use Webauthn\Bundle\Security\Http\Authenticator\WebauthnAuthenticator;
+
+/**
+ * Issue #827: classes inside the bundle used to type-hint the deprecated
+ * PublicKeyCredentialSourceRepositoryInterface, so a user repository implementing only the new
+ * CredentialRecordRepositoryInterface could not be autowired. Each constructor below must now
+ * accept the new interface.
+ *
+ * @internal
+ */
+final class Issue827RegressionTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{class-string, string}>
+     */
+    public static function bundleClassesExpectingCredentialRepository(): iterable
+    {
+        yield 'WebauthnAuthenticator' => [WebauthnAuthenticator::class, 'publicKeyCredentialSourceRepository'];
+        yield 'WebauthnBadgeListener' => [WebauthnBadgeListener::class, 'publicKeyCredentialSourceRepository'];
+        yield 'AttestationResponseController' => [
+            AttestationResponseController::class,
+            'credentialSourceRepository',
+        ];
+        yield 'AssertionResponseController' => [
+            AssertionResponseController::class,
+            'publicKeyCredentialSourceRepository',
+        ];
+        yield 'AttestationControllerFactory' => [
+            AttestationControllerFactory::class,
+            'publicKeyCredentialSourceRepository',
+        ];
+        yield 'AssertionControllerFactory' => [
+            AssertionControllerFactory::class,
+            'publicKeyCredentialSourceRepository',
+        ];
+        yield 'ProfileBasedCreationOptionsBuilder' => [
+            ProfileBasedCreationOptionsBuilder::class,
+            'credentialSourceRepository',
+        ];
+        yield 'ProfileBasedRequestOptionsBuilder' => [
+            ProfileBasedRequestOptionsBuilder::class,
+            'credentialSourceRepository',
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('bundleClassesExpectingCredentialRepository')]
+    public function constructorAcceptsTheNewCredentialRecordRepositoryInterface(
+        string $class,
+        string $parameterName
+    ): void {
+        $constructor = new ReflectionMethod($class, '__construct');
+
+        $matchingParameter = null;
+        foreach ($constructor->getParameters() as $parameter) {
+            if ($parameter->getName() === $parameterName) {
+                $matchingParameter = $parameter;
+                break;
+            }
+        }
+
+        static::assertNotNull(
+            $matchingParameter,
+            sprintf('Class %s should have a constructor parameter named "%s".', $class, $parameterName)
+        );
+
+        $type = $matchingParameter->getType();
+        static::assertInstanceOf(ReflectionNamedType::class, $type);
+        static::assertSame(
+            CredentialRecordRepositoryInterface::class,
+            $type->getName(),
+            sprintf(
+                'Class %s::__construct(...$%s) must accept the new CredentialRecordRepositoryInterface so that user repositories implementing only the new interface can be autowired (issue #827). Was: %s.',
+                $class,
+                $parameterName,
+                $type->getName()
+            )
+        );
+    }
+
+    #[Test]
+    public function deprecatedRepositoryInterfaceStillExtendsTheNewOne(): void
+    {
+        // BC: a 5.2.x user repository implementing the legacy interface must still be injectable
+        // wherever the bundle now requires the new interface.
+        $reflection = new ReflectionClass(PublicKeyCredentialSourceRepositoryInterface::class);
+
+        static::assertTrue($reflection->implementsInterface(CredentialRecordRepositoryInterface::class));
+    }
+}

--- a/tests/symfony/unit/Repository/Issue832RegressionTest.php
+++ b/tests/symfony/unit/Repository/Issue832RegressionTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Bundle\Unit\Repository;
+
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionNamedType;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+use Webauthn\Bundle\Repository\DoctrineCredentialSourceRepository;
+use Webauthn\CredentialRecord;
+use Webauthn\PublicKeyCredentialDescriptor;
+use Webauthn\PublicKeyCredentialSource;
+use Webauthn\TrustPath\EmptyTrustPath;
+
+/**
+ * Issue #832: subclasses of DoctrineCredentialSourceRepository overriding
+ * saveCredentialSource(PublicKeyCredentialSource) (5.2.x style) must keep compiling
+ * AND must still be invoked when the bundle saves a credential.
+ *
+ * @internal
+ */
+final class Issue832RegressionTest extends TestCase
+{
+    #[Test]
+    public function legacySubclassWithOldSignatureCompiles(): void
+    {
+        // Just loading the class body would have crashed in vanilla 5.3.x with:
+        //   Compile Error: Declaration of [...]::saveCredentialSource(PublicKeyCredentialSource)
+        //   must be compatible with [...]::saveCredentialSource(CredentialRecord)
+        $reflection = new ReflectionMethod(LegacyDoctrineRepositoryFixture::class, 'saveCredentialSource');
+        $parameters = $reflection->getParameters();
+
+        static::assertCount(1, $parameters);
+        $type = $parameters[0]->getType();
+        static::assertInstanceOf(ReflectionNamedType::class, $type);
+        static::assertSame(PublicKeyCredentialSource::class, $type->getName());
+    }
+
+    #[Test]
+    public function newSaveDispatchesToLegacyOverrideWhenInstanceIsPublicKeyCredentialSource(): void
+    {
+        // saveCredentialRecord() must route PublicKeyCredentialSource arguments through
+        // saveCredentialSource() so that a 5.2.x subclass override is honored.
+        $repository = (new ReflectionClass(LegacyDoctrineRepositoryFixture::class))
+            ->newInstanceWithoutConstructor();
+
+        $pkcs = new PublicKeyCredentialSource(
+            'pkcs-id',
+            PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
+            [],
+            'none',
+            EmptyTrustPath::create(),
+            Uuid::v4(),
+            'public-key',
+            'user-handle',
+            10
+        );
+
+        $repository->saveCredentialRecord($pkcs);
+
+        static::assertSame([$pkcs], $repository->savedViaLegacyMethod);
+    }
+
+    #[Test]
+    public function newSaveBypassesLegacyOverrideForBareCredentialRecord(): void
+    {
+        // A raw CredentialRecord (not a PublicKeyCredentialSource) cannot be passed to the legacy
+        // method (parameter is typed as PublicKeyCredentialSource), so the parent must persist directly.
+        // Persistence requires a real Doctrine EntityManager, which we don't bootstrap here, so we
+        // simply assert that the legacy override path is NOT taken.
+        $repository = (new ReflectionClass(LegacyDoctrineRepositoryFixture::class))
+            ->newInstanceWithoutConstructor();
+
+        $credentialRecord = CredentialRecord::create(
+            'cr-id',
+            PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
+            [],
+            'none',
+            EmptyTrustPath::create(),
+            Uuid::v4(),
+            'public-key',
+            'user-handle',
+            10
+        );
+
+        try {
+            $repository->saveCredentialRecord($credentialRecord);
+        } catch (Throwable) {
+            // Expected: persistCredentialRecord() requires an EntityManager we did not wire.
+            // The important assertion is that the legacy method was not invoked.
+        }
+
+        static::assertSame([], $repository->savedViaLegacyMethod);
+    }
+}
+
+/**
+ * Mimics user code documented for v5.0/5.1/5.2: extends the deprecated
+ * DoctrineCredentialSourceRepository and keeps the legacy save signature.
+ *
+ * @internal
+ *
+ * @extends DoctrineCredentialSourceRepository<PublicKeyCredentialSource>
+ */
+final class LegacyDoctrineRepositoryFixture extends DoctrineCredentialSourceRepository
+{
+    /**
+     * @var list<PublicKeyCredentialSource>
+     */
+    public array $savedViaLegacyMethod = [];
+
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, PublicKeyCredentialSource::class);
+    }
+
+    public function saveCredentialSource(PublicKeyCredentialSource $publicKeyCredentialSource): void
+    {
+        $this->savedViaLegacyMethod[] = $publicKeyCredentialSource;
+    }
+}

--- a/tests/symfony/unit/Repository/Issue833RegressionTest.php
+++ b/tests/symfony/unit/Repository/Issue833RegressionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Bundle\Unit\Repository;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
+use Webauthn\Bundle\Security\Authentication\WebauthnBadgeListener;
+
+/**
+ * Issue #833: when multiple security.providers are declared, Symfony does not create an
+ * autowiring alias for UserProviderInterface, so WebauthnBadgeListener cannot be autowired
+ * unless its $userProvider argument is wired explicitly to security.user_providers.
+ *
+ * @internal
+ */
+final class Issue833RegressionTest extends TestCase
+{
+    #[Test]
+    public function webauthnBadgeListenerHasExplicitUserProviderArgument(): void
+    {
+        $container = new ContainerBuilder();
+        $loader = new PhpFileLoader(
+            $container,
+            new FileLocator(__DIR__ . '/../../../../src/symfony/src/Resources/config')
+        );
+        $loader->load('security.php');
+
+        static::assertTrue(
+            $container->hasDefinition(WebauthnBadgeListener::class),
+            'WebauthnBadgeListener should be registered by security.php.'
+        );
+
+        $definition = $container->getDefinition(WebauthnBadgeListener::class);
+        $argument = $definition->getArgument('$userProvider');
+
+        static::assertInstanceOf(Reference::class, $argument);
+        static::assertSame(
+            'security.user_providers',
+            (string) $argument,
+            'WebauthnBadgeListener::$userProvider must be wired to security.user_providers so that '
+                . 'autowiring works even when multiple user providers are configured (issue #833).'
+        );
+    }
+}

--- a/tests/symfony/unit/Repository/RepositoryImplementationsTest.php
+++ b/tests/symfony/unit/Repository/RepositoryImplementationsTest.php
@@ -10,7 +10,6 @@ use Psr\Log\NullLogger;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionNamedType;
-use Symfony\Component\Uid\Uuid;
 use Webauthn\Bundle\Repository\CanSaveCredentialRecord;
 use Webauthn\Bundle\Repository\CanSaveCredentialSource;
 use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
@@ -19,10 +18,7 @@ use Webauthn\Bundle\Repository\DummyCredentialRecordRepository;
 use Webauthn\Bundle\Repository\DummyPublicKeyCredentialSourceRepository;
 use Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface;
 use Webauthn\CredentialRecord;
-use Webauthn\PublicKeyCredentialDescriptor;
 use Webauthn\PublicKeyCredentialSource;
-use Webauthn\PublicKeyCredentialUserEntity;
-use Webauthn\TrustPath\EmptyTrustPath;
 
 /**
  * Tests for bundle repository implementations to ensure they properly handle both
@@ -33,133 +29,100 @@ use Webauthn\TrustPath\EmptyTrustPath;
 final class RepositoryImplementationsTest extends TestCase
 {
     #[Test]
-    public function dummyCredentialRecordRepositoryImplementsCorrectInterfaces(): void
+    public function dummyCredentialRecordRepositoryImplementsNewInterface(): void
     {
-        // Given
         $repository = new DummyCredentialRecordRepository(new NullLogger());
 
-        // Then
         static::assertInstanceOf(CredentialRecordRepositoryInterface::class, $repository);
     }
 
     #[Test]
-    public function dummyPublicKeyCredentialSourceRepositoryImplementsCorrectInterfaces(): void
+    public function dummyPublicKeyCredentialSourceRepositoryImplementsLegacyInterface(): void
     {
-        // Given
         $repository = new DummyPublicKeyCredentialSourceRepository(new NullLogger());
 
-        // Then
         static::assertInstanceOf(PublicKeyCredentialSourceRepositoryInterface::class, $repository);
+        // Old interface extends new one, so the legacy dummy is also a CredentialRecordRepositoryInterface.
+        static::assertInstanceOf(CredentialRecordRepositoryInterface::class, $repository);
     }
 
     #[Test]
-    public function dummyCredentialRecordRepositoryReturnsCredentialRecord(): void
+    public function doctrineCredentialSourceRepositoryImplementsBothSaverInterfaces(): void
     {
-        // Given
-        $repository = new DummyCredentialRecordRepository(new NullLogger());
-
-        // Then - verify the return type is CredentialRecord (nullable)
-        $reflection = new ReflectionMethod($repository, 'findOneByCredentialId');
-        $returnType = $reflection->getReturnType();
-
-        static::assertInstanceOf(ReflectionNamedType::class, $returnType);
-        static::assertSame(CredentialRecord::class, $returnType->getName());
-        static::assertTrue($returnType->allowsNull());
-    }
-
-    #[Test]
-    public function dummyPublicKeyCredentialSourceRepositoryReturnsCredentialRecord(): void
-    {
-        // Given
-        $repository = new DummyPublicKeyCredentialSourceRepository(new NullLogger());
-
-        // Then - verify the return type is CredentialRecord (nullable)
-        $reflection = new ReflectionMethod($repository, 'findOneByCredentialId');
-        $returnType = $reflection->getReturnType();
-
-        static::assertInstanceOf(ReflectionNamedType::class, $returnType);
-        static::assertSame(CredentialRecord::class, $returnType->getName());
-        static::assertTrue($returnType->allowsNull());
-    }
-
-    #[Test]
-    public function doctrineCredentialSourceRepositoryImplementsCorrectInterfaces(): void
-    {
-        // Given - use reflection to check class declaration instead of instantiating
         $reflection = new ReflectionClass(DoctrineCredentialSourceRepository::class);
 
-        // Then
+        // BC: implements both interfaces so legacy subclasses overriding saveCredentialSource(PublicKeyCredentialSource)
+        // keep working AND new code can call saveCredentialRecord(CredentialRecord).
         static::assertTrue($reflection->implementsInterface(PublicKeyCredentialSourceRepositoryInterface::class));
         static::assertTrue($reflection->implementsInterface(CanSaveCredentialSource::class));
-    }
-
-    #[Test]
-    public function doctrineCredentialSourceRepositoryAcceptsCredentialRecordInSaveMethod(): void
-    {
-        // Given - use reflection to check method signature
-        $reflection = new ReflectionMethod(DoctrineCredentialSourceRepository::class, 'saveCredentialSource');
-        $parameters = $reflection->getParameters();
-
-        // Then - verify the parameter type accepts CredentialRecord
-        static::assertCount(1, $parameters);
-        $paramType = $parameters[0]->getType();
-
-        static::assertInstanceOf(ReflectionNamedType::class, $paramType);
-        static::assertSame(CredentialRecord::class, $paramType->getName());
-    }
-
-    #[Test]
-    public function doctrineCredentialSourceRepositoryReturnsCredentialRecord(): void
-    {
-        // Given - use reflection to check method signature
-        $reflection = new ReflectionMethod(DoctrineCredentialSourceRepository::class, 'findOneByCredentialId');
-        $returnType = $reflection->getReturnType();
-
-        // Then - verify the return type is CredentialRecord (nullable)
-        static::assertInstanceOf(ReflectionNamedType::class, $returnType);
-        static::assertSame(CredentialRecord::class, $returnType->getName());
-        static::assertTrue($returnType->allowsNull());
-    }
-
-    #[Test]
-    public function canSaveCredentialRecordInterfaceAcceptsCredentialRecord(): void
-    {
-        // This test verifies that the interface itself has the correct signature
-        $reflection = new ReflectionMethod(CanSaveCredentialRecord::class, 'saveCredentialSource');
-        $parameters = $reflection->getParameters();
-
-        static::assertCount(1, $parameters);
-        $paramType = $parameters[0]->getType();
-
-        static::assertInstanceOf(ReflectionNamedType::class, $paramType);
-        static::assertSame(CredentialRecord::class, $paramType->getName());
-    }
-
-    #[Test]
-    public function canSaveCredentialSourceInterfaceExtendsCanSaveCredentialRecord(): void
-    {
-        // This test verifies that the deprecated interface extends the new one
-        $reflection = new ReflectionClass(CanSaveCredentialSource::class);
-
         static::assertTrue($reflection->implementsInterface(CanSaveCredentialRecord::class));
     }
 
     #[Test]
-    public function credentialRecordRepositoryInterfaceReturnsCredentialRecord(): void
+    public function doctrineLegacySaveMethodKeeps52XSignature(): void
     {
-        // Verify findOneByCredentialId returns CredentialRecord (nullable)
-        $reflection = new ReflectionMethod(CredentialRecordRepositoryInterface::class, 'findOneByCredentialId');
-        $returnType = $reflection->getReturnType();
+        // Issue #832: subclasses overriding saveCredentialSource(PublicKeyCredentialSource) must keep compiling.
+        $reflection = new ReflectionMethod(DoctrineCredentialSourceRepository::class, 'saveCredentialSource');
+        $parameters = $reflection->getParameters();
 
-        static::assertInstanceOf(ReflectionNamedType::class, $returnType);
-        static::assertSame(CredentialRecord::class, $returnType->getName());
-        static::assertTrue($returnType->allowsNull());
+        static::assertCount(1, $parameters);
+        $paramType = $parameters[0]->getType();
+
+        static::assertInstanceOf(ReflectionNamedType::class, $paramType);
+        static::assertSame(PublicKeyCredentialSource::class, $paramType->getName());
+    }
+
+    #[Test]
+    public function doctrineNewSaveMethodAcceptsCredentialRecord(): void
+    {
+        $reflection = new ReflectionMethod(DoctrineCredentialSourceRepository::class, 'saveCredentialRecord');
+        $parameters = $reflection->getParameters();
+
+        static::assertCount(1, $parameters);
+        $paramType = $parameters[0]->getType();
+
+        static::assertInstanceOf(ReflectionNamedType::class, $paramType);
+        static::assertSame(CredentialRecord::class, $paramType->getName());
+    }
+
+    #[Test]
+    public function newSaverInterfaceUsesNewMethodName(): void
+    {
+        $reflection = new ReflectionMethod(CanSaveCredentialRecord::class, 'saveCredentialRecord');
+        $parameters = $reflection->getParameters();
+
+        static::assertCount(1, $parameters);
+        $paramType = $parameters[0]->getType();
+
+        static::assertInstanceOf(ReflectionNamedType::class, $paramType);
+        static::assertSame(CredentialRecord::class, $paramType->getName());
+    }
+
+    #[Test]
+    public function legacySaverInterfaceKeepsOldSignature(): void
+    {
+        $reflection = new ReflectionMethod(CanSaveCredentialSource::class, 'saveCredentialSource');
+        $parameters = $reflection->getParameters();
+
+        static::assertCount(1, $parameters);
+        $paramType = $parameters[0]->getType();
+
+        static::assertInstanceOf(ReflectionNamedType::class, $paramType);
+        static::assertSame(PublicKeyCredentialSource::class, $paramType->getName());
+    }
+
+    #[Test]
+    public function legacySaverInterfaceDoesNotExtendNewOne(): void
+    {
+        // Otherwise legacy implementations would be forced to also declare saveCredentialRecord().
+        $reflection = new ReflectionClass(CanSaveCredentialSource::class);
+
+        static::assertFalse($reflection->implementsInterface(CanSaveCredentialRecord::class));
     }
 
     #[Test]
     public function publicKeyCredentialSourceRepositoryInterfaceExtendsCredentialRecordRepositoryInterface(): void
     {
-        // Verify the deprecated interface extends the new one
         $reflection = new ReflectionClass(PublicKeyCredentialSourceRepositoryInterface::class);
 
         static::assertTrue($reflection->implementsInterface(CredentialRecordRepositoryInterface::class));
@@ -168,86 +131,8 @@ final class RepositoryImplementationsTest extends TestCase
     #[Test]
     public function publicKeyCredentialSourceExtendsCredentialRecord(): void
     {
-        // Verify inheritance relationship
         $reflection = new ReflectionClass(PublicKeyCredentialSource::class);
 
         static::assertTrue($reflection->isSubclassOf(CredentialRecord::class));
-    }
-
-    #[Test]
-    public function repositoryCanStoreAndRetrieveBothTypes(): void
-    {
-        // Given - a mock repository that simulates real storage
-        $storage = [];
-
-        $repository = new class($storage) implements CredentialRecordRepositoryInterface, CanSaveCredentialRecord {
-            public function __construct(
-                private array &$storage
-            ) {
-            }
-
-            public function saveCredentialSource(CredentialRecord $credentialRecord): void
-            {
-                $this->storage[$credentialRecord->publicKeyCredentialId] = $credentialRecord;
-            }
-
-            public function findOneByCredentialId(string $publicKeyCredentialId): ?CredentialRecord
-            {
-                return $this->storage[$publicKeyCredentialId] ?? null;
-            }
-
-            public function findAllForUserEntity(PublicKeyCredentialUserEntity $publicKeyCredentialUserEntity): array
-            {
-                return array_filter(
-                    $this->storage,
-                    fn ($credential) => $credential->userHandle === $publicKeyCredentialUserEntity->id
-                );
-            }
-        };
-
-        $credentialRecord = CredentialRecord::create(
-            'cr-id',
-            PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
-            [],
-            'none',
-            EmptyTrustPath::create(),
-            Uuid::v4(),
-            'public-key',
-            'user-1',
-            10
-        );
-
-        $publicKeyCredentialSource = new PublicKeyCredentialSource(
-            'pkcs-id',
-            PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
-            [],
-            'none',
-            EmptyTrustPath::create(),
-            Uuid::v4(),
-            'public-key-2',
-            'user-1',
-            20
-        );
-
-        // When - saving both types (PublicKeyCredentialSource extends CredentialRecord)
-        $repository->saveCredentialSource($credentialRecord);
-        $repository->saveCredentialSource($publicKeyCredentialSource);
-
-        // Then - both can be retrieved as CredentialRecord
-        $retrievedCr = $repository->findOneByCredentialId('cr-id');
-        $retrievedPkcs = $repository->findOneByCredentialId('pkcs-id');
-
-        static::assertInstanceOf(CredentialRecord::class, $retrievedCr);
-        static::assertInstanceOf(CredentialRecord::class, $retrievedPkcs);
-        // PublicKeyCredentialSource is still a PublicKeyCredentialSource (inheritance)
-        static::assertInstanceOf(PublicKeyCredentialSource::class, $retrievedPkcs);
-        static::assertSame('user-1', $retrievedCr->userHandle);
-        static::assertSame('user-1', $retrievedPkcs->userHandle);
-
-        // And - findAllForUserEntity returns both
-        $userEntity = PublicKeyCredentialUserEntity::create('user-1', 'user-1', 'User 1');
-        $allCredentials = $repository->findAllForUserEntity($userEntity);
-
-        static::assertCount(2, $allCredentials);
     }
 }


### PR DESCRIPTION
## Summary

Fixes three regressions reported on the 5.3.x branch that all stem from the `PublicKeyCredentialSource → CredentialRecord` refactor being incomplete:

- **#827** — `CredentialRecordRepositoryInterface` is unusable: ~15 internal type-hints still required the deprecated `PublicKeyCredentialSourceRepositoryInterface`, so a user repository implementing only the new interface couldn't be autowired.
- **#832** — Signature change of `DoctrineCredentialSourceRepository::saveCredentialSource()` breaks user subclasses documented in v5.0/5.1/5.2 (compile error on the `PublicKeyCredentialSource` parameter).
- **#833** — `WebauthnBadgeListener::$userProvider` cannot be autowired when multiple `security.providers` are configured; the explicit `service('security.user_providers')` argument was dropped from `security.php`.

## Changes

### Interfaces (#832)
- `CanSaveCredentialRecord` now declares `saveCredentialRecord(CredentialRecord)` — fresh method name to avoid the LSP trap.
- `CanSaveCredentialSource` becomes a standalone deprecated interface declaring `saveCredentialSource(PublicKeyCredentialSource)` (5.2.x signature). It no longer `extends` the new interface, so legacy implementations are not forced to declare both methods.
- `DoctrineCredentialSourceRepository` implements both interfaces. `saveCredentialRecord()` routes `PublicKeyCredentialSource` arguments through `saveCredentialSource()` so 5.2.x subclass overrides keep being honored.

### Type-hints (#827)
Switched from `PublicKeyCredentialSourceRepositoryInterface` (deprecated child) to `CredentialRecordRepositoryInterface` (parent) in:
- `WebauthnAuthenticator`, `WebauthnBadgeListener`
- `AttestationResponseController`, `AssertionResponseController`
- `AttestationControllerFactory`, `AssertionControllerFactory`
- `ProfileBasedCreationOptionsBuilder`, `ProfileBasedRequestOptionsBuilder`
- `WebauthnExtension`, `WebauthnFactory`, `security.php`

All eight bundle classes are `final` (or `final readonly`). Per the [Symfony BC promise](https://symfony.com/doc/current/contributing/code/bc.html) notes 7 & 8: widening an argument type to a parent type is allowed for `@final` classes. The deprecated `PublicKeyCredentialSourceRepositoryInterface` extends the new one, so 5.2.x user repositories continue to satisfy the type-hint.

DI alias `CredentialRecordRepositoryInterface` is added; the deprecated `PublicKeyCredentialSourceRepositoryInterface` alias is kept for BC.

### Save BC bridge
Validators now return `CredentialRecord`, not `PublicKeyCredentialSource`. To keep calling 5.2.x-style `CanSaveCredentialSource` repositories with a `PublicKeyCredentialSource`, the framework wraps via the new internal helper `PublicKeyCredentialSource::fromCredentialRecord(CredentialRecord)`.

### Autowiring (#833)
Restored `->arg('\$userProvider', service('security.user_providers'))` on `WebauthnBadgeListener` in `security.php`.

### Tests
- `Issue827RegressionTest` (data provider on 8 classes) locks the new constructor type-hints in place.
- `Issue832RegressionTest` verifies that a 5.2.x-style subclass with the legacy signature compiles AND that `saveCredentialRecord(PKCS)` routes through the override.
- `Issue833RegressionTest` compiles `security.php` in a `ContainerBuilder` and asserts the explicit user-provider wiring.
- Existing `RepositoryCompatibilityTest`, `RepositoryImplementationsTest`, `RepositoryFunctionalTest` and the test repositories `PublicKeyCredentialSourceRepository` / `CredentialRecordRepository` realigned with the BC contract (legacy repo accepts only PKCS, new repo accepts any CR).

## Test plan

- [x] `vendor/bin/phpunit -c .ci-tools/phpunit.xml.dist` — 288 tests pass.
- [x] `castor phpstan` — clean (baseline regenerated).
- [x] `castor ecs` — clean.
- [ ] Manual verification by a 5.2.x user upgrading their existing `DoctrineCredentialSourceRepository` subclass.
- [ ] Manual verification of the multi-provider Contao reproducer described in #833.