### PR TITLE
feat: support Conditional Create mediation for auto-register flows (#831)

### DIFF
--- a/src/symfony/src/CredentialOptionsBuilder/ProfileBasedCreationOptionsBuilder.php
+++ b/src/symfony/src/CredentialOptionsBuilder/ProfileBasedCreationOptionsBuilder.php
@@ -52,6 +52,7 @@ final readonly class ProfileBasedCreationOptionsBuilder implements PublicKeyCred
         $authenticatorSelection = $this->buildAuthenticatorSelectionCriteria($optionsRequest);
         $attestation = $this->getEffectiveAttestation($optionsRequest);
         $extensions = $this->getEffectiveExtensions($optionsRequest);
+        $mediation = $this->getEffectiveMediation($optionsRequest);
 
         return $this->publicKeyCredentialCreationOptionsFactory->create(
             $this->profile,
@@ -59,8 +60,15 @@ final readonly class ProfileBasedCreationOptionsBuilder implements PublicKeyCred
             $excludedCredentials,
             $authenticatorSelection,
             $attestation,
-            $extensions
+            $extensions,
+            $mediation,
         );
+    }
+
+    private function getEffectiveMediation(PublicKeyCredentialCreationOptionsRequest $optionsRequest): ?string
+    {
+        /** @var string|null */
+        return $this->overridePolicy->getEffectiveValue('mediation', $optionsRequest->mediation, null);
     }
 
     private function buildAuthenticatorSelectionCriteria(

--- a/src/symfony/src/DependencyInjection/Configuration.php
+++ b/src/symfony/src/DependencyInjection/Configuration.php
@@ -215,6 +215,24 @@ final readonly class Configuration implements ConfigurationInterface
             ->end()
             ->end()
             ->end()
+            ->arrayNode('mediation')
+            ->addDefaultsIfNotSet()
+            ->children()
+            ->booleanNode('enabled')
+            ->defaultFalse()
+            ->info('Whether to allow client requests to request the conditional mediation flow (auto-register).')
+            ->end()
+            ->arrayNode('allowed_values')
+            ->defaultValue([
+                PublicKeyCredentialCreationOptions::MEDIATION_DEFAULT,
+                PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL,
+            ])
+            ->scalarPrototype()
+            ->end()
+            ->info('List of allowed mediation values')
+            ->end()
+            ->end()
+            ->end()
             ->end()
             ->end()
             ->end();

--- a/src/symfony/src/Dto/PublicKeyCredentialCreationOptionsRequest.php
+++ b/src/symfony/src/Dto/PublicKeyCredentialCreationOptionsRequest.php
@@ -44,6 +44,13 @@ class PublicKeyCredentialCreationOptionsRequest
     ])]
     public ?string $authenticatorAttachment = null;
 
+    #[NotBlank(allowNull: true)]
+    #[Choice(choices: [
+        PublicKeyCredentialCreationOptions::MEDIATION_DEFAULT,
+        PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL,
+    ])]
+    public ?string $mediation = null;
+
     /**
      * @var array<string, mixed>|null
      */

