### PR TITLE
test: deepen #833 regression coverage with multi-providers functional config

### DIFF
--- a/tests/symfony/config/config.yml
+++ b/tests/symfony/config/config.yml
@@ -178,8 +178,16 @@ security:
   providers:
     default:
       id: 'Webauthn\Tests\Bundle\Functional\UserProvider'
+    # Second (unused) provider declared on purpose: it reproduces the multi-providers scenario
+    # from issue #833. With more than one provider, Symfony does not autowire UserProviderInterface,
+    # so WebauthnBadgeListener must keep its explicit `$userProvider => security.user_providers`
+    # argument to load.
+    secondary:
+      memory:
+        users: { }
   firewalls:
     main:
+      provider: default
       custom_authenticator: 'Webauthn\Tests\Bundle\Functional\WebauthnAuthenticator'
       webauthn:
         failure_handler: 'Webauthn\Tests\Bundle\Functional\FailureHandler'


### PR DESCRIPTION
## Summary

The unit `Issue833RegressionTest` shipped in #838 only inspected the static service definition produced by `security.php`. It did not exercise the actual reproducer from #833 (a Symfony app declaring more than one `security.providers`).

This change extends the functional test kernel config to declare a second, in-memory provider — the exact shape that triggered the autowiring failure in the original report (Contao back-end + front-end providers). The firewall is updated to point at the existing provider explicitly so the bundle can boot.

If a future change ever drops the explicit `\$userProvider => security.user_providers` argument from `security.php`, the **entire functional suite** now fails at container compile time, not just the dedicated unit test.

## Test plan

- [x] `vendor/bin/phpunit -c .ci-tools/phpunit.xml.dist` — 305 tests pass with the second provider declared.
- [x] `castor rector` — clean.
- [x] `castor ecs` — clean.
- [x] PHPStan — clean (the two pre-existing PHP 8.5-only `chr()` warnings remain unrelated; CI runs on PHP 8.4).