### PR TITLE
test: pin the three user-provider resolution paths exposed by the bundle

### DIFF
--- a/tests/symfony/unit/DependencyInjection/Factory/Security/WebauthnFactoryFirewallProviderTest.php
+++ b/tests/symfony/unit/DependencyInjection/Factory/Security/WebauthnFactoryFirewallProviderTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Bundle\Unit\DependencyInjection\Factory\Security;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Webauthn\Bundle\DependencyInjection\Factory\Security\WebauthnFactory;
+use Webauthn\Bundle\DependencyInjection\Factory\Security\WebauthnServicesFactory;
+
+/**
+ * Documents Path 2 of the user-provider resolution: when the bundle's `webauthn:` firewall is
+ * used, the authenticator created for that firewall MUST receive the firewall's configured
+ * `provider:` (resolved by Symfony's security framework into a service id), not the global chain.
+ *
+ * The factory is the seam where Symfony hands off the per-firewall provider to the bundle, so we
+ * test it at that exact boundary.
+ *
+ * @internal
+ */
+final class WebauthnFactoryFirewallProviderTest extends TestCase
+{
+    #[Test]
+    public function authenticatorServiceReceivesTheFirewallSpecificUserProvider(): void
+    {
+        $container = $this->containerWithAuthenticatorTemplate();
+        $factory = new WebauthnFactory(new WebauthnServicesFactory());
+
+        $authenticatorId = $this->invokeCreateAuthenticatorService(
+            $factory,
+            $container,
+            firewallName: 'admin',
+            userProviderId: 'security.user.provider.concrete.admin_provider',
+        );
+
+        $definition = $container->getDefinition($authenticatorId);
+        $userProviderArgument = $definition->getArgument(1);
+
+        static::assertInstanceOf(Reference::class, $userProviderArgument);
+        static::assertSame(
+            'security.user.provider.concrete.admin_provider',
+            (string) $userProviderArgument,
+            'WebauthnFactory must wire the firewall-scoped user provider as argument #1 of the authenticator service.',
+        );
+    }
+
+    #[Test]
+    public function eachFirewallGetsAnAuthenticatorBoundToItsOwnUserProvider(): void
+    {
+        // Multi-firewall scenario, the same one #833 reported (back-end + front-end providers).
+        $container = $this->containerWithAuthenticatorTemplate();
+        $factory = new WebauthnFactory(new WebauthnServicesFactory());
+
+        $backendId = $this->invokeCreateAuthenticatorService(
+            $factory,
+            $container,
+            firewallName: 'backend',
+            userProviderId: 'security.user.provider.concrete.backend',
+        );
+        $frontendId = $this->invokeCreateAuthenticatorService(
+            $factory,
+            $container,
+            firewallName: 'frontend',
+            userProviderId: 'security.user.provider.concrete.frontend',
+        );
+
+        static::assertNotSame($backendId, $frontendId, 'Each firewall must get its own authenticator service.');
+        static::assertSame(
+            'security.user.provider.concrete.backend',
+            (string) $container->getDefinition($backendId)
+                ->getArgument(1),
+        );
+        static::assertSame(
+            'security.user.provider.concrete.frontend',
+            (string) $container->getDefinition($frontendId)
+                ->getArgument(1),
+        );
+    }
+
+    private function invokeCreateAuthenticatorService(
+        WebauthnFactory $factory,
+        ContainerBuilder $container,
+        string $firewallName,
+        string $userProviderId,
+    ): string {
+        // The public createAuthenticator() pulls in route/controller side-effects that are out of
+        // scope for this test. createAuthenticatorService() is the private seam that wires the
+        // user-provider argument; reach it via reflection.
+        $method = new ReflectionMethod(WebauthnFactory::class, 'createAuthenticatorService');
+
+        return $method->invoke(
+            $factory,
+            $container,
+            $firewallName,
+            $userProviderId,
+            'success.handler.id',
+            'failure.handler.id',
+            'firewall.config.id',
+            null,
+            'assertion.validator.id',
+            'attestation.validator.id',
+        );
+    }
+
+    private function containerWithAuthenticatorTemplate(): ContainerBuilder
+    {
+        // The factory adds ChildDefinitions of WebauthnFactory::AUTHENTICATOR_DEFINITION_ID; the
+        // template must therefore exist in the container, even if we never compile it.
+        $container = new ContainerBuilder();
+        $container->setDefinition(
+            WebauthnFactory::AUTHENTICATOR_DEFINITION_ID,
+            (new Definition())->setAbstract(true),
+        );
+
+        return $container;
+    }
+}

