### PR TITLE
fix(stimulus): restore AssetMapper path + add canonical importmap name (#842)

### DIFF
--- a/src/stimulus/assets/README.md
+++ b/src/stimulus/assets/README.md
@@ -119,6 +119,12 @@ Combined controller for backward compatibility. Handles both registration and au
 </form>
 ```
 
+> **Deprecated since 5.3.x**: importing this controller as `@web-auth/webauthn-stimulus/webauthn` is deprecated and will be removed in 6.0. Use the canonical name `@web-auth/webauthn-stimulus` and pull the `WebauthnController` named export instead:
+>
+> ```javascript
+> import { WebauthnController } from '@web-auth/webauthn-stimulus';
+> ```
+
 ## Configuration Values
 
 ### Common Values (all controllers)

--- a/src/stimulus/assets/package.json
+++ b/src/stimulus/assets/package.json
@@ -31,6 +31,7 @@
         "importmap": {
             "@hotwired/stimulus": "^3.0.0",
             "@simplewebauthn/browser": "^13.2.0",
+            "@web-auth/webauthn-stimulus": "path:%PACKAGE%/src/index.js",
             "@web-auth/webauthn-stimulus/webauthn": "path:%PACKAGE%/src/controller.js",
             "@web-auth/webauthn-stimulus/authentication": "path:%PACKAGE%/src/authentication-controller.js",
             "@web-auth/webauthn-stimulus/registration": "path:%PACKAGE%/src/registration-controller.js"

--- a/src/stimulus/src/WebauthnStimulusBundle.php
+++ b/src/stimulus/src/WebauthnStimulusBundle.php
@@ -4,8 +4,57 @@ declare(strict_types=1);
 
 namespace Webauthn\Stimulus;
 
+use function dirname;
+use function is_array;
+use function is_string;
+use Symfony\Component\AssetMapper\AssetMapperInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
 
 final class WebauthnStimulusBundle extends AbstractBundle
 {
+    public function prependExtension(ContainerConfigurator $container, ContainerBuilder $builder): void
+    {
+        if (! $this->isAssetMapperAvailable($builder)) {
+            return;
+        }
+
+        // Registers assets/src as an AssetMapper path under the @web-auth/webauthn-stimulus
+        // namespace so the `path:%PACKAGE%/...` entries published in package.json resolve
+        // through ImportMapManager::findAsset(). Without this, importmap:require fails with
+        // "The path ... cannot be found" when the recipe processes the package on install
+        // (issue #842).
+        $builder->prependExtensionConfig('framework', [
+            'asset_mapper' => [
+                'paths' => [
+                    dirname(__DIR__) . '/assets/src' => '@web-auth/webauthn-stimulus',
+                ],
+            ],
+        ]);
+    }
+
+    private function isAssetMapperAvailable(ContainerBuilder $container): bool
+    {
+        if (! interface_exists(AssetMapperInterface::class)) {
+            return false;
+        }
+
+        $bundlesMetadata = $container->getParameter('kernel.bundles_metadata');
+        if (! is_array($bundlesMetadata)) {
+            return false;
+        }
+
+        $frameworkBundle = $bundlesMetadata['FrameworkBundle'] ?? null;
+        if (! is_array($frameworkBundle)) {
+            return false;
+        }
+
+        $frameworkBundlePath = $frameworkBundle['path'] ?? null;
+        if (! is_string($frameworkBundlePath)) {
+            return false;
+        }
+
+        return is_file($frameworkBundlePath . '/Resources/config/asset_mapper.php');
+    }
 }

--- a/tests/symfony/unit/StimulusBundle/Issue842RegressionTest.php
+++ b/tests/symfony/unit/StimulusBundle/Issue842RegressionTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Bundle\Unit\StimulusBundle;
+
+use const JSON_THROW_ON_ERROR;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Webauthn\Stimulus\WebauthnStimulusBundle;
+
+/**
+ * Issue #842: upgrading from 5.2.x to 5.3.0 broke `importmap:require` because the bundle no longer
+ * registered its assets directory as an AssetMapper path, leaving the new `path:%PACKAGE%/...`
+ * importmap entries unresolvable. The bundle must prepend the `framework.asset_mapper.paths` config
+ * whenever AssetMapper is available, and the canonical `@web-auth/webauthn-stimulus` import name
+ * must be present alongside the legacy `webauthn` subpath.
+ *
+ * @internal
+ */
+final class Issue842RegressionTest extends TestCase
+{
+    #[Test]
+    public function bundleRegistersAssetMapperPathWhenAssetMapperIsAvailable(): void
+    {
+        $builder = $this->buildContainerWithFrameworkBundle();
+        $configurator = static::createStub(ContainerConfigurator::class);
+
+        $bundle = new WebauthnStimulusBundle();
+        $bundle->prependExtension($configurator, $builder);
+
+        $configs = $builder->getExtensionConfig('framework');
+        static::assertNotSame([], $configs, 'Bundle must prepend a framework config when AssetMapper is installed.');
+
+        $assetMapperPaths = $configs[0]['asset_mapper']['paths'] ?? null;
+        static::assertIsArray($assetMapperPaths, 'asset_mapper.paths must be prepended.');
+
+        $expectedDir = realpath(__DIR__ . '/../../../../src/stimulus/assets/src');
+        static::assertNotFalse($expectedDir, 'assets/src directory must exist in the source tree.');
+
+        $resolved = [];
+        foreach ($assetMapperPaths as $dir => $namespace) {
+            $resolved[realpath($dir) ?: $dir] = $namespace;
+        }
+        static::assertSame(
+            '@web-auth/webauthn-stimulus',
+            $resolved[$expectedDir] ?? null,
+            'assets/src must be exposed under the @web-auth/webauthn-stimulus namespace.',
+        );
+    }
+
+    #[Test]
+    public function bundleSkipsPrependWhenFrameworkBundleIsMissing(): void
+    {
+        $builder = new ContainerBuilder();
+        $builder->setParameter('kernel.bundles_metadata', []);
+        $configurator = static::createStub(ContainerConfigurator::class);
+
+        $bundle = new WebauthnStimulusBundle();
+        $bundle->prependExtension($configurator, $builder);
+
+        static::assertSame([], $builder->getExtensionConfig('framework'));
+    }
+
+    #[Test]
+    public function packageJsonExposesCanonicalImportName(): void
+    {
+        $packageJson = $this->readPackageJson();
+        $importmap = $packageJson['symfony']['importmap'] ?? [];
+
+        static::assertArrayHasKey(
+            '@web-auth/webauthn-stimulus',
+            $importmap,
+            'package.json must expose the canonical @web-auth/webauthn-stimulus import name.',
+        );
+        static::assertSame(
+            'path:%PACKAGE%/src/index.js',
+            $importmap['@web-auth/webauthn-stimulus'],
+            'Canonical entry must point to src/index.js so the package can be imported as a whole.',
+        );
+    }
+
+    #[Test]
+    public function packageJsonKeepsLegacyWebauthnSubpathForBackwardCompatibility(): void
+    {
+        $packageJson = $this->readPackageJson();
+        $importmap = $packageJson['symfony']['importmap'] ?? [];
+
+        static::assertArrayHasKey(
+            '@web-auth/webauthn-stimulus/webauthn',
+            $importmap,
+            'Legacy /webauthn subpath must still be exposed for projects upgrading from 5.2.x.',
+        );
+        static::assertSame(
+            'path:%PACKAGE%/src/controller.js',
+            $importmap['@web-auth/webauthn-stimulus/webauthn'],
+            'Legacy subpath must keep pointing at the combined controller.js file.',
+        );
+    }
+
+    private function buildContainerWithFrameworkBundle(): ContainerBuilder
+    {
+        $frameworkBundle = realpath(__DIR__ . '/../../../../vendor/symfony/framework-bundle');
+        static::assertNotFalse(
+            $frameworkBundle,
+            'symfony/framework-bundle must be installed for this regression test (composer install).',
+        );
+
+        $builder = new ContainerBuilder();
+        $builder->setParameter('kernel.bundles_metadata', [
+            'FrameworkBundle' => [
+                'path' => $frameworkBundle,
+                'namespace' => 'Symfony\\Bundle\\FrameworkBundle',
+                'class' => FrameworkBundle::class,
+            ],
+        ]);
+
+        return $builder;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readPackageJson(): array
+    {
+        $path = __DIR__ . '/../../../../src/stimulus/assets/package.json';
+        static::assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true, flags: JSON_THROW_ON_ERROR);
+        static::assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #842 — `composer update` from 5.2.x to 5.3.0 fails with:

```
The path "C:\Users\home/vendor/web-auth/webauthn-stimulus/assets/src/controller.js"
of the package "@web-auth/webauthn-stimulus/webauthn" cannot be found:
either pass the logical name of the asset or a relative path starting with "./".
```

### Root cause

PR #772 removed `WebauthnStimulusBundle::prependExtension()`, which used to register `assets/src` as an AssetMapper path under the `@web-auth/webauthn-stimulus` namespace. The same PR added `path:%PACKAGE%/...` entries to `assets/package.json`. Once Symfony Flex resolves `%PACKAGE%` to the absolute vendor path and hands it to `ImportMapManager::findAsset()`, the lookup fails because the directory is not registered as an asset path — hence the error during `importmap:require`.

### Fix

- Restore the asset mapper path prepend on the bundle, with stricter type guards on `kernel.bundles_metadata` so PHPStan stays clean.
- Add `@web-auth/webauthn-stimulus` (no sub-path) to `symfony.importmap`, pointing at `src/index.js`. This is now the canonical import name and matches the documented npm-style usage (`import { AuthenticationController, RegistrationController } from '@web-auth/webauthn-stimulus'`).
- Keep `@web-auth/webauthn-stimulus/webauthn` for back-compat with existing 5.2.x `importmap.php` entries; mark it as deprecated in the README, scheduled for removal in 6.0.

### Tests

`tests/symfony/unit/StimulusBundle/Issue842RegressionTest.php` covers:

1. The bundle prepends the correct `framework.asset_mapper.paths` config when AssetMapper is available.
2. The bundle prepends nothing when FrameworkBundle is missing.
3. `assets/package.json` exposes the canonical `@web-auth/webauthn-stimulus` entry pointing at `src/index.js`.
4. The legacy `@web-auth/webauthn-stimulus/webauthn` entry is kept and still points at `controller.js` (BC).

## Test plan

- [x] `vendor/bin/phpunit --filter Issue842RegressionTest` — 4/4 green
- [x] `vendor/bin/phpunit tests/symfony` — 123/123 green (kernel still boots)
- [x] `castor rector` — clean
- [x] `castor ecs` — clean
- [x] `castor phpstan` — only the 2 pre-existing PHP 8.5 `chr()` warnings remain (unrelated)
- [ ] Manual: `composer require web-auth/webauthn-stimulus` on a fresh Symfony 7 / AssetMapper project upgrading from 5.2.x and confirm `importmap:require` no longer errors