--- a/src/symfony/src/Service/PublicKeyCredentialCreationOptionsFactory.php
+++ b/src/symfony/src/Service/PublicKeyCredentialCreationOptionsFactory.php
@@ -26,7 +26,7 @@ final class PublicKeyCredentialCreationOptionsFactory implements CanDispatchEven
     private EventDispatcherInterface $eventDispatcher;
 
     /**
-     * @param array<string, array{rp: array{name: string, id: ?string}, challenge_length: int, timeout?: ?int, attestation_conveyance?: ?string, authenticator_selection_criteria: array{authenticator_attachment: ?string, user_verification: ?string, resident_key: ?string}, public_key_credential_parameters: list<int>, extensions: array<string, mixed>}> $profiles
+     * @param array<string, array{rp: array{name: string, id: ?string}, challenge_length: int, timeout?: ?int, attestation_conveyance?: ?string, authenticator_selection_criteria: array{authenticator_attachment: ?string, user_verification: ?string, resident_key: ?string}, public_key_credential_parameters: list<int>, extensions: array<string, mixed>, conditional_create?: bool}> $profiles
      */
     public function __construct(
         private readonly array $profiles,
@@ -48,7 +48,8 @@ final class PublicKeyCredentialCreationOptionsFactory implements CanDispatchEven
         array $excludeCredentials = [],
         null|AuthenticatorSelectionCriteria $authenticatorSelection = null,
         null|string $attestationConveyance = null,
-        null|AuthenticationExtensions $AuthenticationExtensions = null
+        null|AuthenticationExtensions $AuthenticationExtensions = null,
+        null|string $mediation = null,
     ): PublicKeyCredentialCreationOptions {
         array_key_exists($key, $this->profiles) || throw new InvalidArgumentException(sprintf(
             'The profile with key "%s" does not exist.',
@@ -64,6 +65,14 @@ final class PublicKeyCredentialCreationOptionsFactory implements CanDispatchEven
         ));
         $attestation = $attestationConveyance ?? $profile['attestation_conveyance'] ?? null;
 
+        // The legacy `conditional_create: true` profile flag stays as a shortcut and feeds the new
+        // `mediation` mechanism: an explicit per-request mediation always wins, otherwise the profile
+        // default applies.
+        $effectiveMediation = $mediation
+            ?? (($profile['conditional_create'] ?? false) === true
+                ? PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL
+                : null);
+
         /** @var int<1, max> $challengeLength */
         $challengeLength = $profile['challenge_length'];
         $options = PublicKeyCredentialCreationOptions
@@ -78,7 +87,8 @@ final class PublicKeyCredentialCreationOptionsFactory implements CanDispatchEven
                 attestation: $attestation,
                 excludeCredentials: $excludeCredentials,
                 timeout: $timeout,
-                extensions: $AuthenticationExtensions ?? $this->createExtensions($profile)
+                extensions: $AuthenticationExtensions ?? $this->createExtensions($profile),
+                mediation: $effectiveMediation,
             );
         $this->eventDispatcher->dispatch(PublicKeyCredentialCreationOptionsCreatedEvent::create($options));
 

--- a/src/webauthn/src/CeremonyStep/CheckUserWasPresent.php
+++ b/src/webauthn/src/CeremonyStep/CheckUserWasPresent.php
@@ -14,10 +14,13 @@ use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
 
 /**
- * Conditional check for user presence
+ * Conditional check for user presence.
  *
- * This step allows user presence to be false for Conditional Create scenarios
- * where mediation: 'conditional' is used (e.g., auto-register after password login).
+ * The User Presence (UP) bit MUST be set unless the ceremony explicitly opts out via the
+ * Conditional Create flow (e.g. SimpleWebAuthn `useAutoRegister: true`). The opt-out is
+ * controlled at runtime by `PublicKeyCredentialCreationOptions::$mediation`, which the
+ * options builder sets from the configured policy. The constructor flag remains a static
+ * fallback used by `CeremonyStepManagerFactory::conditionalCreateCeremony()`.
  *
  * @see https://github.com/w3c/webauthn/wiki/Explainer:-Conditional-Create
  */
@@ -43,7 +46,7 @@ final readonly class CheckUserWasPresent implements CeremonyStep
                 self::class
             );
         }
-        if (! $this->requireUserPresence) {
+        if (! $this->isUserPresenceRequired($publicKeyCredentialOptions)) {
             return;
         }
 
@@ -54,5 +57,16 @@ final readonly class CheckUserWasPresent implements CeremonyStep
         $authData->isUserPresent() || throw AuthenticatorResponseVerificationException::create(
             'User was not present'
         );
+    }
+
+    private function isUserPresenceRequired(
+        PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions
+    ): bool {
+        if ($publicKeyCredentialOptions instanceof PublicKeyCredentialCreationOptions
+            && $publicKeyCredentialOptions->mediation === PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL) {
+            return false;
+        }
+
+        return $this->requireUserPresence;
     }
 }