--- a/tests/symfony/unit/Security/Authentication/WebauthnBadgeListenerUserProviderTest.php
+++ b/tests/symfony/unit/Security/Authentication/WebauthnBadgeListenerUserProviderTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Bundle\Unit\Security\Authentication;
+
+use LogicException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use RuntimeException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Event\CheckPassportEvent;
+use Symfony\Component\Serializer\SerializerInterface;
+use Webauthn\AuthenticatorAssertionResponseValidator;
+use Webauthn\AuthenticatorAttestationResponseValidator;
+use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
+use Webauthn\Bundle\Repository\PublicKeyCredentialUserEntityRepositoryInterface;
+use Webauthn\Bundle\Security\Authentication\WebauthnBadge;
+use Webauthn\Bundle\Security\Authentication\WebauthnBadgeListener;
+use Webauthn\Bundle\Security\Authentication\WebauthnPassport;
+use Webauthn\Bundle\Security\Storage\OptionsStorage;
+use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
+
+/**
+ * Documents the three user-provider resolution paths that the bundle exposes (issue #833 follow-up).
+ *
+ * Path 1: badge created with an explicit `userLoader` callback → priority over anything else.
+ * Path 2: built-in `webauthn:` firewall → uses the firewall's `provider:` config (covered by a
+ *         dedicated integration test on the security factory wiring, see WebauthnFactoryFirewallProviderTest).
+ * Path 3: badge created without `userLoader` → listener falls back to the injected
+ *         `UserProviderInterface` (currently `security.user_providers`).
+ *
+ * @internal
+ */
+final class WebauthnBadgeListenerUserProviderTest extends TestCase
+{
+    #[Test]
+    public function explicitBadgeUserLoaderTakesPriorityOverListenerFallback(): void
+    {
+        $explicitLoader = static fn (string $identifier): UserInterface => new InMemoryUser('from-badge-loader', null);
+        $badge = new WebauthnBadge('localhost', '{}', userLoader: $explicitLoader);
+
+        $listener = $this->createListener(
+            $this->failingUserProvider(
+                'Listener fallback should not be invoked when the badge already has a user loader.'
+            ),
+        );
+
+        $listener->checkPassport($this->makeEvent($badge));
+
+        // The listener must leave the explicit loader untouched.
+        static::assertSame($explicitLoader, $badge->getUserLoader());
+    }
+
+    #[Test]
+    public function listenerInstallsUserLoaderFromInjectedProviderWhenBadgeHasNone(): void
+    {
+        $badge = new WebauthnBadge('localhost', '{}');
+        static::assertNull($badge->getUserLoader(), 'Sanity check: badge starts with no user loader.');
+
+        $expectedUser = new InMemoryUser('from-injected-provider', null);
+        $listener = $this->createListener($this->capturingUserProvider($expectedUser));
+
+        $listener->checkPassport($this->makeEvent($badge));
+
+        $loader = $badge->getUserLoader();
+        static::assertNotNull($loader, 'The listener must install a user loader when none was provided.');
+        static::assertSame($expectedUser, $loader('alice'));
+    }
+
+    #[Test]
+    public function resolvedBadgeIsLeftUntouched(): void
+    {
+        // Once a badge is resolved, no path is re-applied — the flow is idempotent.
+        $sentinelLoader = static fn (string $identifier): UserInterface => new InMemoryUser('sentinel', null);
+        $badge = new WebauthnBadge('localhost', '{}', userLoader: $sentinelLoader);
+        $this->markBadgeResolved($badge);
+
+        $listener = $this->createListener(
+            $this->failingUserProvider('Resolved badges must short-circuit before any provider lookup.'),
+        );
+
+        $listener->checkPassport($this->makeEvent($badge));
+
+        static::assertSame($sentinelLoader, $badge->getUserLoader());
+    }
+
+    private function createListener(UserProviderInterface $userProvider): WebauthnBadgeListener
+    {
+        // Stub the deserializer so it throws immediately: the listener catches the exception in its
+        // try/catch and returns. The user-provider resolution we test happens BEFORE that try/catch,
+        // so the early short-circuit does not affect what we assert.
+        $serializer = static::createStub(SerializerInterface::class);
+        $serializer->method('deserialize')
+            ->willThrowException(new RuntimeException('intentionally short-circuited'));
+
+        return new WebauthnBadgeListener(
+            optionsStorage: static::createStub(OptionsStorage::class),
+            publicKeyCredentialLoader: $serializer,
+            credentialUserEntityRepository: static::createStub(PublicKeyCredentialUserEntityRepositoryInterface::class),
+            publicKeyCredentialSourceRepository: static::createStub(CredentialRecordRepositoryInterface::class),
+            assertionResponseValidator: AuthenticatorAssertionResponseValidator::create(
+                (new CeremonyStepManagerFactory())->requestCeremony()
+            ),
+            attestationResponseValidator: AuthenticatorAttestationResponseValidator::create(
+                (new CeremonyStepManagerFactory())->creationCeremony()
+            ),
+            userProvider: $userProvider,
+        );
+    }
+
+    private function makeEvent(WebauthnBadge $badge): CheckPassportEvent
+    {
+        return new CheckPassportEvent(
+            static::createStub(AuthenticatorInterface::class),
+            new WebauthnPassport($badge),
+        );
+    }
+
+    /**
+     * Provider that fails the test if its lookup is invoked — used to assert that the listener
+     * stays away from its own provider on Path 1 and on the resolved-badge short-circuit.
+     */
+    private function failingUserProvider(string $message): UserProviderInterface
+    {
+        return new class($message) implements UserProviderInterface {
+            public function __construct(
+                private readonly string $message
+            ) {
+            }
+
+            public function loadUserByIdentifier(string $identifier): UserInterface
+            {
+                TestCase::fail($this->message);
+            }
+
+            public function refreshUser(UserInterface $user): UserInterface
+            {
+                throw new LogicException('not used');
+            }
+
+            public function supportsClass(string $class): bool
+            {
+                return false;
+            }
+        };
+    }
+
+    /**
+     * Provider that returns a fixed user — used on Path 3 to assert the loader installed by the
+     * listener actually invokes the injected provider.
+     */
+    private function capturingUserProvider(UserInterface $user): UserProviderInterface
+    {
+        return new class($user) implements UserProviderInterface {
+            public function __construct(
+                private readonly UserInterface $user
+            ) {
+            }
+
+            public function loadUserByIdentifier(string $identifier): UserInterface
+            {
+                return $this->user;
+            }
+
+            public function refreshUser(UserInterface $user): UserInterface
+            {
+                throw new UserNotFoundException();
+            }
+
+            public function supportsClass(string $class): bool
+            {
+                return false;
+            }
+        };
+    }
+
+    private function markBadgeResolved(WebauthnBadge $badge): void
+    {
+        $reflection = new ReflectionProperty(WebauthnBadge::class, 'isResolved');
+        $reflection->setValue($badge, true);
+    }
+}


