### PR TITLE
docs(stimulus): recommend the npm package install path

### DIFF
--- a/src/stimulus/assets/README.md
+++ b/src/stimulus/assets/README.md
@@ -31,19 +31,15 @@ These are listed as peer dependencies and should be installed in your project.
 
 ### Usage with Module Bundlers
 
-If you're using a module bundler (webpack, Vite, etc.) without Symfony UX, you can import controllers directly:
+With any module bundler (webpack, Vite, esbuild…), import controllers from the package entry point and register them yourself:
 
 ```javascript
-// Import individual controllers
+import { Application } from '@hotwired/stimulus';
 import { AuthenticationController, RegistrationController } from '@web-auth/webauthn-stimulus';
 
-// Or import specific ones
-import AuthenticationController from '@web-auth/webauthn-stimulus/src/authentication-controller.js';
-
-// Register with Stimulus
-import { Application } from '@hotwired/stimulus';
 const app = Application.start();
 app.register('webauthn--authentication', AuthenticationController);
+app.register('webauthn--registration', RegistrationController);
 ```
 
 ## Available Controllers
@@ -193,13 +189,28 @@ See [@simplewebauthn/server](https://simplewebauthn.dev/docs/packages/server) fo
 
 ## Symfony Integration
 
-This package is designed to work seamlessly with the [web-auth/webauthn-framework](https://github.com/web-auth/webauthn-framework) Symfony bundle:
+The recommended path for Symfony applications is to install this npm package straight from your asset pipeline. The package ships a `symfony.importmap` configuration so Symfony AssetMapper resolves the canonical sub-paths (`/authentication`, `/registration`, `/webauthn`) out of the box.
+
+### With Symfony AssetMapper (recommended)
 
 ```bash
-composer require web-auth/webauthn-stimulus
+php bin/console importmap:require @web-auth/webauthn-stimulus
 ```
 
-When installed via Composer with Symfony Flex, the controllers are automatically registered and available in your Twig templates:
+Then enable the controllers you want in `assets/controllers.json`:
+
+```json
+{
+    "controllers": {
+        "@web-auth/webauthn-stimulus": {
+            "authentication": { "enabled": true, "fetch": "eager" },
+            "registration": { "enabled": true, "fetch": "eager" }
+        }
+    }
+}
+```
+
+You can now use the `stimulus_controller()` Twig helper:
 
 ```twig
 <form {{ stimulus_controller('@web-auth/webauthn-stimulus/authentication') }}>
@@ -207,10 +218,15 @@ When installed via Composer with Symfony Flex, the controllers are automatically
 </form>
 ```
 
-For detailed Symfony integration documentation, visit:
+### With Webpack Encore / Vite / any other bundler
 
-- [Bundle documentation](https://github.com/web-auth/webauthn-framework/tree/5.3.x/src/stimulus)
-- [Main framework repository](https://github.com/web-auth/webauthn-framework)
+Install the package and register the controllers yourself — see [Usage with Module Bundlers](#usage-with-module-bundlers) above.
+
+### Deprecated: the `web-auth/webauthn-stimulus` Composer package
+
+> **Deprecated since 5.3.x — removed in 6.0.0.** The PHP wrapper `web-auth/webauthn-stimulus` is no longer needed: this npm package is the canonical and only maintained source going forward. New projects should not install it; existing projects should migrate to `importmap:require` (or `npm install`) before upgrading to 6.0.0.
+
+For more context and migration steps, see the [project documentation](https://webauthn-doc.spomky-labs.com/).
 
 ## Browser Support
 


### PR DESCRIPTION
## Summary

Brings the `@web-auth/webauthn-stimulus` npm package README in line with the v5.3.x direction: install via npm/AssetMapper, the Composer package becomes a deprecated path.

- Drop the misleading "without Symfony UX" caveat from the bundler section and replace the deep `/src/...` import with a clean named import that works with any bundler (webpack, Vite, esbuild, AssetMapper).
- Rewrite the **Symfony Integration** section to recommend `importmap:require @web-auth/webauthn-stimulus` + `assets/controllers.json` as the canonical path.
- Add a "Deprecated" subsection for the `web-auth/webauthn-stimulus` Composer package, scheduled for removal in 6.0.0.
- Replace the stale `tree/5.3.x/src/stimulus` link with a pointer to the user-facing docs.

No code change — README only.

## Test plan
- [ ] Render the README on the npm registry preview / GitHub and confirm the install snippets and links resolve correctly.
- [ ] Verify the `importmap:require @web-auth/webauthn-stimulus` flow on a fresh Symfony AssetMapper app and that the `controllers.json` snippet enables the expected controllers.