--- a/src/webauthn/src/PublicKeyCredentialCreationOptions.php
+++ b/src/webauthn/src/PublicKeyCredentialCreationOptions.php
@@ -29,6 +29,25 @@ final class PublicKeyCredentialCreationOptions extends PublicKeyCredentialOption
         self::ATTESTATION_CONVEYANCE_PREFERENCE_ENTERPRISE,
     ];
 
+    public const MEDIATION_DEFAULT = 'default';
+
+    public const MEDIATION_CONDITIONAL = 'conditional';
+
+    public const MEDIATIONS = [self::MEDIATION_DEFAULT, self::MEDIATION_CONDITIONAL];
+
+    /**
+     * Server-side mediation hint. Mirrors the JS `mediation` option of `navigator.credentials.create()`
+     * but is *not* sent to the browser — it controls how the framework validates the response.
+     *
+     * - `MEDIATION_DEFAULT` (default) — full ceremony validation, including User Presence (UP) bit.
+     * - `MEDIATION_CONDITIONAL` — auto-register flow (e.g. SimpleWebAuthn `useAutoRegister: true`):
+     *   the UP bit is allowed to be false because the user already authenticated through another
+     *   factor (typically password). All other checks remain.
+     *
+     * @see https://github.com/w3c/webauthn/wiki/Explainer:-Conditional-Create
+     */
+    public null|string $mediation = null;
+
     /**
      * @param PublicKeyCredentialParameters[] $pubKeyCredParams
      * @param PublicKeyCredentialDescriptor[] $excludeCredentials
@@ -46,6 +65,7 @@ final class PublicKeyCredentialCreationOptions extends PublicKeyCredentialOption
         null|int $timeout = null,
         null|AuthenticationExtensions $extensions = null,
         array $hints = [],
+        null|string $mediation = null,
     ) {
         foreach ($pubKeyCredParams as $pubKeyCredParam) {
             $pubKeyCredParam instanceof PublicKeyCredentialParameters || throw new InvalidArgumentException(
@@ -61,6 +81,12 @@ final class PublicKeyCredentialCreationOptions extends PublicKeyCredentialOption
             $attestation,
             'Invalid attestation conveyance mode'
         );
+        $mediation === null || in_array($mediation, self::MEDIATIONS, true) || throw InvalidDataException::create(
+            $mediation,
+            'Invalid mediation requirement'
+        );
+
+        $this->mediation = $mediation;
 
         parent::__construct($challenge, $timeout, $extensions, $hints);
     }
@@ -82,6 +108,7 @@ final class PublicKeyCredentialCreationOptions extends PublicKeyCredentialOption
         null|int $timeout = null,
         null|AuthenticationExtensions $extensions = null,
         array $hints = [],
+        null|string $mediation = null,
     ): self {
         return new self(
             $rp,
@@ -93,7 +120,8 @@ final class PublicKeyCredentialCreationOptions extends PublicKeyCredentialOption
             $excludeCredentials,
             $timeout,
             $extensions,
-            $hints
+            $hints,
+            $mediation,
         );
     }
 }

--- a/tests/library/Unit/CeremonyStep/CheckUserWasPresentTest.php
+++ b/tests/library/Unit/CeremonyStep/CheckUserWasPresentTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Unit\CeremonyStep;
+
+use function chr;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+use Webauthn\AttestationStatement\AttestationObject;
+use Webauthn\AttestationStatement\AttestationStatement;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\AuthenticatorData;
+use Webauthn\CeremonyStep\CheckUserWasPresent;
+use Webauthn\CollectedClientData;
+use Webauthn\CredentialRecord;
+use Webauthn\Exception\AuthenticatorResponseVerificationException;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialDescriptor;
+use Webauthn\PublicKeyCredentialRpEntity;
+use Webauthn\PublicKeyCredentialUserEntity;
+use Webauthn\Tests\AbstractTestCase;
+use Webauthn\TrustPath\EmptyTrustPath;
+
+/**
+ * Issue #831 — verify the runtime mediation override on `PublicKeyCredentialCreationOptions::$mediation`
+ * is honored by CheckUserWasPresent, regardless of the constructor flag.
+ *
+ * @internal
+ */
+final class CheckUserWasPresentTest extends AbstractTestCase
+{
+    #[Test]
+    public function strictStepThrowsWhenUserWasNotPresentAndOptionsHaveNoMediation(): void
+    {
+        $step = new CheckUserWasPresent(requireUserPresence: true);
+
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+        $this->expectExceptionMessage('User was not present');
+
+        $step->process(
+            $this->credentialRecord(),
+            $this->attestationResponseWithUpFlag(false),
+            $this->creationOptions(mediation: null),
+            null,
+            'example.com',
+        );
+    }
+
+    #[Test]
+    public function strictStepIsBypassedWhenOptionsRequestConditionalMediation(): void
+    {
+        $step = new CheckUserWasPresent(requireUserPresence: true);
+
+        // Must NOT throw — `mediation: conditional` opts out of the User Presence requirement at runtime.
+        $step->process(
+            $this->credentialRecord(),
+            $this->attestationResponseWithUpFlag(false),
+            $this->creationOptions(mediation: PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL),
+            null,
+            'example.com',
+        );
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function strictStepStillRunsWhenOptionsExplicitlyRequestDefaultMediation(): void
+    {
+        $step = new CheckUserWasPresent(requireUserPresence: true);
+
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+
+        $step->process(
+            $this->credentialRecord(),
+            $this->attestationResponseWithUpFlag(false),
+            $this->creationOptions(mediation: PublicKeyCredentialCreationOptions::MEDIATION_DEFAULT),
+            null,
+            'example.com',
+        );
+    }
+
+    #[Test]
+    public function lenientStepKeepsWorkingForBackwardCompatibility(): void
+    {
+        // CeremonyStepManagerFactory::conditionalCreateCeremony() builds the step with requireUserPresence=false.
+        // That static fallback must keep working when no mediation hint is set on the options.
+        $step = new CheckUserWasPresent(requireUserPresence: false);
+
+        $step->process(
+            $this->credentialRecord(),
+            $this->attestationResponseWithUpFlag(false),
+            $this->creationOptions(mediation: null),
+            null,
+            'example.com',
+        );
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function strictStepAllowsValidUserPresenceRegardlessOfMediation(): void
+    {
+        $step = new CheckUserWasPresent(requireUserPresence: true);
+
+        $step->process(
+            $this->credentialRecord(),
+            $this->attestationResponseWithUpFlag(true),
+            $this->creationOptions(mediation: null),
+            null,
+            'example.com',
+        );
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    private function credentialRecord(): CredentialRecord
+    {
+        return CredentialRecord::create(
+            'credential-id',
+            PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
+            [],
+            'none',
+            EmptyTrustPath::create(),
+            Uuid::v4(),
+            'public-key',
+            'user-handle',
+            0,
+        );
+    }
+
+    private function creationOptions(?string $mediation): PublicKeyCredentialCreationOptions
+    {
+        return PublicKeyCredentialCreationOptions::create(
+            PublicKeyCredentialRpEntity::create('Test RP'),
+            PublicKeyCredentialUserEntity::create('alice', 'uid', 'Alice'),
+            'challenge-bytes',
+            mediation: $mediation,
+        );
+    }
+
+    private function attestationResponseWithUpFlag(bool $userPresent): AuthenticatorAttestationResponse
+    {
+        $flags = chr($userPresent ? AuthenticatorData::FLAG_UP : 0);
+        $authData = AuthenticatorData::create(
+            authData: '',
+            rpIdHash: str_repeat("\0", 32),
+            flags: $flags,
+            signCount: 0,
+        );
+
+        return AuthenticatorAttestationResponse::create(
+            CollectedClientData::create('{}', [
+                'type' => 'webauthn.create',
+                'challenge' => 'challenge-bytes',
+                'origin' => 'https://example.com',
+            ]),
+            AttestationObject::create(
+                rawAttestationObject: '',
+                attStmt: AttestationStatement::createNone('none', [], EmptyTrustPath::create()),
+                authData: $authData,
+            ),
+        );
+    }
+}

--- a/tests/library/Unit/PublicKeyCredentialCreationOptionsTest.php
+++ b/tests/library/Unit/PublicKeyCredentialCreationOptionsTest.php
@@ -7,6 +7,7 @@ namespace Webauthn\Tests\Unit;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+use Webauthn\Exception\InvalidDataException;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialDescriptor;
 use Webauthn\PublicKeyCredentialParameters;
@@ -197,5 +198,80 @@ final class PublicKeyCredentialCreationOptionsTest extends AbstractTestCase
 
         // Then
         static::assertSame([], $options->hints);
+    }
+
+    #[Test]
+    public function mediationDefaultsToNull(): void
+    {
+        $options = PublicKeyCredentialCreationOptions::create(
+            PublicKeyCredentialRpEntity::create('Test'),
+            PublicKeyCredentialUserEntity::create('alice', 'uid', 'Alice'),
+            'challenge',
+        );
+
+        static::assertNull($options->mediation);
+    }
+
+    #[Test]
+    public function conditionalMediationIsAcceptedAndStored(): void
+    {
+        $options = PublicKeyCredentialCreationOptions::create(
+            PublicKeyCredentialRpEntity::create('Test'),
+            PublicKeyCredentialUserEntity::create('alice', 'uid', 'Alice'),
+            'challenge',
+            mediation: PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL,
+        );
+
+        static::assertSame(PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL, $options->mediation);
+    }
+
+    #[Test]
+    public function invalidMediationIsRejected(): void
+    {
+        $this->expectException(InvalidDataException::class);
+        $this->expectExceptionMessage('Invalid mediation requirement');
+
+        PublicKeyCredentialCreationOptions::create(
+            PublicKeyCredentialRpEntity::create('Test'),
+            PublicKeyCredentialUserEntity::create('alice', 'uid', 'Alice'),
+            'challenge',
+            mediation: 'invalid',
+        );
+    }
+
+    #[Test]
+    public function mediationIsNotEmittedInTheJsonSentToTheBrowser(): void
+    {
+        // The browser receives `mediation` via the JS API, not via the server-side options dictionary.
+        // Leaking it in the JSON would pollute the payload without any client-side effect.
+        $options = PublicKeyCredentialCreationOptions::create(
+            PublicKeyCredentialRpEntity::create('Test'),
+            PublicKeyCredentialUserEntity::create('alice', 'uid', 'Alice'),
+            'challenge',
+            mediation: PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL,
+        );
+
+        $json = $this->getSerializer()
+            ->serialize($options, 'json');
+
+        static::assertStringNotContainsString('mediation', $json);
+    }
+
+    #[Test]
+    public function mediationSurvivesPhpNativeSerializationRoundTrip(): void
+    {
+        // The bundle's OptionsStorage uses PHP native serialize/unserialize to persist
+        // the options between the request and response phases.
+        $options = PublicKeyCredentialCreationOptions::create(
+            PublicKeyCredentialRpEntity::create('Test'),
+            PublicKeyCredentialUserEntity::create('alice', 'uid', 'Alice'),
+            'challenge',
+            mediation: PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL,
+        );
+
+        /** @var PublicKeyCredentialCreationOptions $restored */
+        $restored = unserialize(serialize($options));
+
+        static::assertSame(PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL, $restored->mediation);
     }
 }

--- a/tests/symfony/unit/Issue831RegressionTest.php
+++ b/tests/symfony/unit/Issue831RegressionTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Bundle\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Webauthn\Bundle\Dto\PublicKeyCredentialCreationOptionsRequest;
+use Webauthn\Bundle\Policy\ClientOverridePolicy;
+use Webauthn\Bundle\Service\PublicKeyCredentialCreationOptionsFactory;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+/**
+ * Issue #831: when a Conditional Create flow is used (e.g. SimpleWebAuthn `useAutoRegister: true`),
+ * the User Presence bit may legitimately be false. The bundle must let the relying party opt out of
+ * the strict UP check on a per-request basis, mirroring the JS `mediation: 'conditional'` option.
+ *
+ * @internal
+ */
+final class Issue831RegressionTest extends TestCase
+{
+    #[Test]
+    public function profileConditionalCreateFlagSetsMediationOnOptions(): void
+    {
+        // Backward-compat: existing profiles using the legacy boolean keep working and now produce
+        // a mediation hint that flows through to CheckUserWasPresent at runtime.
+        $factory = new PublicKeyCredentialCreationOptionsFactory($this->profiles(conditionalCreate: true));
+
+        $options = $factory->create('default', $this->userEntity());
+
+        static::assertSame(PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL, $options->mediation);
+    }
+
+    #[Test]
+    public function profileWithoutConditionalCreateLeavesMediationNull(): void
+    {
+        $factory = new PublicKeyCredentialCreationOptionsFactory($this->profiles(conditionalCreate: false));
+
+        $options = $factory->create('default', $this->userEntity());
+
+        static::assertNull($options->mediation);
+    }
+
+    #[Test]
+    public function explicitMediationOverridesProfileDefault(): void
+    {
+        $factory = new PublicKeyCredentialCreationOptionsFactory($this->profiles(conditionalCreate: true));
+
+        $options = $factory->create(
+            'default',
+            $this->userEntity(),
+            mediation: PublicKeyCredentialCreationOptions::MEDIATION_DEFAULT,
+        );
+
+        static::assertSame(PublicKeyCredentialCreationOptions::MEDIATION_DEFAULT, $options->mediation);
+    }
+
+    #[Test]
+    public function clientOverridePolicyRejectsMediationByDefault(): void
+    {
+        // Out of the box, the policy is restrictive: a malicious client cannot downgrade UP enforcement
+        // by sending `mediation: conditional` unless the RP explicitly enabled the override.
+        $policy = new ClientOverridePolicy();
+
+        static::assertFalse($policy->canOverride('mediation'));
+        static::assertNull($policy->getEffectiveValue(
+            'mediation',
+            PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL,
+            null,
+        ));
+    }
+
+    #[Test]
+    public function clientOverridePolicyHonoursMediationWhenEnabled(): void
+    {
+        $policy = new ClientOverridePolicy([
+            'mediation' => [
+                'enabled' => true,
+                'allowed_values' => [
+                    PublicKeyCredentialCreationOptions::MEDIATION_DEFAULT,
+                    PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL,
+                ],
+            ],
+        ]);
+
+        static::assertSame(
+            PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL,
+            $policy->getEffectiveValue(
+                'mediation',
+                PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL,
+                null,
+            ),
+        );
+    }
+
+    #[Test]
+    public function clientOverridePolicyRejectsValueOutsideAllowedList(): void
+    {
+        $policy = new ClientOverridePolicy([
+            'mediation' => [
+                'enabled' => true,
+                'allowed_values' => [PublicKeyCredentialCreationOptions::MEDIATION_DEFAULT],
+            ],
+        ]);
+
+        // Even when the override is enabled, a non-allowed value falls back to the profile default.
+        static::assertNull($policy->getEffectiveValue(
+            'mediation',
+            PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL,
+            null,
+        ));
+    }
+
+    #[Test]
+    public function dtoAcceptsValidMediationValues(): void
+    {
+        $request = new PublicKeyCredentialCreationOptionsRequest();
+        $request->mediation = PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL;
+
+        static::assertSame(PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL, $request->mediation);
+    }
+
+    /**
+     * @return array<string, array{rp: array{name: string, id: ?string}, challenge_length: int, attestation_conveyance: ?string, authenticator_selection_criteria: array{authenticator_attachment: ?string, user_verification: ?string, resident_key: ?string}, public_key_credential_parameters: list<int>, extensions: array<string, mixed>, conditional_create: bool}>
+     */
+    private function profiles(bool $conditionalCreate): array
+    {
+        return [
+            'default' => [
+                'rp' => [
+                    'name' => 'Test RP',
+                    'id' => null,
+                ],
+                'challenge_length' => 32,
+                'attestation_conveyance' => null,
+                'authenticator_selection_criteria' => [
+                    'authenticator_attachment' => null,
+                    'user_verification' => 'preferred',
+                    'resident_key' => null,
+                ],
+                'public_key_credential_parameters' => [-7],
+                'extensions' => [],
+                'conditional_create' => $conditionalCreate,
+            ],
+        ];
+    }
+
+    private function userEntity(): PublicKeyCredentialUserEntity
+    {
+        return PublicKeyCredentialUserEntity::create('alice', 'uid-alice', 'Alice');
+    }
+}


### PR DESCRIPTION
## Summary

Closes #831.

When a credential is created through a Conditional Create / auto-register flow (e.g. SimpleWebAuthn's `useAutoRegister: true`), the User Presence (UP) bit may legitimately be false: the user already authenticated through another factor (typically password) and the browser does not solicit a fresh consent gesture. SimpleWebAuthn's [server-side counterpart](https://simplewebauthn.dev/docs/packages/server#2-verify-registration-response) uses `requireUserPresence: false` to handle this. Until now, the framework had no equivalent and `CheckUserWasPresent` always threw.

This PR adds a per-request `mediation` hint that flows through the bundle from policy → DTO → options → ceremony step.

## Design notes

- The new `mediation` property lives on `PublicKeyCredentialCreationOptions` (per-request, RP-side). It is **not** included in the JSON sent to the browser (the browser receives `mediation` via the JS API).
- `CheckUserWasPresent::process()` reads the property at runtime and skips the UP check only when `mediation === 'conditional'`. The static constructor flag remains as a fallback for direct lib users of `CeremonyStepManagerFactory::conditionalCreateCeremony()`.
- `ClientOverridePolicy` gets a new `mediation` entry, disabled by default. RPs must opt in to allow clients to request `mediation: conditional` over the wire.
- The legacy per-profile `conditional_create: true` boolean keeps working — the factory now translates it into `mediation = 'conditional'` on the produced options, so existing configurations behave identically with no migration step required.
- Storage round-trip: the bundle's `OptionsStorage` (Session / Cache) uses PHP native `serialize()` so the `$mediation` property survives between the request and response phases.

## Aligned with the future policy-centric model

The `mediation` field is added to `ClientOverridePolicy` rather than as another per-profile boolean, so it fits the upcoming direction where the policy becomes the central authority over what clients can negotiate.

## Test plan

- [x] `vendor/bin/phpunit -c .ci-tools/phpunit.xml.dist` — 305 tests pass.
- [x] `castor ecs` — clean.
- [x] PHPStan — clean (the two pre-existing PHP 8.5-only `chr()` warnings remain unrelated; CI runs on PHP 8.4).
- [ ] Manual: walk the SimpleWebAuthn `useAutoRegister: true` reproducer from #831 against this branch with `client_override_policy.mediation.enabled: true`.

## Behavioural matrix

| Caller config | UP=true response | UP=false response |
| --- | --- | --- |
| No mediation set (default) | ✅ pass | ❌ throws |
| `mediation: default` set explicitly | ✅ pass | ❌ throws |
| `mediation: conditional` set | ✅ pass | ✅ pass |
| Legacy `conditional_create: true` profile | ✅ pass | ✅ pass (auto-translated to `mediation: conditional`) |
| `CeremonyStepManagerFactory::conditionalCreateCeremony()` consumer | ✅ pass | ✅ pass (existing static fallback) |