### PR DESCRIPTION
## Summary

Issue #833 follow-up. The bundle exposes three distinct paths to choose which user provider authenticates a WebAuthn response, but until now nothing documented or pinned them. This PR adds tests for each so any future regression — or any deliberate change to how the bundle resolves the user provider — fails loudly.

## The three paths

| # | Path | Source of the user provider |
| - | --- | --- |
| 1 | Custom authenticator + `WebauthnBadge` constructed with an explicit `userLoader` callback | the developer's callback (always wins) |
| 2 | Built-in `webauthn:` firewall configuration | the firewall's resolved `provider:` (per-firewall) |
| 3 | Custom authenticator + `WebauthnBadge` constructed without a `userLoader` | the listener's injected `UserProviderInterface` (`security.user_providers`) |

## Tests added

- **`WebauthnBadgeListenerUserProviderTest`** — Paths 1 & 3.
  Stubs the listener's heavy dependencies (deserializer made to throw immediately so the listener short-circuits in its existing try/catch *after* the user-provider resolution under test). Then observes the badge's loader before and after. A failing-by-default provider asserts the listener never reaches its own fallback when the badge already carries a loader (or when the badge is already resolved). A capturing provider asserts that on Path 3 the loader installed by the listener actually invokes the injected provider.
- **`WebauthnFactoryFirewallProviderTest`** — Path 2.
  Drives `WebauthnFactory::createAuthenticatorService()` (via reflection, to avoid the unrelated route/controller side effects of the public `createAuthenticator()`) and asserts the resulting authenticator service receives the firewall's user provider id as argument #1, including in a multi-firewall scenario reproducing the back-end + front-end providers from #833.

## Test plan

- [x] `vendor/bin/phpunit -c .ci-tools/phpunit.xml.dist` — 310 tests pass.
- [x] `castor rector` — clean.
- [x] `castor ecs` — clean.
- [x] PHPStan — clean (the two pre-existing PHP 8.5-only `chr()` warnings remain unrelated; CI runs on PHP 8.4).