### PR TITLE
feat(prf): builder validation, controller fixes, end-to-end demo

### DIFF
--- a/docs/examples/prf-demo/.gitignore
+++ b/docs/examples/prf-demo/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+/composer.lock
+/var/*.json

--- a/docs/examples/prf-demo/README.md
+++ b/docs/examples/prf-demo/README.md
@@ -1,0 +1,259 @@
+# PRF Demo — `web-auth/webauthn-lib`
+
+A minimal end-to-end demo of the W3C [WebAuthn PRF
+extension](https://www.w3.org/TR/webauthn-3/#prf-extension) used as a primitive
+for **client-side encryption**, inspired by Matt Miller's
+[2023 write-up](https://blog.millerti.me/2023/01/22/encrypting-data-in-the-browser-using-webauthn/).
+
+> ## ⚠️ Read this before you build a real product on PRF
+>
+> Quoting Matt Miller's [May 2025 update](https://blog.millerti.me/2023/01/22/encrypting-data-in-the-browser-using-webauthn/)
+> on his original article:
+>
+> > **If you delete a passkey you will permanently lose access to all of its
+> > PRF-protected data.** In such a scenario there is no way to recover
+> > PRF-protected data. It's gone. Kaput!
+> >
+> > There are legitimate use cases for PRF. But before you go off and implement
+> > some whiz-bang PRF-powered encryption system for your website, please keep
+> > in mind that your users risk losing all of their encrypted data if they
+> > ever delete (or even recreate) a passkey for your site. As the website
+> > owner you will naturally bear the brunt of their ire — unless you
+> > architected your use of PRF in a way that allows for "recovery" (of data,
+> > of account access, etc.) in the case of passkey loss.
+>
+> Concretely: every passkey owns its own PRF input-key inside the authenticator.
+> The relying party never sees that key, the user agent never sees that key,
+> and there is no API to export it. Re-creating a passkey produces a brand-new
+> input-key and a brand-new PRF output, even with the same salt — so the AES key
+> derived from it is also brand-new and **cannot decrypt anything that was
+> sealed under the previous passkey.**
+>
+> This demo is single-passkey, single-key by design — it does **not**
+> implement recovery and exists purely to show the mechanism. A production
+> design needs at least one of: a second passkey enrolled and salt-shared
+> upfront, a server-side recovery wrap (KMS, …) escrowed behind a strong
+> second factor, or an explicit "you will lose this data if you lose this
+> passkey" UX contract the user accepts.
+
+The relying party server hands the browser a per-credential salt at every
+ceremony. The authenticator computes `HMAC-SHA256(credentialBoundKey, salt)` and
+the user agent surfaces the result as
+`clientExtensionResults.prf.results.first`. The demo derives an AES-GCM key
+from that PRF output via HKDF and uses it to **encrypt and decrypt arbitrary
+items entirely inside the browser**. The server only ever sees the ciphertexts
+and the salt — never the key, never the plaintext.
+
+## Three pages, three phases
+
+| Page | What it does |
+|---|---|
+| [`/register.html`](same-origin/public/register.html) | Registers a credential with the `prf` extension primed. Two salts are generated server-side, persisted next to the credential, and re-issued on every authentication. No items yet. |
+| [`/vault.html`](same-origin/public/vault.html) | Authenticates with that credential to derive **two** keys (AES-GCM from `prf.results.first`, HMAC-SHA256 from `prf.results.second`), kept in tab memory only. Lets the user add items (label + plaintext, encrypted client-side + label/iv/ciphertext HMAC computed locally, all sent to the server) and decrypt items (server hands back the ciphertexts; the page decrypts and verifies the HMAC on demand). Reload → keys gone, re-authenticate. |
+| [`/offline.html`](same-origin/public/offline.html) | Reuses the passkey registered through `/register.html`. That page mirrors `{credId, prfSalt, prfSalt2}` into `localStorage` automatically, so by the time you hit `/offline.html` everything is already there. Unlocks read from `localStorage`, run the PRF assertion against `rpId = location.hostname` with a locally-generated challenge, derive both keys, and load encrypted items from `localStorage`. A service worker caches the page on first load — disconnect / airplane mode and reload still works. |
+
+## What it demonstrates
+
+- **Registration** — the page calls
+  `navigator.credentials.create({ publicKey: { …, extensions: { prf: { eval: { first: salt } } } } })`.
+  The server validates with `AuthenticatorAttestationResponseValidator` and
+  stores `(credential, salt)`.
+- **Unlock** — the page calls
+  `navigator.credentials.get({ publicKey: { …, extensions: { prf: { evalByCredential: { credId: { first: salt } } } } } })`
+  with the salt the server re-issued. The browser returns the same PRF output
+  → the same AES-GCM key. Server flips a per-session "vault unlocked" flag.
+- **Encrypt-and-store** — every new item is AES-GCM-encrypted in the page
+  using the in-memory key, then `POST /api/vault/items/add` with the
+  `{label, ciphertext, iv}` triple. The server appends to the credential's
+  item list without ever seeing the plaintext.
+- **Decrypt-on-demand** — clicking *Decrypt* on an item runs Web Crypto's
+  AES-GCM decrypt against the still-in-memory key. Clicking *Lock vault*
+  drops the key and forces a re-authentication.
+
+```
+┌──────────────────┐     POST /api/register/options       ┌──────────────────────┐
+│  register.html   │ ───────────────────────────────────▶ │  router.php (RP)     │
+│  (browser)       │ ◀────────── creation options ─────── │  - lib + serializer  │
+│                  │            extensions.prf.eval.first │  - PRF salt random   │
+│                  │     POST /api/register/verify        │  - CredentialStore   │
+│                  │ ───────────────────────────────────▶ │  Validator->check    │
+└──────────────────┘                                      └──────────────────────┘
+
+┌──────────────────┐     POST /api/vault/options          ┌──────────────────────┐
+│  vault.html      │ ───────────────────────────────────▶ │  evalByCredential[id]│
+│  (unlock phase)  │ ◀── options + stored items list ──── │      = stored salt   │
+│                  │     POST /api/vault/verify           │  → vault_unlocked    │
+│                  │ ───────────────────────────────────▶ │      session flag    │
+└──────────────────┘                                      └──────────────────────┘
+        │
+        ├── PRF output → HKDF → AES-GCM key (kept in JS memory only)
+        ▼
+┌──────────────────┐     POST /api/vault/items/add        ┌──────────────────────┐
+│  vault.html      │ ───────────────────────────────────▶ │  appendItem(...)     │
+│  (use phase)     │       { label, ciphertext, iv }      │                      │
+│  - encrypt       │     POST /api/vault/items/delete     │                      │
+│  - decrypt       │ ───────────────────────────────────▶ │  deleteItem(itemId)  │
+│  - delete        │                                      │                      │
+└──────────────────┘                                      └──────────────────────┘
+```
+
+## Run it
+
+```bash
+cd docs/examples/prf-demo
+./same-origin/run.sh
+```
+
+The script `composer install`s on first run and boots the demo on
+<http://localhost:8000>. The shipped `composer.json` symlinks
+`web-auth/webauthn-framework` from this checkout (`../../..`), so you get the
+not-yet-released PRF builder code straight from `src/`. To run against a
+published `^5.4` release once one exists, swap the path-repo block for the
+standard packagist `web-auth/webauthn-lib` requirement.
+
+Open <http://localhost:8000> in a browser that supports the PRF extension:
+
+- A platform authenticator (Touch ID, Windows Hello, Android device unlock) or
+  a hardware key that exposes `hmac-secret`.
+- A secure context. `localhost` qualifies; otherwise serve over HTTPS.
+- Chrome 116+ / Edge 116+ on the desktop side, recent Safari (iOS 18+ /
+  macOS 15+). Firefox is still trailing as of this writing.
+
+Walk through the pages in order:
+
+1. <http://localhost:8000/register.html> — register a credential (online).
+2. <http://localhost:8000/vault.html> — authenticate, then encrypt/decrypt (online).
+3. <http://localhost:8000/offline.html> — uses the credential id + salts that step 1 mirrored to `localStorage`; the unlock ceremony and the encrypt/decrypt loop are 100% client-side. Once the page has loaded once, it survives airplane mode (service worker).
+
+State (registered credentials, ciphertexts, in-flight challenges, the
+"unlocked" flag) lives in a JSON file at `var/credentials.json` and the
+PHP session.
+
+## Why the PHP code is short
+
+Most of the demo is boilerplate identical to a regular WebAuthn ceremony — the
+only PRF-specific lines are this builder call:
+
+```php
+use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
+use Webauthn\AuthenticationExtensions\PseudoRandomFunctionInputExtensionBuilder;
+
+$options->extensions = AuthenticationExtensions::create([
+    PseudoRandomFunctionInputExtensionBuilder::create()
+        ->withInputs($salt)              // registration: global eval
+        ->build(),
+]);
+
+// or, during authentication, per-credential salts:
+$prf = PseudoRandomFunctionInputExtensionBuilder::create();
+foreach ($credentialIds as $id) {
+    $prf->withCredentialInputs(
+        \ParagonIE\ConstantTime\Base64UrlSafe::encodeUnpadded($id),
+        $saltFor[$id],
+    );
+}
+$options->extensions = AuthenticationExtensions::create([$prf->build()]);
+```
+
+The framework does **not** validate `clientExtensionResults.prf.results`
+server-side, and intentionally so — the PRF output is a secret that lives in
+the browser only. The lib's job is to surface the right inputs in the options
+sent to the browser; the rest is Web Crypto inside the page.
+
+## Two PRF salts per ceremony
+
+The W3C `prf` extension lets the relying party send **two** salts per
+ceremony — `first` and `second`. The authenticator runs the PRF over both in a
+single round-trip, the page receives both outputs in
+`clientExtensionResults.prf.results.{first,second}`. The library exposes this
+via the second argument of the builder methods:
+
+```php
+PseudoRandomFunctionInputExtensionBuilder::create()
+    ->withInputs($salt, $salt2)                        // creation: both `eval` salts
+    ->withCredentialInputs($credId, $salt, $salt2)     // assertion: both per-credential salts
+    ->build();
+```
+
+This demo wires both salts end-to-end — server-side they live in
+`CredentialStore`, client-side both outputs are logged on every ceremony — and
+**uses only `first`** to derive the AES-GCM key. `second` is left unused so
+the example stays readable, but typical use cases for it are:
+
+- a separate HMAC key over the item labels, so the server cannot silently
+  rename items;
+- an envelope-key / data-key split (one for AES, one for key-wrapping);
+- key rotation: at the rotation moment, run an assertion with `first = old
+  salt` and `second = new salt`, decrypt under `first`, re-encrypt under
+  `second`, then drop the old salt.
+
+## Going fully offline
+
+The PRF computation happens **inside the authenticator** — there is zero network
+involved in `HMAC-SHA256(credentialBoundKey, salt)`, and `navigator.credentials.get()`
+itself does not hit the network. So once a passkey is enrolled and its salt is
+sitting on the device, **the unlock ceremony is 100 % offline**: no fetch, no
+server roundtrip is needed to derive the AES key.
+
+The server endpoints in this demo (`/api/vault/options`, `/api/vault/verify`,
+`/api/vault/items/*`) exist for two reasons that are **not cryptographic**:
+
+1. transport — they are how this demo ships the salt and the stored
+   ciphertexts to the page. In an offline build that role moves to
+   `localStorage` / IndexedDB / the Cache API;
+2. server-side policy — `/api/vault/verify` flips a `vault_unlocked` session
+   flag that gates `/api/vault/items/{add,delete}`. In an offline build there
+   is no server to gate, so the flag and the call disappear.
+
+To flip the demo to offline-only you adjust:
+
+| Concern | Online demo (this code) | Offline-capable build |
+|---|---|---|
+| Where the ciphertext + IV live | server JSON file (`var/credentials.json`) | IndexedDB / localStorage / Cache API on the device |
+| Where the per-credential salt lives | server JSON file | localStorage on the device (the salt is not a secret — it is sent in clear in the options on every ceremony) |
+| Page availability without network | needs `php -S` running | installable PWA + service worker caching the static assets |
+| `allowCredentials` in the assertion options | enumerated by the server | leave empty — works because we registered with `residentKey: 'required'` (discoverable / passkey) |
+| Challenge | random bytes from the server, replay-checked at `/verify` | random bytes from `crypto.getRandomValues(new Uint8Array(32))` — fine because we are not proving authentication to a server, only invoking the PRF; AES-GCM's tag detects any wrong-key attempt |
+| `rpId` | the relying party domain | same constraint — the PWA must be served from that domain |
+| Server-side `→check()` validation | required, that's the whole point of WebAuthn login | skipped — no server is verifying the assertion in the offline path |
+
+A bare-bones offline call inside an installed PWA would look like:
+
+```js
+const credId    = b64u.decode(localStorage.getItem('credId'));
+const salt      = b64u.decode(localStorage.getItem('prfSalt'));
+const blob      = JSON.parse(localStorage.getItem('vault')); // {iv, ciphertext}
+
+const credential = await navigator.credentials.get({
+    publicKey: {
+        challenge: crypto.getRandomValues(new Uint8Array(32)),
+        rpId: location.hostname,
+        allowCredentials: [{ type: 'public-key', id: credId }],
+        userVerification: 'required',
+        extensions: { prf: { eval: { first: salt } } },
+    },
+});
+
+const prfBytes = credential.getClientExtensionResults().prf.results.first;
+// …same HKDF + AES-GCM decrypt as in vault.html…
+```
+
+`offline.html` in this demo implements the post-registration half of the
+loop — unlock + add + decrypt — using the credential and the salts that
+`register.html` writes to `localStorage` after a successful server-validated
+register. The companion service worker `sw.js` caches the page so it loads
+in airplane mode after a first online visit. Registration itself stays
+online because the server still validates the attestation and persists the
+salts (which makes `vault.html` available alongside `offline.html`).
+
+## What this demo deliberately leaves out
+
+- A real database / user system (uses a JSON file).
+- **Recovery.** See the warning at the top of this README. If the user deletes
+  the passkey, the encrypted items become permanently unreadable. A production
+  design needs an explicit recovery story before turning PRF into the only key.
+- Salt rotation — the salts are fixed per credential to keep the demo readable.
+- Multi-credential UI / cross-origin / multi-RP setups.
+- A long-lived "unlock" cookie — the `vault_unlocked` session flag stays only
+  for the lifetime of the PHP session and is rotated on the next
+  `/api/vault/options` call.

--- a/docs/examples/prf-demo/composer.json
+++ b/docs/examples/prf-demo/composer.json
@@ -1,0 +1,30 @@
+{
+    "name": "web-auth/prf-demo",
+    "description": "End-to-end demo of the WebAuthn PRF extension for client-side encryption using web-auth/webauthn-lib",
+    "type": "project",
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../..",
+            "options": {
+                "symlink": true,
+                "versions": {
+                    "web-auth/webauthn-framework": "5.4.x-dev"
+                }
+            }
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "ext-json": "*",
+        "ext-openssl": "*",
+        "web-auth/webauthn-framework": "5.4.x-dev",
+        "symfony/clock": "^6.4 || ^7.0",
+        "symfony/serializer": "^6.4 || ^7.0",
+        "symfony/property-access": "^6.4 || ^7.0",
+        "symfony/property-info": "^6.4 || ^7.0",
+        "symfony/uid": "^6.4 || ^7.0"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/docs/examples/prf-demo/same-origin/public/index.html
+++ b/docs/examples/prf-demo/same-origin/public/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>PRF Demo — Home</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 720px; margin: 40px auto; padding: 20px; color: #1f2937; line-height: 1.55; }
+        h1 { font-size: 1.6rem; }
+        h2 { font-size: 1.2rem; margin-top: 1.6rem; }
+        ol li { margin-bottom: 0.4rem; }
+        nav a { color: #2563eb; margin-right: 1rem; }
+        code { background: #f3f4f6; padding: 2px 5px; border-radius: 4px; }
+        .warning { background: #fef3c7; border-left: 4px solid #d97706; padding: 14px 18px; border-radius: 6px; margin: 1.5rem 0; }
+        .warning strong { color: #92400e; }
+    </style>
+</head>
+<body>
+<h1>WebAuthn PRF — client-side encryption demo</h1>
+
+<p>
+    A minimal, dependency-free demo of the
+    <a href="https://www.w3.org/TR/webauthn-3/#prf-extension" target="_blank" rel="noopener">WebAuthn PRF extension</a>,
+    inspired by Matt Miller's
+    <a href="https://blog.millerti.me/2023/01/22/encrypting-data-in-the-browser-using-webauthn/" target="_blank" rel="noopener">2023
+    write-up on encrypting data in the browser using WebAuthn</a>.
+</p>
+
+<div class="warning">
+    <strong>⚠ Read this before you build a real product on PRF.</strong> Quoting Matt's
+    <a href="https://blog.millerti.me/2023/01/22/encrypting-data-in-the-browser-using-webauthn/" target="_blank" rel="noopener">May 2025 update</a>
+    to that article: <em>“If you delete a passkey you will permanently lose access to all of its
+    PRF-protected data. In such a scenario there is no way to recover PRF-protected data. It’s gone.”</em>
+    The PRF input-key lives inside the authenticator, never leaves it, and a re-created passkey
+    produces a brand-new one — even with the same salt. <strong>This demo intentionally has no
+    recovery path</strong> and is a learning aid only. A production design must escrow a recovery
+    wrap, enroll a second passkey upfront, or surface an explicit “you will lose this data if you
+    lose this passkey” contract.
+</div>
+
+<p>
+    The relying party server hands the browser a per-credential salt at every ceremony. The
+    authenticator computes <code>HMAC-SHA256(credentialBoundKey, salt)</code> and the user
+    agent surfaces the result as <code>clientExtensionResults.prf.results.first</code>. This
+    demo derives an AES-GCM key from that PRF output via HKDF and uses it to encrypt
+    (registration) and decrypt (authentication) a short note <strong>entirely inside the
+    browser</strong>. The server only ever sees the ciphertext and the salt — never the key,
+    never the plaintext.
+</p>
+
+<h2>Walk-through</h2>
+<ol>
+    <li><a href="/register.html">/register.html</a> — register a credential with PRF support against the relying-party server.</li>
+    <li><a href="/vault.html">/vault.html</a> — authenticate against the server, then encrypt &amp; decrypt items of your choice. The AES-GCM key derived from <code>prf.results.first</code> and the HMAC key derived from <code>prf.results.second</code> stay in tab memory; reload to lock.</li>
+    <li><a href="/offline.html">/offline.html</a> — same vault but <strong>without any server</strong>. Salts and ciphertexts live in <code>localStorage</code>; a service worker caches the page so you can hit airplane mode and reload.</li>
+</ol>
+
+<h2>What this demo deliberately leaves out</h2>
+<ul>
+    <li>A real database / user system (uses a JSON file under <code>var/</code>).</li>
+    <li>Account recovery (lose the credential → lose access to the ciphertext, by design).</li>
+    <li>Key rotation: the salt is fixed per credential to keep the demo readable.</li>
+    <li>Cross-origin / multi-RP setups.</li>
+</ul>
+</body>
+</html>

--- a/docs/examples/prf-demo/same-origin/public/offline.html
+++ b/docs/examples/prf-demo/same-origin/public/offline.html
@@ -1,0 +1,460 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>PRF Demo — Offline vault (no server)</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 760px; margin: 40px auto; padding: 20px; color: #1f2937; line-height: 1.5; }
+        h1 { font-size: 1.5rem; }
+        h2 { font-size: 1.15rem; margin-top: 1.5rem; }
+        label { display: block; margin: 0.55rem 0 0.2rem; font-weight: 500; }
+        input, textarea, button { padding: 0.5rem 0.75rem; font-size: 1rem; border-radius: 6px; border: 1px solid #d1d5db; box-sizing: border-box; font-family: inherit; }
+        input, textarea { width: 100%; }
+        textarea { min-height: 80px; }
+        button { background: #2563eb; color: #fff; border: none; cursor: pointer; }
+        button.danger { background: #b91c1c; }
+        button.muted { background: #6b7280; }
+        button:disabled { background: #94a3b8; cursor: not-allowed; }
+        pre { background: #f3f4f6; padding: 12px; border-radius: 6px; overflow-x: auto; max-height: 220px; white-space: pre-wrap; word-break: break-all; }
+        nav a { color: #2563eb; margin-right: 1rem; }
+        .item { border: 1px solid #e5e7eb; padding: 12px 14px; border-radius: 8px; margin-bottom: 12px; }
+        .item header { display: flex; justify-content: space-between; gap: 8px; align-items: baseline; }
+        .item .label { font-weight: 600; }
+        .item .meta { font-size: 0.85rem; color: #6b7280; }
+        .item .ciphertext { font-family: ui-monospace, SFMono-Regular, monospace; font-size: 0.8rem; color: #6b7280; word-break: break-all; margin-top: 6px; }
+        .item .plaintext { background: #ecfdf5; border: 1px solid #10b981; padding: 8px 10px; border-radius: 6px; margin-top: 8px; font-size: 0.95rem; }
+        .mac-badge { font-size: 0.78rem; padding: 2px 8px; border-radius: 999px; background: #f3f4f6; color: #6b7280; }
+        .mac-ok { background: #d1fae5; color: #047857; }
+        .mac-bad { background: #fee2e2; color: #991b1b; }
+        .row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+        .ok { color: #047857; }
+        .err { color: #b91c1c; }
+        .hidden { display: none; }
+        .empty { color: #6b7280; font-style: italic; }
+        .warning { background: #fef3c7; border-left: 4px solid #d97706; padding: 12px 16px; border-radius: 6px; margin: 1.2rem 0; font-size: 0.95rem; }
+        .warning strong { color: #92400e; }
+        .net-status { display: inline-block; padding: 2px 10px; border-radius: 999px; font-size: 0.85rem; }
+        .net-online { background: #d1fae5; color: #047857; }
+        .net-offline { background: #e0e7ff; color: #1e3a8a; }
+    </style>
+</head>
+<body>
+<nav><a href="/">← Home</a><a href="/register.html">Register (online)</a><a href="/vault.html">Vault (online)</a></nav>
+
+<h1>Offline vault — no fetch after first load <span id="net-status" class="net-status"></span></h1>
+
+<p>
+    This page does <strong>not</strong> register passkeys. The credential id and
+    the two PRF salts must already be in this browser's <code>localStorage</code> —
+    which is the case as soon as you have completed
+    <a href="/register.html">/register.html</a> on this same browser (that page
+    mirrors <code>{credId, prfSalt, prfSalt2}</code> into <code>localStorage</code>
+    automatically after a successful register).
+</p>
+<p>
+    From there everything happens client-side: <code>navigator.credentials.get()</code>
+    runs with a locally-generated challenge against
+    <code>rpId = location.hostname</code>, the two PRF outputs become an AES-GCM
+    key and an HMAC-SHA256 key, and ciphertexts live in <code>localStorage</code>.
+    A service worker caches the page on first load, so you can disconnect (or hit
+    airplane mode) and reload — everything keeps working.
+</p>
+
+<div class="warning">
+    <strong>⚠ If you delete the passkey or clear the site data, your encrypted
+    items are gone forever.</strong> See the home page for the full caveat. This
+    page is a learning aid, not a production design.
+</div>
+
+<section id="setup-section" class="hidden">
+    <h2>This browser is not set up yet</h2>
+    <p>
+        No credential id or salts found in <code>localStorage</code>. Visit
+        <a href="/register.html">/register.html</a> first — it registers a passkey
+        through the relying-party server <em>and</em> mirrors the credential id +
+        both salts into the same <code>localStorage</code> keys this page reads
+        from. Then come back here and reload.
+    </p>
+    <p class="row">
+        <a href="/register.html"><button type="button">Go to /register.html</button></a>
+    </p>
+</section>
+
+<section id="locked-section" class="hidden">
+    <h2>2. Unlock the offline vault</h2>
+    <p>
+        Reads <code>{credId, prfSalt, prfSalt2}</code> from
+        <code>localStorage</code>, calls
+        <code>navigator.credentials.get()</code> with a locally-generated
+        challenge, derives the AES-GCM and HMAC keys from the two PRF outputs,
+        keeps both keys in this tab's memory.
+    </p>
+    <button id="unlock-btn">Authenticate &amp; unlock</button>
+    <button type="button" id="reset-btn" class="danger">Reset everything (forget local data)</button>
+</section>
+
+<section id="vault-section" class="hidden">
+    <h2>3. Encrypt a new item (writes to localStorage)</h2>
+    <form id="add-form">
+        <label for="label">Label (in clear, used to find items)</label>
+        <input id="label" name="label" required placeholder="API token, recovery codes, …">
+        <label for="plaintext">Plaintext (encrypted before localStorage write)</label>
+        <textarea id="plaintext" name="plaintext" required placeholder="anything you want to seal"></textarea>
+        <p><button type="submit" id="add-btn">Encrypt &amp; save (offline)</button></p>
+    </form>
+
+    <h2>4. Stored items <span id="item-count" class="meta"></span></h2>
+    <p class="row">
+        <button type="button" id="reveal-all" class="muted">Decrypt all</button>
+        <button type="button" id="hide-all" class="muted">Hide plaintexts</button>
+        <button type="button" id="lock-btn" class="danger">Lock vault (forget keys)</button>
+    </p>
+    <div id="items-list"></div>
+</section>
+
+<h2>Output</h2>
+<pre id="output">Loading…</pre>
+
+<script type="module">
+    const $ = (id) => document.getElementById(id);
+    const setupSection = $('setup-section');
+    const lockedSection = $('locked-section');
+    const vaultSection = $('vault-section');
+    const unlockBtn = $('unlock-btn');
+    const resetBtn = $('reset-btn');
+    const addForm = $('add-form');
+    const addBtn = $('add-btn');
+    const itemsList = $('items-list');
+    const itemCount = $('item-count');
+    const output = $('output');
+    const netStatus = $('net-status');
+
+    const log = (msg, cls = '') => {
+        const line = document.createElement('div');
+        if (cls) line.className = cls;
+        line.textContent = msg;
+        output.appendChild(line);
+    };
+
+    const b64u = {
+        encode: (buf) => {
+            const bytes = new Uint8Array(buf);
+            let str = '';
+            for (let i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i]);
+            return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+        },
+        decode: (s) => {
+            s = s.replace(/-/g, '+').replace(/_/g, '/');
+            const pad = (4 - (s.length % 4)) % 4;
+            s += '='.repeat(pad);
+            const bin = atob(s);
+            const out = new Uint8Array(bin.length);
+            for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+            return out;
+        },
+    };
+
+    const STORAGE_KEYS = {
+        credId:   'prf-offline:credId',
+        salt:     'prf-offline:prfSalt',
+        salt2:    'prf-offline:prfSalt2',
+        items:    'prf-offline:items',
+    };
+
+    const loadItems = () => JSON.parse(localStorage.getItem(STORAGE_KEYS.items) || '[]');
+    const saveItems = (arr) => localStorage.setItem(STORAGE_KEYS.items, JSON.stringify(arr));
+
+    const updateNetStatus = () => {
+        const online = navigator.onLine;
+        netStatus.textContent = online ? 'online (but unused)' : 'offline';
+        netStatus.className = `net-status ${online ? 'net-online' : 'net-offline'}`;
+    };
+    updateNetStatus();
+    window.addEventListener('online', updateNetStatus);
+    window.addEventListener('offline', updateNetStatus);
+
+    const isSetup = () =>
+        localStorage.getItem(STORAGE_KEYS.credId) &&
+        localStorage.getItem(STORAGE_KEYS.salt) &&
+        localStorage.getItem(STORAGE_KEYS.salt2);
+
+    const showInitialSection = () => {
+        if (isSetup()) {
+            setupSection.classList.add('hidden');
+            lockedSection.classList.remove('hidden');
+        } else {
+            setupSection.classList.remove('hidden');
+            lockedSection.classList.add('hidden');
+        }
+        vaultSection.classList.add('hidden');
+    };
+
+    /** Register the SW so the page is reachable in airplane mode after first load. */
+    const registerServiceWorker = async () => {
+        if (!('serviceWorker' in navigator)) {
+            log('⚠ Service workers are not available — the page itself will still need network on reload.', 'err');
+            return;
+        }
+        try {
+            const reg = await navigator.serviceWorker.register('/sw.js', { scope: '/' });
+            log(`✓ Service worker registered (scope: ${reg.scope}). Next reload works offline.`, 'ok');
+        } catch (e) {
+            log(`⚠ Service worker registration failed: ${e.message}`, 'err');
+        }
+    };
+
+    /** HKDF-derive an AES-GCM key from the raw PRF output. */
+    const deriveAesKey = async (prfBytes) => {
+        const ikm = await crypto.subtle.importKey('raw', prfBytes, 'HKDF', false, ['deriveKey']);
+        return crypto.subtle.deriveKey(
+            { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(), info: new TextEncoder().encode('webauthn-prf-demo:aes') },
+            ikm,
+            { name: 'AES-GCM', length: 256 },
+            false,
+            ['encrypt', 'decrypt'],
+        );
+    };
+
+    /** HKDF-derive an HMAC-SHA256 key from the raw PRF output. */
+    const deriveHmacKey = async (prfBytes) => {
+        const ikm = await crypto.subtle.importKey('raw', prfBytes, 'HKDF', false, ['deriveKey']);
+        return crypto.subtle.deriveKey(
+            { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(), info: new TextEncoder().encode('webauthn-prf-demo:hmac') },
+            ikm,
+            { name: 'HMAC', hash: 'SHA-256', length: 256 },
+            false,
+            ['sign', 'verify'],
+        );
+    };
+
+    /** Canonical bytes the HMAC is computed over. Same shape as vault.html. */
+    const macBytesFor = (label, ivB64Url, ciphertextB64Url) => {
+        const enc = new TextEncoder();
+        const labelBytes = enc.encode(label);
+        const ivBytes = b64u.decode(ivB64Url);
+        const ctBytes = b64u.decode(ciphertextB64Url);
+        const out = new Uint8Array(2 + 4 + labelBytes.length + ivBytes.length + ctBytes.length);
+        out[0] = 0x76; out[1] = 0x31;
+        new DataView(out.buffer).setUint32(2, labelBytes.length, false);
+        out.set(labelBytes, 6);
+        out.set(ivBytes, 6 + labelBytes.length);
+        out.set(ctBytes, 6 + labelBytes.length + ivBytes.length);
+        return out;
+    };
+
+    // In-memory state — never persisted.
+    let aesKey = null;
+    let hmacKey = null;
+    let items = [];
+
+    const renderItems = () => {
+        itemsList.innerHTML = '';
+        itemCount.textContent = items.length === 0 ? '' : `(${items.length})`;
+        if (items.length === 0) {
+            const empty = document.createElement('p');
+            empty.className = 'empty';
+            empty.textContent = 'Vault is empty. Add an item above.';
+            itemsList.appendChild(empty);
+            return;
+        }
+        for (const item of items) {
+            const node = document.createElement('div');
+            node.className = 'item';
+            node.dataset.id = item.id;
+            node.innerHTML = `
+                <header>
+                    <span class="label"></span>
+                    <span class="row">
+                        <span class="mac-badge"></span>
+                        <button type="button" class="reveal">Decrypt</button>
+                        <button type="button" class="hide hidden muted">Hide</button>
+                        <button type="button" class="del danger">Delete</button>
+                    </span>
+                </header>
+                <div class="meta"></div>
+                <div class="ciphertext"></div>
+                <div class="plaintext hidden"></div>
+            `;
+            node.querySelector('.label').textContent = item.label;
+            node.querySelector('.meta').textContent = `id ${item.id}`;
+            node.querySelector('.ciphertext').textContent = `ct: ${item.ciphertext}`;
+            const badge = node.querySelector('.mac-badge');
+            if (item.macStatus === 'ok') { badge.textContent = '✓ HMAC valid'; badge.className = 'mac-badge mac-ok'; }
+            else if (item.macStatus === 'bad') { badge.textContent = '✗ HMAC mismatch'; badge.className = 'mac-badge mac-bad'; }
+            else { badge.textContent = '… verifying'; badge.className = 'mac-badge'; }
+            node.querySelector('.reveal').addEventListener('click', () => decryptOne(item.id));
+            node.querySelector('.hide').addEventListener('click', () => hideOne(item.id));
+            node.querySelector('.del').addEventListener('click', () => deleteOne(item.id));
+            itemsList.appendChild(node);
+        }
+    };
+
+    const verifyAllMacs = async () => {
+        if (!hmacKey) return;
+        for (const item of items) {
+            try {
+                const ok = await crypto.subtle.verify(
+                    'HMAC',
+                    hmacKey,
+                    b64u.decode(item.mac),
+                    macBytesFor(item.label, item.iv, item.ciphertext),
+                );
+                item.macStatus = ok ? 'ok' : 'bad';
+            } catch (_e) {
+                item.macStatus = 'bad';
+            }
+        }
+        renderItems();
+    };
+
+    const decryptOne = async (id) => {
+        const item = items.find((it) => it.id === id);
+        if (!item || !aesKey) return;
+        try {
+            const buf = await crypto.subtle.decrypt(
+                { name: 'AES-GCM', iv: b64u.decode(item.iv) },
+                aesKey,
+                b64u.decode(item.ciphertext),
+            );
+            const node = itemsList.querySelector(`[data-id="${CSS.escape(id)}"]`);
+            const pt = node.querySelector('.plaintext');
+            pt.textContent = new TextDecoder().decode(buf);
+            pt.classList.remove('hidden');
+            node.querySelector('.reveal').classList.add('hidden');
+            node.querySelector('.hide').classList.remove('hidden');
+        } catch (e) {
+            log(`✗ Decrypt failed for ${id}: ${e.message}`, 'err');
+        }
+    };
+
+    const hideOne = (id) => {
+        const node = itemsList.querySelector(`[data-id="${CSS.escape(id)}"]`);
+        if (!node) return;
+        const pt = node.querySelector('.plaintext');
+        pt.textContent = '';
+        pt.classList.add('hidden');
+        node.querySelector('.reveal').classList.remove('hidden');
+        node.querySelector('.hide').classList.add('hidden');
+    };
+
+    const decryptAll = async () => { for (const item of items) await decryptOne(item.id); };
+    const hideAll = () => { for (const item of items) hideOne(item.id); };
+
+    const deleteOne = (id) => {
+        if (!confirm('Delete this item from localStorage?')) return;
+        items = items.filter((it) => it.id !== id);
+        saveItems(items);
+        renderItems();
+        log(`✓ removed ${id} from localStorage`, 'ok');
+    };
+
+    const lockVault = () => {
+        aesKey = null;
+        hmacKey = null;
+        items = [];
+        renderItems();
+        showInitialSection();
+        log('▶ Vault locked. AES + HMAC keys forgotten; localStorage data still on disk.', 'ok');
+    };
+
+    unlockBtn.addEventListener('click', async () => {
+        unlockBtn.disabled = true;
+        try {
+            const credId = b64u.decode(localStorage.getItem(STORAGE_KEYS.credId));
+            const salt   = b64u.decode(localStorage.getItem(STORAGE_KEYS.salt));
+            const salt2  = b64u.decode(localStorage.getItem(STORAGE_KEYS.salt2));
+
+            log('▶ Calling navigator.credentials.get({extensions:{prf}}) — challenge generated locally, no fetch…');
+            const credential = await navigator.credentials.get({
+                publicKey: {
+                    challenge: crypto.getRandomValues(new Uint8Array(32)),
+                    rpId: location.hostname,
+                    allowCredentials: [{ type: 'public-key', id: credId }],
+                    userVerification: 'required',
+                    extensions: { prf: { eval: { first: salt, second: salt2 } } },
+                },
+            });
+            const ext = credential.getClientExtensionResults();
+            const prfBytes  = ext?.prf?.results?.first;
+            const prfBytes2 = ext?.prf?.results?.second;
+            if (!prfBytes) throw new Error('No prf.results.first on the assertion.');
+            log(`✓ assertion done. prf.results.first = ${prfBytes.byteLength} bytes (AES key)`, 'ok');
+            if (prfBytes2) log(`              prf.results.second = ${prfBytes2.byteLength} bytes (HMAC key)`, 'ok');
+
+            aesKey = await deriveAesKey(new Uint8Array(prfBytes));
+            hmacKey = prfBytes2 ? await deriveHmacKey(new Uint8Array(prfBytes2)) : null;
+
+            items = loadItems();
+            renderItems();
+            await verifyAllMacs();
+
+            lockedSection.classList.add('hidden');
+            vaultSection.classList.remove('hidden');
+            log('✓ Vault unlocked. No network call has happened during the unlock.', 'ok');
+        } catch (err) {
+            log(`✗ ${err.message}`, 'err');
+        } finally {
+            unlockBtn.disabled = false;
+        }
+    });
+
+    resetBtn.addEventListener('click', () => {
+        if (!confirm('Forget the credId and the salts in localStorage? You will have to re-create a passkey, and any encrypted items become unrecoverable.')) return;
+        for (const k of Object.values(STORAGE_KEYS)) localStorage.removeItem(k);
+        aesKey = null; hmacKey = null; items = [];
+        log('✓ localStorage wiped.', 'ok');
+        showInitialSection();
+    });
+
+    addForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        if (!aesKey || !hmacKey) {
+            log('✗ Vault is locked.', 'err');
+            return;
+        }
+        addBtn.disabled = true;
+        try {
+            const label = addForm.label.value.trim();
+            const plaintext = addForm.plaintext.value;
+            const iv = crypto.getRandomValues(new Uint8Array(12));
+            const ciphertext = new Uint8Array(await crypto.subtle.encrypt(
+                { name: 'AES-GCM', iv }, aesKey, new TextEncoder().encode(plaintext),
+            ));
+            const ivB64 = b64u.encode(iv);
+            const ctB64 = b64u.encode(ciphertext);
+            const macBytes = new Uint8Array(await crypto.subtle.sign(
+                'HMAC', hmacKey, macBytesFor(label, ivB64, ctB64),
+            ));
+            const item = {
+                id: crypto.randomUUID().slice(0, 16),
+                label,
+                ciphertext: ctB64,
+                iv: ivB64,
+                mac: b64u.encode(macBytes),
+                createdAt: Date.now(),
+                macStatus: 'ok',
+            };
+            items = [...items, item];
+            saveItems(items);
+            renderItems();
+            addForm.reset();
+            log(`✓ encrypted & saved item ${item.id} to localStorage (no fetch). HMAC ✓`, 'ok');
+        } catch (err) {
+            log(`✗ ${err.message}`, 'err');
+        } finally {
+            addBtn.disabled = false;
+        }
+    });
+
+    $('reveal-all').addEventListener('click', decryptAll);
+    $('hide-all').addEventListener('click', hideAll);
+    $('lock-btn').addEventListener('click', lockVault);
+
+    // Boot
+    output.textContent = '';
+    log(`▶ Page loaded. ${isSetup() ? 'credId + salts found in localStorage (mirrored from a previous /register.html visit). Click "Authenticate & unlock".' : 'No credId/salts in localStorage — visit /register.html first.'}`);
+    showInitialSection();
+    registerServiceWorker();
+</script>
+</body>
+</html>

--- a/docs/examples/prf-demo/same-origin/public/register.html
+++ b/docs/examples/prf-demo/same-origin/public/register.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>PRF Demo — Register</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 720px; margin: 40px auto; padding: 20px; color: #1f2937; line-height: 1.55; }
+        h1 { font-size: 1.5rem; }
+        label { display: block; margin: 0.6rem 0 0.25rem; font-weight: 500; }
+        input, button { padding: 0.55rem 0.75rem; font-size: 1rem; border-radius: 6px; border: 1px solid #d1d5db; box-sizing: border-box; }
+        input { width: 100%; }
+        button { background: #2563eb; color: #fff; border: none; cursor: pointer; }
+        button:disabled { background: #94a3b8; cursor: not-allowed; }
+        pre { background: #f3f4f6; padding: 12px; border-radius: 6px; overflow-x: auto; max-height: 360px; white-space: pre-wrap; word-break: break-all; }
+        .ok { color: #047857; }
+        .err { color: #b91c1c; }
+        nav a { color: #2563eb; margin-right: 1rem; }
+        .warning { background: #fef3c7; border-left: 4px solid #d97706; padding: 12px 16px; border-radius: 6px; margin: 1.2rem 0; font-size: 0.95rem; }
+        .warning strong { color: #92400e; }
+    </style>
+</head>
+<body>
+<nav><a href="/">← Home</a><a href="/vault.html">Vault →</a></nav>
+
+<h1>1. Register a credential with PRF support</h1>
+
+<p>
+    The page calls <code>navigator.credentials.create()</code> with the
+    <code>prf</code> extension primed by two server-issued salts. The server stores both
+    salts next to the credential so they can be re-issued on every authentication. No
+    secrets leave the browser; the relying party only ever sees the assertion proof.
+</p>
+
+<div class="warning">
+    <strong>⚠ If you delete this passkey you will permanently lose access to everything you
+    seal under it.</strong> The PRF input-key lives inside the authenticator and a re-created
+    passkey produces a brand-new one — even with the same salt. This demo has no recovery
+    path; a production system needs one (escrowed wrap, second enrolled passkey, …).
+    See the <a href="https://blog.millerti.me/2023/01/22/encrypting-data-in-the-browser-using-webauthn/" target="_blank" rel="noopener">May 2025 update on Matt's blog</a>.
+</div>
+
+<p>
+    Once registered, head to the <a href="/vault.html">vault</a> to encrypt and
+    decrypt items of your choice.
+</p>
+
+<form id="register-form">
+    <label for="username">Username (email)</label>
+    <input id="username" name="username" type="email" required value="jane.doe@example.com">
+
+    <p><button type="submit" id="submit">Register</button></p>
+</form>
+
+<h2>Output</h2>
+<pre id="output">Submit the form to start a registration ceremony.</pre>
+
+<script type="module">
+    const form = document.getElementById('register-form');
+    const submit = document.getElementById('submit');
+    const output = document.getElementById('output');
+
+    const log = (msg, cls = '') => {
+        const line = document.createElement('div');
+        if (cls) line.className = cls;
+        line.textContent = msg;
+        output.appendChild(line);
+    };
+
+    const b64u = {
+        encode: (buf) => {
+            const bytes = new Uint8Array(buf);
+            let str = '';
+            for (let i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i]);
+            return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+        },
+        decode: (s) => {
+            s = s.replace(/-/g, '+').replace(/_/g, '/');
+            const pad = (4 - (s.length % 4)) % 4;
+            s += '='.repeat(pad);
+            const bin = atob(s);
+            const out = new Uint8Array(bin.length);
+            for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+            return out;
+        },
+    };
+
+    const toCreateOptions = (json) => {
+        const o = { ...json };
+        o.challenge = b64u.decode(json.challenge);
+        o.user = { ...json.user, id: b64u.decode(json.user.id) };
+        if (json.excludeCredentials) {
+            o.excludeCredentials = json.excludeCredentials.map((c) => ({
+                ...c,
+                id: b64u.decode(c.id),
+            }));
+        }
+        if (json.extensions?.prf?.eval) {
+            o.extensions = {
+                ...json.extensions,
+                prf: {
+                    eval: {
+                        first: b64u.decode(json.extensions.prf.eval.first),
+                        ...(json.extensions.prf.eval.second
+                            ? { second: b64u.decode(json.extensions.prf.eval.second) }
+                            : {}),
+                    },
+                },
+            };
+            const eSecond = json.extensions.prf.eval.second ? ' + second' : '';
+            log(`▶ PRF inputs received from server: first${eSecond}`);
+        }
+        return o;
+    };
+
+    const credentialToJson = (cred) => ({
+        id: cred.id,
+        rawId: b64u.encode(cred.rawId),
+        type: cred.type,
+        response: {
+            clientDataJSON: b64u.encode(cred.response.clientDataJSON),
+            attestationObject: b64u.encode(cred.response.attestationObject),
+        },
+    });
+
+    // Same keys as /offline.html so the offline page can reuse this very passkey
+    // without asking the user to create a second one.
+    const STORAGE_KEYS = {
+        credId: 'prf-offline:credId',
+        salt:   'prf-offline:prfSalt',
+        salt2:  'prf-offline:prfSalt2',
+    };
+
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        submit.disabled = true;
+        output.textContent = '';
+
+        try {
+            const username = form.username.value;
+
+            log('▶ Asking server for creation options…');
+            const optResp = await fetch('/api/register/options', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username }),
+            });
+            if (!optResp.ok) throw new Error(`options HTTP ${optResp.status}: ${await optResp.text()}`);
+            const optsJson = await optResp.json();
+            log('✓ options received (PRF salt is in extensions.prf.eval.first)');
+
+            log('▶ Calling navigator.credentials.create({ extensions: { prf } })…');
+            const credential = await navigator.credentials.create({ publicKey: toCreateOptions(optsJson) });
+            const ext = credential.getClientExtensionResults();
+            const prfEnabled = ext?.prf?.enabled === true;
+            log(`✓ credential created (prf.enabled=${prfEnabled})`, prfEnabled ? 'ok' : 'err');
+            if (!prfEnabled) {
+                log('⚠ Your authenticator does not advertise PRF support. The vault will not be able to derive an encryption key.', 'err');
+            }
+            // Some platforms (Chromium with security keys, Android) also return PRF outputs at
+            // registration time. Most platform authenticators only return them on assertion.
+            const r = ext?.prf?.results;
+            if (r?.first) log(`  prf.results.first  = ${r.first.byteLength} bytes`, 'ok');
+            if (r?.second) log(`  prf.results.second = ${r.second.byteLength} bytes (available for an independent derivation)`, 'ok');
+
+            log('▶ POST /api/register/verify…');
+            const verifyResp = await fetch('/api/register/verify', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(credentialToJson(credential)),
+            });
+            if (!verifyResp.ok) throw new Error(`verify HTTP ${verifyResp.status}: ${await verifyResp.text()}`);
+            const verified = await verifyResp.json();
+            log(`✓ stored. credentialId=${verified.credentialId}`, 'ok');
+
+            // Mirror the credential id and the two salts into localStorage so /offline.html
+            // can re-use this very passkey instead of asking the user to create a second one.
+            // The salts were generated server-side and arrived in `optsJson.extensions.prf.eval`;
+            // they are not secrets (they travel in clear at every ceremony anyway).
+            if (optsJson.extensions?.prf?.eval) {
+                localStorage.setItem(STORAGE_KEYS.credId, b64u.encode(credential.rawId));
+                localStorage.setItem(STORAGE_KEYS.salt,   optsJson.extensions.prf.eval.first);
+                if (optsJson.extensions.prf.eval.second) {
+                    localStorage.setItem(STORAGE_KEYS.salt2, optsJson.extensions.prf.eval.second);
+                }
+                log(`✓ credId + salts mirrored to localStorage (${Object.values(STORAGE_KEYS).join(', ')}).`, 'ok');
+                log('▶ This browser is now set up for offline use too — open /offline.html anytime, even with no network.', 'ok');
+            }
+
+            log('Open /vault.html to encrypt items with this credential (online), or /offline.html (no server).');
+        } catch (err) {
+            log(`✗ ${err.message}`, 'err');
+        } finally {
+            submit.disabled = false;
+        }
+    });
+</script>
+</body>
+</html>

--- a/docs/examples/prf-demo/same-origin/public/sw.js
+++ b/docs/examples/prf-demo/same-origin/public/sw.js
@@ -1,0 +1,33 @@
+'use strict';
+
+// Cache-first service worker for the offline-only PRF page. We only cache the
+// static assets that the offline experience needs; API calls under /api/* are
+// pass-through, but offline.html doesn't make any.
+const CACHE = 'prf-offline-v1';
+const ASSETS = ['/', '/offline.html', '/sw.js'];
+
+self.addEventListener('install', (event) => {
+    event.waitUntil(
+        caches.open(CACHE).then((cache) => cache.addAll(ASSETS)).then(() => self.skipWaiting()),
+    );
+});
+
+self.addEventListener('activate', (event) => {
+    event.waitUntil(
+        caches
+            .keys()
+            .then((keys) => Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k))))
+            .then(() => self.clients.claim()),
+    );
+});
+
+self.addEventListener('fetch', (event) => {
+    const url = new URL(event.request.url);
+    // Never cache API calls — they belong to the online demo only.
+    if (url.pathname.startsWith('/api/')) {
+        return;
+    }
+    event.respondWith(
+        caches.match(event.request).then((hit) => hit || fetch(event.request)),
+    );
+});

--- a/docs/examples/prf-demo/same-origin/public/vault.html
+++ b/docs/examples/prf-demo/same-origin/public/vault.html
@@ -1,0 +1,462 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>PRF Demo — Vault</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 760px; margin: 40px auto; padding: 20px; color: #1f2937; line-height: 1.5; }
+        h1 { font-size: 1.5rem; }
+        h2 { font-size: 1.15rem; margin-top: 1.5rem; }
+        label { display: block; margin: 0.55rem 0 0.2rem; font-weight: 500; }
+        input, textarea, button { padding: 0.5rem 0.75rem; font-size: 1rem; border-radius: 6px; border: 1px solid #d1d5db; box-sizing: border-box; font-family: inherit; }
+        input, textarea { width: 100%; }
+        textarea { min-height: 80px; }
+        button { background: #2563eb; color: #fff; border: none; cursor: pointer; }
+        button.danger { background: #b91c1c; }
+        button.muted { background: #6b7280; }
+        button:disabled { background: #94a3b8; cursor: not-allowed; }
+        pre { background: #f3f4f6; padding: 12px; border-radius: 6px; overflow-x: auto; max-height: 220px; white-space: pre-wrap; word-break: break-all; }
+        nav a { color: #2563eb; margin-right: 1rem; }
+        .item { border: 1px solid #e5e7eb; padding: 12px 14px; border-radius: 8px; margin-bottom: 12px; }
+        .item header { display: flex; justify-content: space-between; gap: 8px; align-items: baseline; }
+        .item .label { font-weight: 600; }
+        .item .meta { font-size: 0.85rem; color: #6b7280; }
+        .item .ciphertext { font-family: ui-monospace, SFMono-Regular, monospace; font-size: 0.8rem; color: #6b7280; word-break: break-all; margin-top: 6px; }
+        .item .plaintext { background: #ecfdf5; border: 1px solid #10b981; padding: 8px 10px; border-radius: 6px; margin-top: 8px; font-size: 0.95rem; }
+        .mac-badge { font-size: 0.78rem; padding: 2px 8px; border-radius: 999px; background: #f3f4f6; color: #6b7280; }
+        .mac-ok { background: #d1fae5; color: #047857; }
+        .mac-bad { background: #fee2e2; color: #991b1b; }
+        .row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+        .ok { color: #047857; }
+        .err { color: #b91c1c; }
+        .hidden { display: none; }
+        .empty { color: #6b7280; font-style: italic; }
+    </style>
+</head>
+<body>
+<nav><a href="/">← Home</a><a href="/register.html">Register</a></nav>
+
+<h1>Vault — encrypt anything, decrypt on demand</h1>
+
+<p>
+    Authenticate with the credential you registered earlier. The page derives
+    <strong>two</strong> keys from the PRF outputs and keeps them in memory for
+    this tab — never persisted, never sent:
+</p>
+<ul>
+    <li>an <strong>AES-GCM key</strong> from <code>prf.results.first</code>
+        (HKDF info <code>"webauthn-prf-demo:aes"</code>) — used to encrypt
+        and decrypt item plaintexts;</li>
+    <li>an <strong>HMAC-SHA256 key</strong> from <code>prf.results.second</code>
+        (HKDF info <code>"webauthn-prf-demo:hmac"</code>) — used to
+        authenticate the <em>label + iv + ciphertext</em> tuple of every item
+        so the page can detect if the server (or anyone with database access)
+        silently changed a label or swapped two ciphertexts.</li>
+</ul>
+<p>
+    Every item you add is encrypted and signed client-side before leaving the
+    page. Reload the tab → both keys are gone, you have to re-authenticate.
+</p>
+
+<section id="lock-section">
+    <h2>1. Unlock the vault</h2>
+    <form id="unlock-form">
+        <label for="username">Username (email)</label>
+        <input id="username" name="username" type="email" required value="jane.doe@example.com">
+        <p><button type="submit" id="unlock-btn">Authenticate &amp; unlock</button></p>
+    </form>
+</section>
+
+<section id="vault-section" class="hidden">
+    <h2>2. Encrypt a new item</h2>
+    <form id="add-form">
+        <label for="label">Label (stored in clear, used to find items)</label>
+        <input id="label" name="label" required placeholder="API token, recovery codes, …">
+        <label for="plaintext">Plaintext (encrypted client-side)</label>
+        <textarea id="plaintext" name="plaintext" required placeholder="anything you want to seal"></textarea>
+        <p><button type="submit" id="add-btn">Encrypt &amp; save</button></p>
+    </form>
+
+    <h2>3. Stored items <span id="item-count" class="meta"></span></h2>
+    <p class="row">
+        <button type="button" id="reveal-all" class="muted">Decrypt all</button>
+        <button type="button" id="hide-all" class="muted">Hide plaintexts</button>
+        <button type="button" id="lock-btn" class="danger">Lock vault (forget key)</button>
+    </p>
+    <div id="items-list"></div>
+</section>
+
+<h2>Output</h2>
+<pre id="output">Authenticate to unlock the vault.</pre>
+
+<script type="module">
+    const $ = (id) => document.getElementById(id);
+    const lockSection = $('lock-section');
+    const vaultSection = $('vault-section');
+    const unlockForm = $('unlock-form');
+    const unlockBtn = $('unlock-btn');
+    const addForm = $('add-form');
+    const addBtn = $('add-btn');
+    const itemsList = $('items-list');
+    const itemCount = $('item-count');
+    const output = $('output');
+
+    const log = (msg, cls = '') => {
+        const line = document.createElement('div');
+        if (cls) line.className = cls;
+        line.textContent = msg;
+        output.appendChild(line);
+    };
+
+    const b64u = {
+        encode: (buf) => {
+            const bytes = new Uint8Array(buf);
+            let str = '';
+            for (let i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i]);
+            return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+        },
+        decode: (s) => {
+            s = s.replace(/-/g, '+').replace(/_/g, '/');
+            const pad = (4 - (s.length % 4)) % 4;
+            s += '='.repeat(pad);
+            const bin = atob(s);
+            const out = new Uint8Array(bin.length);
+            for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+            return out;
+        },
+    };
+
+    const toGetOptions = (json) => {
+        const o = { ...json };
+        o.challenge = b64u.decode(json.challenge);
+        if (json.allowCredentials) {
+            o.allowCredentials = json.allowCredentials.map((c) => ({ ...c, id: b64u.decode(c.id) }));
+        }
+        if (json.extensions?.prf?.evalByCredential) {
+            const evalByCredential = {};
+            for (const [k, v] of Object.entries(json.extensions.prf.evalByCredential)) {
+                evalByCredential[k] = {
+                    first: b64u.decode(v.first),
+                    ...(v.second ? { second: b64u.decode(v.second) } : {}),
+                };
+            }
+            o.extensions = { ...json.extensions, prf: { evalByCredential } };
+        }
+        return o;
+    };
+
+    const credentialToJson = (cred) => ({
+        id: cred.id,
+        rawId: b64u.encode(cred.rawId),
+        type: cred.type,
+        response: {
+            clientDataJSON: b64u.encode(cred.response.clientDataJSON),
+            authenticatorData: b64u.encode(cred.response.authenticatorData),
+            signature: b64u.encode(cred.response.signature),
+            ...(cred.response.userHandle ? { userHandle: b64u.encode(cred.response.userHandle) } : {}),
+        },
+    });
+
+    /** HKDF-derive an AES-GCM key from the raw PRF output bytes. */
+    const deriveAesKey = async (prfBytes) => {
+        const ikm = await crypto.subtle.importKey('raw', prfBytes, 'HKDF', false, ['deriveKey']);
+        return crypto.subtle.deriveKey(
+            { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(), info: new TextEncoder().encode('webauthn-prf-demo:aes') },
+            ikm,
+            { name: 'AES-GCM', length: 256 },
+            false,
+            ['encrypt', 'decrypt'],
+        );
+    };
+
+    /** HKDF-derive an HMAC-SHA256 key from the raw PRF output bytes (used for label/ciphertext authentication). */
+    const deriveHmacKey = async (prfBytes) => {
+        const ikm = await crypto.subtle.importKey('raw', prfBytes, 'HKDF', false, ['deriveKey']);
+        return crypto.subtle.deriveKey(
+            { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(), info: new TextEncoder().encode('webauthn-prf-demo:hmac') },
+            ikm,
+            { name: 'HMAC', hash: 'SHA-256', length: 256 },
+            false,
+            ['sign', 'verify'],
+        );
+    };
+
+    /** Build the canonical byte string an item is HMAC-ed over. */
+    const macBytesFor = (label, ivB64Url, ciphertextB64Url) => {
+        const enc = new TextEncoder();
+        const labelBytes = enc.encode(label);
+        const ivBytes = b64u.decode(ivB64Url);
+        const ctBytes = b64u.decode(ciphertextB64Url);
+        // version || labelLen(uint32 BE) || label || iv || ciphertext
+        const out = new Uint8Array(2 + 4 + labelBytes.length + ivBytes.length + ctBytes.length);
+        out[0] = 0x76; out[1] = 0x31; // "v1"
+        new DataView(out.buffer).setUint32(2, labelBytes.length, false);
+        out.set(labelBytes, 6);
+        out.set(ivBytes, 6 + labelBytes.length);
+        out.set(ctBytes, 6 + labelBytes.length + ivBytes.length);
+        return out;
+    };
+
+    // In-memory state — never persisted, never sent.
+    let aesKey = null;
+    let hmacKey = null;
+    let credentialIdB64Url = null;
+    let items = []; // {id, label, ciphertext, iv, mac, macStatus?: 'ok'|'bad'|'missing'}
+
+    const renderItems = () => {
+        itemsList.innerHTML = '';
+        itemCount.textContent = items.length === 0 ? '' : `(${items.length})`;
+        if (items.length === 0) {
+            const empty = document.createElement('p');
+            empty.className = 'empty';
+            empty.textContent = 'Vault is empty. Add an item above.';
+            itemsList.appendChild(empty);
+            return;
+        }
+        for (const item of items) {
+            const node = document.createElement('div');
+            node.className = 'item';
+            node.dataset.id = item.id;
+            node.innerHTML = `
+                <header>
+                    <span class="label"></span>
+                    <span class="row">
+                        <span class="mac-badge"></span>
+                        <button type="button" class="reveal">Decrypt</button>
+                        <button type="button" class="hide hidden muted">Hide</button>
+                        <button type="button" class="del danger">Delete</button>
+                    </span>
+                </header>
+                <div class="meta"></div>
+                <div class="ciphertext"></div>
+                <div class="plaintext hidden"></div>
+            `;
+            node.querySelector('.label').textContent = item.label;
+            node.querySelector('.meta').textContent = `id ${item.id}`;
+            node.querySelector('.ciphertext').textContent = `ct: ${item.ciphertext}`;
+            const badge = node.querySelector('.mac-badge');
+            if (item.macStatus === 'ok') {
+                badge.textContent = '✓ HMAC valid';
+                badge.className = 'mac-badge mac-ok';
+            } else if (item.macStatus === 'bad') {
+                badge.textContent = '✗ HMAC mismatch — label or ciphertext was tampered with';
+                badge.className = 'mac-badge mac-bad';
+            } else {
+                badge.textContent = '… verifying';
+                badge.className = 'mac-badge';
+            }
+            node.querySelector('.reveal').addEventListener('click', () => decryptOne(item.id));
+            node.querySelector('.hide').addEventListener('click', () => hideOne(item.id));
+            node.querySelector('.del').addEventListener('click', () => deleteOne(item.id));
+            itemsList.appendChild(node);
+        }
+    };
+
+    /** Recompute and verify the HMAC on every loaded item, mark them ok/bad/missing. */
+    const verifyAllMacs = async () => {
+        if (!hmacKey) return;
+        for (const item of items) {
+            if (!item.mac) {
+                item.macStatus = 'missing';
+                continue;
+            }
+            try {
+                const ok = await crypto.subtle.verify(
+                    'HMAC',
+                    hmacKey,
+                    b64u.decode(item.mac),
+                    macBytesFor(item.label, item.iv, item.ciphertext),
+                );
+                item.macStatus = ok ? 'ok' : 'bad';
+            } catch (_e) {
+                item.macStatus = 'bad';
+            }
+        }
+        renderItems();
+    };
+
+    const decryptOne = async (id) => {
+        const item = items.find((it) => it.id === id);
+        if (!item || !aesKey) return;
+        try {
+            const buf = await crypto.subtle.decrypt(
+                { name: 'AES-GCM', iv: b64u.decode(item.iv) },
+                aesKey,
+                b64u.decode(item.ciphertext),
+            );
+            const node = itemsList.querySelector(`[data-id="${CSS.escape(id)}"]`);
+            const pt = node.querySelector('.plaintext');
+            pt.textContent = new TextDecoder().decode(buf);
+            pt.classList.remove('hidden');
+            node.querySelector('.reveal').classList.add('hidden');
+            node.querySelector('.hide').classList.remove('hidden');
+        } catch (e) {
+            log(`✗ Decrypt failed for ${id}: ${e.message}`, 'err');
+        }
+    };
+
+    const hideOne = (id) => {
+        const node = itemsList.querySelector(`[data-id="${CSS.escape(id)}"]`);
+        if (!node) return;
+        const pt = node.querySelector('.plaintext');
+        pt.textContent = '';
+        pt.classList.add('hidden');
+        node.querySelector('.reveal').classList.remove('hidden');
+        node.querySelector('.hide').classList.add('hidden');
+    };
+
+    const decryptAll = async () => {
+        for (const item of items) await decryptOne(item.id);
+    };
+
+    const hideAll = () => {
+        for (const item of items) hideOne(item.id);
+    };
+
+    const deleteOne = async (id) => {
+        if (!confirm('Delete this item?')) return;
+        try {
+            const resp = await fetch('/api/vault/items/delete', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ id }),
+            });
+            if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${await resp.text()}`);
+            items = items.filter((it) => it.id !== id);
+            renderItems();
+            log(`✓ deleted ${id}`, 'ok');
+        } catch (e) {
+            log(`✗ delete failed: ${e.message}`, 'err');
+        }
+    };
+
+    const lockVault = () => {
+        aesKey = null;
+        hmacKey = null;
+        credentialIdB64Url = null;
+        items = [];
+        renderItems();
+        vaultSection.classList.add('hidden');
+        lockSection.classList.remove('hidden');
+        log('▶ Vault locked. The AES + HMAC keys have been forgotten; re-authenticate to unlock.', 'ok');
+    };
+
+    unlockForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        unlockBtn.disabled = true;
+        output.textContent = '';
+
+        try {
+            const username = unlockForm.username.value;
+
+            log('▶ Asking server for assertion options + stored items…');
+            const optResp = await fetch('/api/vault/options', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username }),
+            });
+            if (!optResp.ok) throw new Error(`options HTTP ${optResp.status}: ${await optResp.text()}`);
+            const { options: optsJson, itemsByCredential } = await optResp.json();
+            log('✓ options received');
+
+            log('▶ Calling navigator.credentials.get({ extensions: { prf } })…');
+            const credential = await navigator.credentials.get({ publicKey: toGetOptions(optsJson) });
+            const ext = credential.getClientExtensionResults();
+            const prfBytes = ext?.prf?.results?.first;
+            const prfBytes2 = ext?.prf?.results?.second;
+            if (!prfBytes) {
+                throw new Error('No PRF output on the assertion. The credential was registered without PRF support, or this authenticator no longer exposes it.');
+            }
+            credentialIdB64Url = b64u.encode(credential.rawId);
+            log(`✓ assertion done. prf.results.first  = ${prfBytes.byteLength} bytes  (used for the AES-GCM data key)`, 'ok');
+            if (prfBytes2) {
+                log(`              prf.results.second = ${prfBytes2.byteLength} bytes  (used for the HMAC label-authentication key)`, 'ok');
+            } else {
+                log('  prf.results.second was not returned — items added now will not carry an HMAC and tampering will not be detectable.', 'err');
+            }
+
+            aesKey = await deriveAesKey(new Uint8Array(prfBytes));
+            hmacKey = prfBytes2 ? await deriveHmacKey(new Uint8Array(prfBytes2)) : null;
+
+            log('▶ POST /api/vault/verify…');
+            const verifyResp = await fetch('/api/vault/verify', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(credentialToJson(credential)),
+            });
+            if (!verifyResp.ok) throw new Error(`verify HTTP ${verifyResp.status}: ${await verifyResp.text()}`);
+            await verifyResp.json();
+            log('✓ server validated assertion. Vault unlocked.', 'ok');
+
+            items = itemsByCredential[credentialIdB64Url] ?? [];
+            renderItems();
+            await verifyAllMacs();
+
+            lockSection.classList.add('hidden');
+            vaultSection.classList.remove('hidden');
+        } catch (err) {
+            log(`✗ ${err.message}`, 'err');
+        } finally {
+            unlockBtn.disabled = false;
+        }
+    });
+
+    addForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        if (!aesKey) {
+            log('✗ Vault is locked.', 'err');
+            return;
+        }
+        if (!hmacKey) {
+            log('✗ Cannot add an item: the HMAC key (derived from prf.results.second) is missing.', 'err');
+            return;
+        }
+        addBtn.disabled = true;
+        try {
+            const label = addForm.label.value.trim();
+            const plaintext = addForm.plaintext.value;
+            const iv = crypto.getRandomValues(new Uint8Array(12));
+            const ciphertext = new Uint8Array(await crypto.subtle.encrypt(
+                { name: 'AES-GCM', iv },
+                aesKey,
+                new TextEncoder().encode(plaintext),
+            ));
+            const ivB64 = b64u.encode(iv);
+            const ctB64 = b64u.encode(ciphertext);
+            const macBytes = new Uint8Array(await crypto.subtle.sign(
+                'HMAC',
+                hmacKey,
+                macBytesFor(label, ivB64, ctB64),
+            ));
+            const macB64 = b64u.encode(macBytes);
+
+            const resp = await fetch('/api/vault/items/add', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    label,
+                    ciphertext: ctB64,
+                    iv: ivB64,
+                    mac: macB64,
+                }),
+            });
+            if (!resp.ok) throw new Error(`add HTTP ${resp.status}: ${await resp.text()}`);
+            const stored = await resp.json();
+            stored.macStatus = 'ok';
+            items = [...items, stored];
+            renderItems();
+            addForm.reset();
+            log(`✓ encrypted & stored item ${stored.id} (label: ${stored.label}, HMAC ✓)`, 'ok');
+        } catch (err) {
+            log(`✗ ${err.message}`, 'err');
+        } finally {
+            addBtn.disabled = false;
+        }
+    });
+
+    $('reveal-all').addEventListener('click', decryptAll);
+    $('hide-all').addEventListener('click', hideAll);
+    $('lock-btn').addEventListener('click', lockVault);
+</script>
+</body>
+</html>

--- a/docs/examples/prf-demo/same-origin/router.php
+++ b/docs/examples/prf-demo/same-origin/router.php
@@ -1,0 +1,335 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Front controller for `php -S`. Routes the API endpoints; for every other
+ * request it returns false so the built-in server falls back to serving the
+ * matching static file from `public/`.
+ *
+ * Run with: php -S localhost:8000 -t public router.php
+ */
+
+use App\PrfDemo\Container;
+use ParagonIE\ConstantTime\Base64;
+use ParagonIE\ConstantTime\Base64UrlSafe;
+use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
+use Webauthn\AuthenticationExtensions\PseudoRandomFunctionInputExtensionBuilder;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\PublicKeyCredential;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialDescriptor;
+use Webauthn\PublicKeyCredentialParameters;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\PublicKeyCredentialRpEntity;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+require_once __DIR__ . '/../src/bootstrap.php';
+require_once __DIR__ . '/../src/CredentialStore.php';
+
+session_start();
+$container = new Container();
+$path = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?: '/';
+
+if (! str_starts_with($path, '/api/')) {
+    return false;
+}
+
+header('Content-Type: application/json');
+
+try {
+    match ($path) {
+        '/api/register/options' => registerOptions($container),
+        '/api/register/verify' => registerVerify($container),
+        '/api/vault/options' => vaultOptions($container),
+        '/api/vault/verify' => vaultVerify($container),
+        '/api/vault/items/add' => vaultItemAdd($container),
+        '/api/vault/items/delete' => vaultItemDelete($container),
+        default => notFound(),
+    };
+} catch (\Throwable $e) {
+    http_response_code(400);
+    echo json_encode([
+        'error' => $e->getMessage(),
+        'class' => $e::class,
+    ], JSON_THROW_ON_ERROR);
+}
+
+function notFound(): void
+{
+    http_response_code(404);
+    echo json_encode(['error' => 'Not found'], JSON_THROW_ON_ERROR);
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function readJson(): array
+{
+    $body = file_get_contents('php://input') ?: '{}';
+    $json = json_decode($body, true, flags: JSON_THROW_ON_ERROR);
+
+    return is_array($json) ? $json : [];
+}
+
+function registerOptions(Container $container): void
+{
+    $body = readJson();
+    $username = (string) ($body['username'] ?? 'jane.doe@example.com');
+
+    // Stable user handle for the demo. In a real app this comes from your user table.
+    $userHandle = hash('sha256', 'demo:' . $username, true);
+    $_SESSION['username'] = $username;
+    $_SESSION['userHandle'] = $userHandle;
+
+    $challenge = random_bytes(32);
+    $_SESSION['register_challenge'] = $challenge;
+
+    // The PRF salts are per-credential, generated at registration and persisted by the
+    // server so they can be re-issued at every authentication. The salts are NOT secrets
+    // (they are sent to the browser in plaintext on every ceremony); the secret is the
+    // PRF *output* the authenticator computes from (salt, credential-bound HMAC key).
+    //
+    // The spec lets you pass two salts per ceremony — `first` and `second`. The
+    // authenticator computes the PRF over both in a single round-trip, the page gets
+    // both outputs back. The demo derives its AES-GCM key from `first` and leaves
+    // `second` for additional derivations (HMAC, secondary key, key rotation, …).
+    $prfSalt = random_bytes(32);
+    $prfSalt2 = random_bytes(32);
+    $_SESSION['register_prf_salt'] = $prfSalt;
+    $_SESSION['register_prf_salt2'] = $prfSalt2;
+
+    $options = PublicKeyCredentialCreationOptions::create(
+        rp: PublicKeyCredentialRpEntity::create($container->relyingPartyName, $container->relyingPartyId),
+        user: PublicKeyCredentialUserEntity::create($username, $userHandle, $username),
+        challenge: $challenge,
+        pubKeyCredParams: [
+            PublicKeyCredentialParameters::create('public-key', -7),    // ES256
+            PublicKeyCredentialParameters::create('public-key', -257),  // RS256
+        ],
+        authenticatorSelection: \Webauthn\AuthenticatorSelectionCriteria::create(
+            authenticatorAttachment: 'platform',
+            userVerification: 'required',
+            residentKey: 'required',
+        ),
+        attestation: PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
+        extensions: AuthenticationExtensions::create([
+            // PRF at registration: the spec only guarantees `prf.enabled: true|false`
+            // back from the authenticator. Actual PRF *outputs* at registration time
+            // depend on the platform — set the salts anyway so the page can detect
+            // support and surface it in the UI before the user navigates to the
+            // vault page.
+            PseudoRandomFunctionInputExtensionBuilder::create()
+                ->withInputs($prfSalt, $prfSalt2)
+                ->build(),
+        ]),
+    );
+    $options->timeout = 60_000;
+
+    echo $container->serializer->serialize($options, 'json', [
+        'json_encode_options' => \JSON_THROW_ON_ERROR,
+        \Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+    ]);
+}
+
+function registerVerify(Container $container): void
+{
+    $body = file_get_contents('php://input') ?: '{}';
+    $credential = $container->serializer->deserialize($body, PublicKeyCredential::class, 'json');
+    \assert($credential instanceof PublicKeyCredential);
+
+    $response = $credential->response;
+    if (! $response instanceof AuthenticatorAttestationResponse) {
+        throw new \RuntimeException('Expected an AuthenticatorAttestationResponse.');
+    }
+
+    $challenge = $_SESSION['register_challenge'] ?? null;
+    $username = (string) ($_SESSION['username'] ?? '');
+    $userHandle = $_SESSION['userHandle'] ?? null;
+    $prfSalt = $_SESSION['register_prf_salt'] ?? null;
+    $prfSalt2 = $_SESSION['register_prf_salt2'] ?? null;
+    if (! is_string($challenge) || $userHandle === null || ! is_string($prfSalt) || ! is_string($prfSalt2)) {
+        throw new \RuntimeException('Missing registration session — start over.');
+    }
+
+    $options = PublicKeyCredentialCreationOptions::create(
+        rp: PublicKeyCredentialRpEntity::create($container->relyingPartyName, $container->relyingPartyId),
+        user: PublicKeyCredentialUserEntity::create($username, $userHandle, $username),
+        challenge: $challenge,
+        pubKeyCredParams: [
+            PublicKeyCredentialParameters::create('public-key', -7),
+            PublicKeyCredentialParameters::create('public-key', -257),
+        ],
+    );
+
+    $record = $container->attestationValidator->check($response, $options, $container->relyingPartyId);
+    $container->credentialStore->save($userHandle, $record, $prfSalt, $prfSalt2);
+
+    echo json_encode([
+        'verified' => true,
+        'credentialId' => Base64::encode($record->publicKeyCredentialId),
+    ], JSON_THROW_ON_ERROR);
+}
+
+function vaultOptions(Container $container): void
+{
+    $body = readJson();
+    $username = (string) ($body['username'] ?? '');
+    if ($username === '') {
+        throw new \RuntimeException('username is required.');
+    }
+
+    $userHandle = hash('sha256', 'demo:' . $username, true);
+    $credentialIds = $container->credentialStore->credentialIdsForUser($userHandle);
+    if ($credentialIds === []) {
+        throw new \RuntimeException('No credential registered for that user — register first.');
+    }
+
+    $challenge = random_bytes(32);
+    $_SESSION['vault_challenge'] = $challenge;
+    $_SESSION['vault_username'] = $username;
+
+    // Re-issue each credential's stored salt as the per-credential PRF input. The
+    // browser will receive the same bytes the authenticator was queried with at
+    // registration → the PRF output is identical → the AES-GCM key is identical →
+    // every ciphertext stored under that credential decrypts.
+    $prfBuilder = PseudoRandomFunctionInputExtensionBuilder::create();
+    $allowCredentials = [];
+    $items = [];
+    foreach ($credentialIds as $idB64) {
+        $rawId = (string) base64_decode($idB64, true);
+        $stored = $container->credentialStore->findByCredentialId($rawId);
+        if ($stored === null) {
+            continue;
+        }
+        $allowCredentials[] = PublicKeyCredentialDescriptor::create('public-key', $rawId);
+        $credIdB64Url = Base64UrlSafe::encodeUnpadded($rawId);
+        // Re-issue both salts so the page recomputes both PRF outputs in a single
+        // authenticator round-trip. `second` is empty for legacy rows registered
+        // before the dual-salt update — fall back to first-salt-only in that case.
+        if ($stored['prfSalt2'] !== '') {
+            $prfBuilder->withCredentialInputs($credIdB64Url, $stored['prfSalt'], $stored['prfSalt2']);
+        } else {
+            $prfBuilder->withCredentialInputs($credIdB64Url, $stored['prfSalt']);
+        }
+        $items[$credIdB64Url] = $stored['items'];
+    }
+
+    $options = PublicKeyCredentialRequestOptions::create(
+        challenge: $challenge,
+        rpId: $container->relyingPartyId,
+        userVerification: 'required',
+        allowCredentials: $allowCredentials,
+        extensions: AuthenticationExtensions::create([$prfBuilder->build()]),
+    );
+    $options->timeout = 60_000;
+
+    echo json_encode([
+        'options' => json_decode($container->serializer->serialize($options, 'json', [
+            'json_encode_options' => \JSON_THROW_ON_ERROR,
+            \Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+        ]), true, flags: JSON_THROW_ON_ERROR),
+        // Hand the stored items back at the same time so the browser can decrypt
+        // them right after the assertion completes. Sent in clear; without the
+        // PRF-derived key they are just noise.
+        'itemsByCredential' => $items,
+    ], JSON_THROW_ON_ERROR);
+}
+
+function vaultVerify(Container $container): void
+{
+    $body = file_get_contents('php://input') ?: '{}';
+    $credential = $container->serializer->deserialize($body, PublicKeyCredential::class, 'json');
+    \assert($credential instanceof PublicKeyCredential);
+
+    $response = $credential->response;
+    if (! $response instanceof AuthenticatorAssertionResponse) {
+        throw new \RuntimeException('Expected an AuthenticatorAssertionResponse.');
+    }
+
+    $challenge = $_SESSION['vault_challenge'] ?? null;
+    if (! is_string($challenge)) {
+        throw new \RuntimeException('Missing vault session — start over.');
+    }
+
+    $rawId = $credential->rawId;
+    $stored = $container->credentialStore->findByCredentialId($rawId);
+    if ($stored === null) {
+        throw new \RuntimeException('Unknown credential.');
+    }
+    $userHandle = $container->credentialStore->findUserHandleByCredentialId($rawId);
+
+    $options = PublicKeyCredentialRequestOptions::create(
+        challenge: $challenge,
+        rpId: $container->relyingPartyId,
+        userVerification: 'required',
+    );
+
+    $updatedRecord = $container->assertionValidator->check(
+        $stored['record'],
+        $response,
+        $options,
+        $container->relyingPartyId,
+        $userHandle,
+    );
+    $container->credentialStore->updateAfterAssertion($updatedRecord);
+
+    // Mark the vault unlocked for this credential. Subsequent add/delete calls
+    // require this flag — without it any cookie holder could pollute another
+    // user's vault. The flag is bound to the assertion challenge, so it expires
+    // naturally once the next /api/vault/options is called (which rotates it).
+    $_SESSION['vault_unlocked'] = base64_encode($rawId);
+
+    echo json_encode([
+        'verified' => true,
+        'credentialId' => Base64::encode($rawId),
+    ], JSON_THROW_ON_ERROR);
+}
+
+function requireUnlocked(): string
+{
+    $unlocked = $_SESSION['vault_unlocked'] ?? null;
+    if (! is_string($unlocked) || $unlocked === '') {
+        throw new \RuntimeException('Vault is locked — authenticate first.');
+    }
+
+    return (string) base64_decode($unlocked, true);
+}
+
+function vaultItemAdd(Container $container): void
+{
+    $credentialId = requireUnlocked();
+    $body = readJson();
+    $label = trim((string) ($body['label'] ?? ''));
+    $ciphertext = (string) ($body['ciphertext'] ?? '');
+    $iv = (string) ($body['iv'] ?? '');
+    $mac = (string) ($body['mac'] ?? '');
+    if ($label === '' || $ciphertext === '' || $iv === '' || $mac === '') {
+        throw new \RuntimeException('label, ciphertext, iv and mac are all required.');
+    }
+
+    $id = $container->credentialStore->appendItem($credentialId, $label, $ciphertext, $iv, $mac);
+
+    echo json_encode([
+        'id' => $id,
+        'label' => $label,
+        'ciphertext' => $ciphertext,
+        'iv' => $iv,
+        'mac' => $mac,
+    ], JSON_THROW_ON_ERROR);
+}
+
+function vaultItemDelete(Container $container): void
+{
+    $credentialId = requireUnlocked();
+    $body = readJson();
+    $itemId = (string) ($body['id'] ?? '');
+    if ($itemId === '') {
+        throw new \RuntimeException('id is required.');
+    }
+
+    $container->credentialStore->deleteItem($credentialId, $itemId);
+
+    echo json_encode(['deleted' => $itemId], JSON_THROW_ON_ERROR);
+}

--- a/docs/examples/prf-demo/same-origin/run.sh
+++ b/docs/examples/prf-demo/same-origin/run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Boot the same-origin PRF demo on http://localhost:8000.
+# Usage:  ./same-origin/run.sh   (from docs/examples/prf-demo/)
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [[ ! -d vendor ]]; then
+    echo "▶ vendor/ missing — running composer install"
+    composer install --no-interaction
+fi
+
+PORT=8000
+
+is_busy() { lsof -i ":$1" >/dev/null 2>&1 || ss -ltn 2>/dev/null | grep -q ":$1 "; }
+if is_busy "$PORT"; then
+    echo "✗ Port $PORT already in use. Free it and retry." >&2
+    exit 1
+fi
+
+cleanup() {
+    echo
+    echo "▶ Stopping server…"
+    [[ -n "${PID:-}" ]] && kill "$PID" 2>/dev/null || true
+    wait 2>/dev/null || true
+}
+trap cleanup INT TERM EXIT
+
+echo "▶ PRF demo (same-origin) → http://localhost:$PORT"
+echo
+echo "Steps:"
+echo "  1. open http://localhost:$PORT/register.html  (register a credential with PRF — online)"
+echo "  2. open http://localhost:$PORT/vault.html     (unlock + add/decrypt items — online)"
+echo "  3. open http://localhost:$PORT/offline.html   (server-free vault: localStorage + service worker)"
+echo
+echo "Logs follow. Ctrl+C to stop."
+echo "──────────────────────────────────────────────────────"
+
+php -S "localhost:$PORT" -t same-origin/public same-origin/router.php &
+PID=$!
+
+wait

--- a/docs/examples/prf-demo/src/CredentialStore.php
+++ b/docs/examples/prf-demo/src/CredentialStore.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\PrfDemo;
+
+use Symfony\Component\Serializer\Serializer;
+use Webauthn\CredentialRecord;
+
+/**
+ * Demo-only credential + vault storage. Persists CredentialRecords plus a list of
+ * client-encrypted vault items (ciphertext, IV, label) to a JSON file so the demo
+ * survives across HTTP requests with `php -S` without needing a database.
+ *
+ * Each credential owns its PRF salt and an array of `items`. Items are opaque to
+ * the server — only the browser can decrypt them.
+ *
+ * Production code MUST use a real persistence layer behind
+ * `Webauthn\CredentialRecordRepositoryInterface` and store the encrypted vault
+ * in its own table.
+ */
+final class CredentialStore
+{
+    public function __construct(
+        private readonly string $file,
+        private readonly Serializer $serializer,
+    ) {
+        $dir = dirname($this->file);
+        if (! is_dir($dir)) {
+            mkdir($dir, 0o755, true);
+        }
+        if (! file_exists($this->file)) {
+            file_put_contents($this->file, '[]');
+        }
+    }
+
+    /**
+     * @return array<string, array{userHandle: string, credentialId: string, source: string, prfSalt: string, prfSalt2: string, items: list<array{id: string, label: string, ciphertext: string, iv: string, mac: string, createdAt: int}>}>
+     */
+    private function readAll(): array
+    {
+        $raw = (string) file_get_contents($this->file);
+        $data = json_decode($raw, true);
+        if (! is_array($data)) {
+            return [];
+        }
+        // Backfill missing fields for rows written by an older version of the demo so
+        // the typed array shape stays consistent across reads.
+        foreach ($data as $key => $row) {
+            if (! isset($row['items']) || ! is_array($row['items'])) {
+                $data[$key]['items'] = [];
+            }
+            if (! isset($row['prfSalt2'])) {
+                $data[$key]['prfSalt2'] = '';
+            }
+            foreach ($data[$key]['items'] as $i => $item) {
+                if (! isset($item['mac'])) {
+                    $data[$key]['items'][$i]['mac'] = '';
+                }
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param array<string, array{userHandle: string, credentialId: string, source: string, prfSalt: string, prfSalt2: string, items: list<array{id: string, label: string, ciphertext: string, iv: string, mac: string, createdAt: int}>}> $data
+     */
+    private function writeAll(array $data): void
+    {
+        file_put_contents($this->file, json_encode($data, \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * Store the freshly registered credential alongside the per-credential PRF salts
+     * the relying party will re-issue at every authentication. The salts are part of
+     * the encryption derivation but they are not the secret — only the PRF *output*
+     * computed by the authenticator is — so storing them in plaintext is fine.
+     *
+     * Two salts are persisted to demonstrate the full PRF input shape: `first` feeds
+     * the AES-GCM data key, `second` is available for any independent derivation
+     * (HMAC over labels, secondary key, …). The browser receives both at every
+     * ceremony so it can recompute both outputs in a single authenticator call.
+     */
+    public function save(string $userHandle, CredentialRecord $record, string $prfSalt, string $prfSalt2): void
+    {
+        $key = base64_encode($record->publicKeyCredentialId);
+        $all = $this->readAll();
+        $all[$key] = [
+            'userHandle' => base64_encode($userHandle),
+            'credentialId' => base64_encode($record->publicKeyCredentialId),
+            'source' => $this->serializer->serialize($record, 'json'),
+            'prfSalt' => base64_encode($prfSalt),
+            'prfSalt2' => base64_encode($prfSalt2),
+            'items' => [],
+        ];
+        $this->writeAll($all);
+    }
+
+    /**
+     * Append a vault item (ciphertext + IV + label HMAC, all computed by the browser) to
+     * the credential. The HMAC is opaque to the server: it lets the page detect, after
+     * a future unlock, that the server (or a tamperer) silently changed the label or
+     * the ciphertext bytes.
+     *
+     * Returns the generated item id so the page can address it.
+     */
+    public function appendItem(string $credentialId, string $label, string $ciphertextB64Url, string $ivB64Url, string $macB64Url): string
+    {
+        $key = base64_encode($credentialId);
+        $all = $this->readAll();
+        if (! isset($all[$key])) {
+            throw new \RuntimeException('Unknown credential.');
+        }
+        $id = bin2hex(random_bytes(8));
+        $all[$key]['items'][] = [
+            'id' => $id,
+            'label' => $label,
+            'ciphertext' => $ciphertextB64Url,
+            'iv' => $ivB64Url,
+            'mac' => $macB64Url,
+            'createdAt' => time(),
+        ];
+        $this->writeAll($all);
+
+        return $id;
+    }
+
+    public function deleteItem(string $credentialId, string $itemId): void
+    {
+        $key = base64_encode($credentialId);
+        $all = $this->readAll();
+        if (! isset($all[$key])) {
+            return;
+        }
+        $all[$key]['items'] = array_values(array_filter(
+            $all[$key]['items'],
+            static fn (array $item): bool => $item['id'] !== $itemId,
+        ));
+        $this->writeAll($all);
+    }
+
+    /**
+     * @return string[] base64-encoded credential IDs registered for the user.
+     */
+    public function credentialIdsForUser(string $userHandle): array
+    {
+        $needle = base64_encode($userHandle);
+        $ids = [];
+        foreach ($this->readAll() as $row) {
+            if ($row['userHandle'] === $needle) {
+                $ids[] = $row['credentialId'];
+            }
+        }
+
+        return $ids;
+    }
+
+    /**
+     * @return array{record: CredentialRecord, prfSalt: string, prfSalt2: string, items: list<array{id: string, label: string, ciphertext: string, iv: string, mac: string, createdAt: int}>}|null
+     */
+    public function findByCredentialId(string $credentialId): ?array
+    {
+        $key = base64_encode($credentialId);
+        $row = $this->readAll()[$key] ?? null;
+        if ($row === null) {
+            return null;
+        }
+
+        $record = $this->serializer->deserialize($row['source'], CredentialRecord::class, 'json');
+
+        return [
+            'record' => $record,
+            'prfSalt' => (string) base64_decode($row['prfSalt'], true),
+            'prfSalt2' => $row['prfSalt2'] === '' ? '' : (string) base64_decode($row['prfSalt2'], true),
+            'items' => $row['items'],
+        ];
+    }
+
+    public function findUserHandleByCredentialId(string $credentialId): ?string
+    {
+        $key = base64_encode($credentialId);
+        $row = $this->readAll()[$key] ?? null;
+
+        return $row === null ? null : (string) base64_decode($row['userHandle'], true);
+    }
+
+    public function updateAfterAssertion(CredentialRecord $record): void
+    {
+        $key = base64_encode($record->publicKeyCredentialId);
+        $all = $this->readAll();
+        if (! isset($all[$key])) {
+            return;
+        }
+        $all[$key]['source'] = $this->serializer->serialize($record, 'json');
+        $this->writeAll($all);
+    }
+}

--- a/docs/examples/prf-demo/src/bootstrap.php
+++ b/docs/examples/prf-demo/src/bootstrap.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\PrfDemo;
+
+use Cose\Algorithm\Manager;
+use Cose\Algorithm\Signature\ECDSA\ES256;
+use Cose\Algorithm\Signature\RSA\RS256;
+use Symfony\Component\Serializer\Serializer;
+use Webauthn\AttestationStatement\AttestationStatementSupportManager;
+use Webauthn\AttestationStatement\NoneAttestationStatementSupport;
+use Webauthn\AuthenticatorAssertionResponseValidator;
+use Webauthn\AuthenticatorAttestationResponseValidator;
+use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
+use Webauthn\Denormalizer\WebauthnSerializerFactory;
+
+// Two ways to load the lib:
+//   1. Standalone — `composer install` in this directory pulls
+//      web-auth/webauthn-lib >= 5.4 into ./vendor.
+//   2. Inside the monorepo — fall back to the framework's own
+//      vendor/autoload.php which exposes the lib via PSR-4.
+$autoloads = [
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../../vendor/autoload.php',
+];
+$loaded = false;
+foreach ($autoloads as $autoload) {
+    if (is_file($autoload)) {
+        require_once $autoload;
+        $loaded = true;
+        break;
+    }
+}
+if (! $loaded) {
+    fwrite(\STDERR, "Run `composer install` in docs/examples/prf-demo/ first.\n");
+    exit(1);
+}
+
+/**
+ * Wires the minimum the PRF demo needs: serializer, attestation/assertion validators,
+ * and a JSON-file credential + ciphertext store.
+ *
+ * Note: the framework does not validate `clientExtensionResults.prf.results` server-side
+ * (and should not — the PRF output is a secret that lives in the browser only). We just
+ * have to surface the PRF inputs in the options sent to the browser; the rest is Web Crypto
+ * inside the page.
+ */
+final class Container
+{
+    public string $relyingPartyId;
+    public string $relyingPartyName;
+    /** @var string[] */
+    public array $allowedOrigins;
+
+    public AttestationStatementSupportManager $attestationManager;
+    public Manager $algorithmManager;
+    public CeremonyStepManagerFactory $ceremonyFactory;
+    public AuthenticatorAttestationResponseValidator $attestationValidator;
+    public AuthenticatorAssertionResponseValidator $assertionValidator;
+    public Serializer $serializer;
+    public CredentialStore $credentialStore;
+
+    public function __construct()
+    {
+        $this->relyingPartyId = $_ENV['RP_ID'] ?? 'localhost';
+        $this->relyingPartyName = 'PRF Demo Vault';
+        $this->allowedOrigins = explode(',', $_ENV['ALLOWED_ORIGINS'] ?? 'http://localhost:8000');
+
+        $this->attestationManager = new AttestationStatementSupportManager();
+        $this->attestationManager->add(new NoneAttestationStatementSupport());
+
+        $this->algorithmManager = Manager::create()->add(ES256::create(), RS256::create());
+
+        $serializer = (new WebauthnSerializerFactory($this->attestationManager))->create();
+        \assert($serializer instanceof Serializer);
+        $this->serializer = $serializer;
+
+        $this->ceremonyFactory = new CeremonyStepManagerFactory();
+        $this->ceremonyFactory->setAttestationStatementSupportManager($this->attestationManager);
+        $this->ceremonyFactory->setAlgorithmManager($this->algorithmManager);
+        $this->ceremonyFactory->setAllowedOrigins($this->allowedOrigins);
+
+        $this->attestationValidator = AuthenticatorAttestationResponseValidator::create(
+            ceremonyStepManager: $this->ceremonyFactory->creationCeremony(),
+        );
+        $this->assertionValidator = AuthenticatorAssertionResponseValidator::create(
+            ceremonyStepManager: $this->ceremonyFactory->requestCeremony(),
+        );
+
+        $varDir = $_ENV['VAR_DIR'] ?? __DIR__ . '/../var';
+        $this->credentialStore = new CredentialStore($varDir . '/credentials.json', $this->serializer);
+    }
+}

--- a/src/stimulus/assets/src/controller.js
+++ b/src/stimulus/assets/src/controller.js
@@ -237,7 +237,7 @@ export default class extends Controller {
 
     _processPrfInput(prf) {
         if (prf.eval) {
-            prf.eval = this._importPrfValues(eval);
+            prf.eval = this._importPrfValues(prf.eval);
         }
 
         if (prf.evalByCredential) {
@@ -250,42 +250,44 @@ export default class extends Controller {
     }
 
     _importPrfValues(values) {
-        values.first = base64URLStringToBuffer(values.first);
+        const result = { ...values };
+        result.first = base64URLStringToBuffer(values.first);
         if (values.second) {
-            values.second = base64URLStringToBuffer(values.second);
+            result.second = base64URLStringToBuffer(values.second);
         }
 
-        return values;
+        return result;
     }
 
-    _processExtensionsOutput(options) {
-        if (!options || !options.extensions) {
-            return options;
+    _processExtensionsOutput(credential) {
+        if (!credential || !credential.clientExtensionResults) {
+            return credential;
         }
 
-        if (options.extensions.prf) {
-            options.extensions.prf = this._processPrfOutput(options.extensions.prf);
+        if (credential.clientExtensionResults.prf) {
+            credential.clientExtensionResults.prf = this._processPrfOutput(credential.clientExtensionResults.prf);
         }
 
-        return options;
+        return credential;
     }
 
     _processPrfOutput(prf) {
-        if (!prf.result) {
+        if (!prf.results) {
             return prf;
         }
 
-        prf.result = this._exportPrfValues(prf.result);
+        prf.results = this._exportPrfValues(prf.results);
 
         return prf;
     }
 
     _exportPrfValues(values) {
-        values.first = bufferToBase64URLString(values.first);
+        const result = { ...values };
+        result.first = bufferToBase64URLString(values.first);
         if (values.second) {
-            values.second = bufferToBase64URLString(values.second);
+            result.second = bufferToBase64URLString(values.second);
         }
 
-        return values;
+        return result;
     }
 }

--- a/src/stimulus/assets/test/authentication-controller.test.js
+++ b/src/stimulus/assets/test/authentication-controller.test.js
@@ -6,8 +6,19 @@ import { clearDOM, mountDOM } from '@symfony/stimulus-testing';
 import * as SimpleWebAuthnBrowser from '@simplewebauthn/browser';
 import AuthenticationController from '../src/authentication-controller';
 
-// Mock @simplewebauthn/browser
-jest.mock('@simplewebauthn/browser');
+// Mock @simplewebauthn/browser but keep base64 helpers + WebAuthnError real so PRF
+// processing in BaseController and `instanceof WebAuthnError` checks behave normally.
+jest.mock('@simplewebauthn/browser', () => {
+    const actual = jest.requireActual('@simplewebauthn/browser');
+    return {
+        ...actual,
+        browserSupportsWebAuthn: jest.fn(),
+        browserSupportsWebAuthnAutofill: jest.fn(),
+        platformAuthenticatorIsAvailable: jest.fn(),
+        startAuthentication: jest.fn(),
+        WebAuthnAbortService: { cancelCeremony: jest.fn() },
+    };
+});
 
 const startStimulus = () => {
     const application = Application.start();
@@ -506,6 +517,111 @@ describe('AuthenticationController', () => {
                     'verify:success',
                 ]);
             });
+        });
+    });
+
+    describe('PRF extension', () => {
+        const PRF_SALT_BYTES = new Uint8Array(32).fill(0x41).buffer;
+        const PRF_SALT_B64 = SimpleWebAuthnBrowser.bufferToBase64URLString(PRF_SALT_BYTES);
+
+        it('decodes evalByCredential salts to ArrayBuffer before calling startAuthentication', async () => {
+            const form = getByTestId(container, 'authentication-form');
+
+            fetchMock
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => ({
+                        challenge: 'test',
+                        extensions: {
+                            prf: {
+                                evalByCredential: {
+                                    'credential-id-base64url': { first: PRF_SALT_B64 },
+                                },
+                            },
+                        },
+                    }),
+                })
+                .mockResolvedValueOnce({ ok: true, json: async () => ({ verified: true }) });
+
+            SimpleWebAuthnBrowser.startAuthentication.mockResolvedValue({ id: 'cred' });
+
+            const connectionPromise = waitForConnection(form);
+            application = startStimulus();
+            await connectionPromise;
+            submitForm(form);
+
+            await waitFor(() => {
+                expect(SimpleWebAuthnBrowser.startAuthentication).toHaveBeenCalled();
+            });
+
+            const passed = SimpleWebAuthnBrowser.startAuthentication.mock.calls[0][0].optionsJSON
+                .extensions.prf.evalByCredential['credential-id-base64url'];
+            expect(passed.first).toBeInstanceOf(ArrayBuffer);
+            expect(passed.first.byteLength).toBe(32);
+        });
+
+        it('exposes PRF results as base64url on the dispatched credential event', async () => {
+            const form = getByTestId(container, 'authentication-form');
+
+            const credentialEvents = [];
+            form.addEventListener('webauthn:authentication:credential', (e) => {
+                credentialEvents.push(e.detail.credential);
+            });
+
+            fetchMock
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => ({
+                        challenge: 'test',
+                        extensions: { prf: { eval: { first: PRF_SALT_B64 } } },
+                    }),
+                })
+                .mockResolvedValueOnce({ ok: true, json: async () => ({ verified: true }) });
+
+            SimpleWebAuthnBrowser.startAuthentication.mockResolvedValue({
+                id: 'cred',
+                clientExtensionResults: {
+                    prf: { results: { first: PRF_SALT_BYTES } },
+                },
+            });
+
+            const connectionPromise = waitForConnection(form);
+            application = startStimulus();
+            await connectionPromise;
+            submitForm(form);
+
+            await waitFor(() => {
+                expect(credentialEvents).toHaveLength(1);
+            });
+            expect(credentialEvents[0].clientExtensionResults.prf.results.first).toBe(PRF_SALT_B64);
+        });
+
+        it('passes through credentials that do not use PRF', async () => {
+            const form = getByTestId(container, 'authentication-form');
+
+            const credentialEvents = [];
+            form.addEventListener('webauthn:authentication:credential', (e) => {
+                credentialEvents.push(e.detail.credential);
+            });
+
+            fetchMock
+                .mockResolvedValueOnce({ ok: true, json: async () => ({ challenge: 'test' }) })
+                .mockResolvedValueOnce({ ok: true, json: async () => ({ verified: true }) });
+
+            SimpleWebAuthnBrowser.startAuthentication.mockResolvedValue({
+                id: 'cred',
+                clientExtensionResults: {},
+            });
+
+            const connectionPromise = waitForConnection(form);
+            application = startStimulus();
+            await connectionPromise;
+            submitForm(form);
+
+            await waitFor(() => {
+                expect(credentialEvents).toHaveLength(1);
+            });
+            expect(credentialEvents[0].clientExtensionResults).toEqual({});
         });
     });
 });

--- a/src/stimulus/assets/test/registration-controller.test.js
+++ b/src/stimulus/assets/test/registration-controller.test.js
@@ -6,8 +6,18 @@ import { clearDOM, mountDOM } from '@symfony/stimulus-testing';
 import * as SimpleWebAuthnBrowser from '@simplewebauthn/browser';
 import RegistrationController from '../src/registration-controller';
 
-// Mock @simplewebauthn/browser
-jest.mock('@simplewebauthn/browser');
+// Mock @simplewebauthn/browser but keep base64 helpers + WebAuthnError real so PRF
+// processing in BaseController and `instanceof WebAuthnError` checks behave normally.
+jest.mock('@simplewebauthn/browser', () => {
+    const actual = jest.requireActual('@simplewebauthn/browser');
+    return {
+        ...actual,
+        browserSupportsWebAuthn: jest.fn(),
+        platformAuthenticatorIsAvailable: jest.fn(),
+        startRegistration: jest.fn(),
+        WebAuthnAbortService: { cancelCeremony: jest.fn() },
+    };
+});
 
 const startStimulus = () => {
     const application = Application.start();
@@ -659,6 +669,154 @@ describe('RegistrationController', () => {
                 expect(errorDetail.error.name).toBe('NotReadableError');
                 expect(errorDetail.error.message).toBe('Authenticator not responding');
             });
+        });
+    });
+
+    describe('PRF extension', () => {
+        // 32 bytes of 0x41 ('A') round-tripped through the same helper the controller uses,
+        // so the assertions stay in sync if SimpleWebAuthn ever changes its base64url output.
+        const PRF_SALT_BYTES = new Uint8Array(32).fill(0x41).buffer;
+        const PRF_SALT_B64 = SimpleWebAuthnBrowser.bufferToBase64URLString(PRF_SALT_BYTES);
+
+        it('decodes base64url PRF inputs to ArrayBuffer before calling startRegistration', async () => {
+            const form = getByTestId(container, 'registration-form');
+
+            fetchMock
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => ({
+                        challenge: 'test',
+                        rp: {},
+                        user: {},
+                        extensions: { prf: { eval: { first: PRF_SALT_B64 } } },
+                    }),
+                })
+                .mockResolvedValueOnce({ ok: true, json: async () => ({ verified: true }) });
+
+            SimpleWebAuthnBrowser.startRegistration.mockResolvedValue({ id: 'cred' });
+
+            const connectionPromise = waitForConnection(form);
+            application = startStimulus();
+            await connectionPromise;
+            submitForm(form);
+
+            await waitFor(() => {
+                expect(SimpleWebAuthnBrowser.startRegistration).toHaveBeenCalled();
+            });
+
+            const call = SimpleWebAuthnBrowser.startRegistration.mock.calls[0][0];
+            const first = call.optionsJSON.extensions.prf.eval.first;
+            expect(first).toBeInstanceOf(ArrayBuffer);
+            expect(first.byteLength).toBe(32);
+            expect(new Uint8Array(first).every((b) => b === 0x41)).toBe(true);
+        });
+
+        it('encodes PRF results from ArrayBuffer back to base64url on the returned credential', async () => {
+            const form = getByTestId(container, 'registration-form');
+            const prfBytes = PRF_SALT_BYTES;
+
+            const credentialEvents = [];
+            form.addEventListener('webauthn:registration:credential', (e) => {
+                credentialEvents.push(e.detail.credential);
+            });
+
+            fetchMock
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => ({
+                        challenge: 'test',
+                        rp: {},
+                        user: {},
+                        extensions: { prf: { eval: { first: PRF_SALT_B64 } } },
+                    }),
+                })
+                .mockResolvedValueOnce({ ok: true, json: async () => ({ verified: true }) });
+
+            SimpleWebAuthnBrowser.startRegistration.mockResolvedValue({
+                id: 'cred',
+                clientExtensionResults: {
+                    prf: { enabled: true, results: { first: prfBytes } },
+                },
+            });
+
+            const connectionPromise = waitForConnection(form);
+            application = startStimulus();
+            await connectionPromise;
+            submitForm(form);
+
+            await waitFor(() => {
+                expect(credentialEvents).toHaveLength(1);
+            });
+            expect(credentialEvents[0].clientExtensionResults.prf.enabled).toBe(true);
+            expect(credentialEvents[0].clientExtensionResults.prf.results.first).toBe(PRF_SALT_B64);
+        });
+
+        it('decodes per-credential PRF inputs (evalByCredential)', async () => {
+            const form = getByTestId(container, 'registration-form');
+
+            fetchMock
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => ({
+                        challenge: 'test',
+                        rp: {},
+                        user: {},
+                        extensions: {
+                            prf: {
+                                evalByCredential: {
+                                    'cred-1': { first: PRF_SALT_B64, second: PRF_SALT_B64 },
+                                },
+                            },
+                        },
+                    }),
+                })
+                .mockResolvedValueOnce({ ok: true, json: async () => ({ verified: true }) });
+
+            SimpleWebAuthnBrowser.startRegistration.mockResolvedValue({ id: 'cred' });
+
+            const connectionPromise = waitForConnection(form);
+            application = startStimulus();
+            await connectionPromise;
+            submitForm(form);
+
+            await waitFor(() => {
+                expect(SimpleWebAuthnBrowser.startRegistration).toHaveBeenCalled();
+            });
+            const inputs = SimpleWebAuthnBrowser.startRegistration.mock.calls[0][0].optionsJSON
+                .extensions.prf.evalByCredential['cred-1'];
+            expect(inputs.first).toBeInstanceOf(ArrayBuffer);
+            expect(inputs.second).toBeInstanceOf(ArrayBuffer);
+        });
+
+        it('passes through credentials that do not use PRF', async () => {
+            const form = getByTestId(container, 'registration-form');
+
+            const credentialEvents = [];
+            form.addEventListener('webauthn:registration:credential', (e) => {
+                credentialEvents.push(e.detail.credential);
+            });
+
+            fetchMock
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => ({ challenge: 'test', rp: {}, user: {} }),
+                })
+                .mockResolvedValueOnce({ ok: true, json: async () => ({ verified: true }) });
+
+            SimpleWebAuthnBrowser.startRegistration.mockResolvedValue({
+                id: 'cred',
+                clientExtensionResults: {},
+            });
+
+            const connectionPromise = waitForConnection(form);
+            application = startStimulus();
+            await connectionPromise;
+            submitForm(form);
+
+            await waitFor(() => {
+                expect(credentialEvents).toHaveLength(1);
+            });
+            expect(credentialEvents[0].clientExtensionResults).toEqual({});
         });
     });
 });

--- a/src/webauthn/src/AuthenticationExtensions/PseudoRandomFunctionInputExtensionBuilder.php
+++ b/src/webauthn/src/AuthenticationExtensions/PseudoRandomFunctionInputExtensionBuilder.php
@@ -6,7 +6,27 @@ namespace Webauthn\AuthenticationExtensions;
 
 use function array_key_exists;
 use ParagonIE\ConstantTime\Base64UrlSafe;
+use Webauthn\Exception\AuthenticationExtensionException;
 
+/**
+ * Fluent builder for the WebAuthn `prf` extension input.
+ *
+ * The Pseudo-Random Function (PRF) extension lets the relying party derive an
+ * authenticator-bound, salt-bound secret on the client. The inputs assembled by
+ * this builder become `extensions.prf` on the {@see \Webauthn\PublicKeyCredentialCreationOptions}
+ * or {@see \Webauthn\PublicKeyCredentialRequestOptions} returned to the browser; the
+ * Stimulus base controller decodes them to ArrayBuffers before the
+ * `navigator.credentials.{create,get}()` call.
+ *
+ * Typical use — server-driven encryption key derivation:
+ * ```php
+ * $options->extensions[] = PseudoRandomFunctionInputExtensionBuilder::create()
+ *     ->withInputs($salt) // 32 random bytes from your KMS / generated per user
+ *     ->build();
+ * ```
+ *
+ * @see https://www.w3.org/TR/webauthn-3/#prf-extension
+ */
 final class PseudoRandomFunctionInputExtensionBuilder
 {
     /**
@@ -23,6 +43,14 @@ final class PseudoRandomFunctionInputExtensionBuilder
         return new self();
     }
 
+    /**
+     * Set the global PRF inputs. Used during registration when the credential is
+     * not yet known, and as a fallback during authentication when a credential is
+     * not covered by {@see self::withCredentialInputs()}.
+     *
+     * @param string $first  Raw salt bytes (typically 32). Encoded to base64url before transport.
+     * @param string|null $second Optional second raw salt bytes; produces `results.second` in the browser output.
+     */
     public function withInputs(string $first, null|string $second = null): self
     {
         $eval = [
@@ -36,6 +64,18 @@ final class PseudoRandomFunctionInputExtensionBuilder
         return $this;
     }
 
+    /**
+     * Set per-credential PRF inputs. Preferred during authentication so each
+     * credential can be queried with its own salt (e.g. a salt rotated alongside
+     * a re-encrypted blob).
+     *
+     * @param string $credentialId Raw credential id bytes (the same bytes that appear in
+     *                              {@see \Webauthn\PublicKeyCredentialDescriptor::$id}); the W3C spec
+     *                              expects the key to be a base64url string. Pre-encode if you only
+     *                              hold the base64url form.
+     * @param string $first  Raw salt bytes for this credential.
+     * @param string|null $second Optional second raw salt bytes.
+     */
     public function withCredentialInputs(string $credentialId, string $first, null|string $second = null): self
     {
         $eval = [
@@ -52,8 +92,20 @@ final class PseudoRandomFunctionInputExtensionBuilder
         return $this;
     }
 
+    /**
+     * @throws AuthenticationExtensionException if neither `eval` nor `evalByCredential`
+     *                                          inputs were provided — sending an empty PRF
+     *                                          extension to the browser is a programming
+     *                                          error that would silently produce no result.
+     */
     public function build(): PseudoRandomFunctionInputExtension
     {
+        if ($this->values === []) {
+            throw AuthenticationExtensionException::create(
+                'Cannot build a PRF extension without any input. Call withInputs() or withCredentialInputs() first.'
+            );
+        }
+
         return new PseudoRandomFunctionInputExtension('prf', $this->values);
     }
 }

--- a/tests/library/Unit/AuthenticationExtensions/PseudoRandomFunctionInputExtensionBuilderTest.php
+++ b/tests/library/Unit/AuthenticationExtensions/PseudoRandomFunctionInputExtensionBuilderTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Unit\AuthenticationExtensions;
+
+use ParagonIE\ConstantTime\Base64UrlSafe;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+use Webauthn\AuthenticationExtensions\PseudoRandomFunctionInputExtension;
+use Webauthn\AuthenticationExtensions\PseudoRandomFunctionInputExtensionBuilder;
+use Webauthn\Exception\AuthenticationExtensionException;
+use Webauthn\Tests\AbstractTestCase;
+
+/**
+ * @internal
+ */
+final class PseudoRandomFunctionInputExtensionBuilderTest extends AbstractTestCase
+{
+    #[Test]
+    public function builderProducesPrfExtensionNamedPrf(): void
+    {
+        $extension = PseudoRandomFunctionInputExtensionBuilder::create()
+            ->withInputs('salt-bytes')
+            ->build();
+
+        static::assertInstanceOf(PseudoRandomFunctionInputExtension::class, $extension);
+        static::assertSame('prf', $extension->name);
+    }
+
+    #[Test]
+    public function singleInputIsBase64UrlEncodedUnderEvalFirst(): void
+    {
+        $raw = "\x00\x01\x02\x03salty";
+        $extension = PseudoRandomFunctionInputExtensionBuilder::create()
+            ->withInputs($raw)
+            ->build();
+
+        static::assertSame([
+            'eval' => [
+                'first' => Base64UrlSafe::encodeUnpadded($raw),
+            ],
+        ], $extension->value);
+    }
+
+    #[Test]
+    public function bothEvalInputsAreEncoded(): void
+    {
+        $first = 'first-salt';
+        $second = 'second-salt';
+        $extension = PseudoRandomFunctionInputExtensionBuilder::create()
+            ->withInputs($first, $second)
+            ->build();
+
+        static::assertSame([
+            'eval' => [
+                'first' => Base64UrlSafe::encodeUnpadded($first),
+                'second' => Base64UrlSafe::encodeUnpadded($second),
+            ],
+        ], $extension->value);
+    }
+
+    #[Test]
+    public function withCredentialInputsKeyedByCredentialId(): void
+    {
+        $extension = PseudoRandomFunctionInputExtensionBuilder::create()
+            ->withCredentialInputs('cred-A', 'salt-A')
+            ->withCredentialInputs('cred-B', 'salt-B', 'salt-B-2')
+            ->build();
+
+        static::assertSame([
+            'evalByCredential' => [
+                'cred-A' => [
+                    'first' => Base64UrlSafe::encodeUnpadded('salt-A'),
+                ],
+                'cred-B' => [
+                    'first' => Base64UrlSafe::encodeUnpadded('salt-B'),
+                    'second' => Base64UrlSafe::encodeUnpadded('salt-B-2'),
+                ],
+            ],
+        ], $extension->value);
+    }
+
+    #[Test]
+    public function evalAndEvalByCredentialCanCoexist(): void
+    {
+        $extension = PseudoRandomFunctionInputExtensionBuilder::create()
+            ->withInputs('default-salt')
+            ->withCredentialInputs('cred-A', 'specific-salt')
+            ->build();
+
+        static::assertSame([
+            'eval' => [
+                'first' => Base64UrlSafe::encodeUnpadded('default-salt'),
+            ],
+            'evalByCredential' => [
+                'cred-A' => [
+                    'first' => Base64UrlSafe::encodeUnpadded('specific-salt'),
+                ],
+            ],
+        ], $extension->value);
+    }
+
+    #[Test]
+    public function lastWriteWinsForRepeatedCalls(): void
+    {
+        $extension = PseudoRandomFunctionInputExtensionBuilder::create()
+            ->withInputs('first-salt')
+            ->withInputs('replacement-salt', 'replacement-second')
+            ->withCredentialInputs('cred', 'one')
+            ->withCredentialInputs('cred', 'two')
+            ->build();
+
+        static::assertSame([
+            'eval' => [
+                'first' => Base64UrlSafe::encodeUnpadded('replacement-salt'),
+                'second' => Base64UrlSafe::encodeUnpadded('replacement-second'),
+            ],
+            'evalByCredential' => [
+                'cred' => [
+                    'first' => Base64UrlSafe::encodeUnpadded('two'),
+                ],
+            ],
+        ], $extension->value);
+    }
+
+    #[Test]
+    public function buildingWithoutAnyInputThrows(): void
+    {
+        $this->expectException(AuthenticationExtensionException::class);
+        $this->expectExceptionMessage('Cannot build a PRF extension without any input');
+
+        PseudoRandomFunctionInputExtensionBuilder::create()->build();
+    }
+
+    #[Test]
+    public function extensionSerializesToTheJsonShapeExpectedByTheBrowser(): void
+    {
+        $extension = PseudoRandomFunctionInputExtensionBuilder::create()
+            ->withInputs('aaaa')
+            ->withCredentialInputs('cred', 'bbbb', 'cccc')
+            ->build();
+
+        $json = $this->getSerializer()
+            ->serialize($extension, 'json', [
+                AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+            ]);
+
+        static::assertJsonStringEqualsJsonString(
+            '{"eval":{"first":"YWFhYQ"},"evalByCredential":{"cred":{"first":"YmJiYg","second":"Y2NjYw"}}}',
+            $json
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- **Fixes** the legacy Stimulus controller's PRF handling (`prf.eval` reference + `prf.results` shape).
- **Hardens** `PseudoRandomFunctionInputExtensionBuilder`: `build()` now throws when no inputs were set, and every public method gets full PHPDoc (including the W3C-mandated base64url shape of `evalByCredential` keys).
- **Adds tests** — 8 PHPUnit cases for the builder, plus PRF input/output coverage (4 + 3 cases) on the non-legacy registration and authentication Stimulus controllers.
- **Adds `docs/examples/prf-demo/`** — a runnable end-to-end demo of client-side encryption built on the PRF extension, modelled on `docs/examples/spc-demo/`. Contains a manual browser walk-through (`register.html` → `vault.html` → `offline.html`, the last with DevTools throttled to "Offline" after first load) since CI cannot exercise a real authenticator.

## What's in the demo

Three pages on a single `php -S` server:

| Page | What it does |
|---|---|
| `register.html` | Register a credential against the relying party, with both PRF salts primed. On success, mirrors `{credId, prfSalt, prfSalt2}` to `localStorage` so `offline.html` can reuse the same passkey. |
| `vault.html` | Server-backed vault. Unlock derives an AES-GCM key from `prf.results.first` and an HMAC-SHA256 key from `prf.results.second` (HKDF, disjoint info strings). Every item is encrypted **and** HMAC'd client-side; reads recompute the HMAC and surface ✓ / ✗ per item. |
| `offline.html` | Same vault behaviour, **server-free** for the encrypt/decrypt loop. Reads credId + salts from `localStorage`, runs the PRF assertion against `rpId = location.hostname` with a locally-generated challenge, persists ciphertexts in `localStorage`. Companion service worker `sw.js` caches the page so it loads in airplane mode after a first online visit. |

The README walks through the architecture and surfaces Matt Miller's [May 2025 caveat](https://blog.millerti.me/2023/01/22/encrypting-data-in-the-browser-using-webauthn/) (deleting the passkey makes the encrypted data unrecoverable), since this is the single most footgun-y aspect of building real products on PRF.

## Notes on what's deliberately out of scope

- No Symfony bundle integration (profile config / DI service for PRF). Useful follow-up; tracked locally.
- No high-level offline-PRF Stimulus controller. The KDF / IV / storage choices are opinionated and don't belong in `webauthn-stimulus` itself; better explored in a PWA-focused bundle.
- Two pre-existing Jest failures (`window.location` redirect tests in registration / authentication controller tests) are **not touched** here; they should be fixed in a separate PR.