### PR TITLE
feat(extensions): parse credProps.authenticatorDisplayName (L3)

### DIFF
--- a/src/webauthn/src/AuthenticationExtensions/CredentialPropertiesOutput.php
+++ b/src/webauthn/src/AuthenticationExtensions/CredentialPropertiesOutput.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\AuthenticationExtensions;
+
+use function is_array;
+use function is_bool;
+use function is_string;
+use Webauthn\Exception\AuthenticationExtensionException;
+
+/**
+ * W3C WebAuthn L3 §10.1.3: typed view of the `credProps` client extension
+ * output. Exposes both `rk` (whether the credential is a discoverable
+ * credential / passkey) and `authenticatorDisplayName` (a human-friendly
+ * name suggested by the authenticator, added in Level 3).
+ *
+ * Use {@see fromExtensions()} or {@see fromExtension()} to materialise the
+ * value object from the raw extension bag returned by the client.
+ */
+final readonly class CredentialPropertiesOutput
+{
+    public function __construct(
+        public ?bool $rk,
+        public ?string $authenticatorDisplayName,
+    ) {
+    }
+
+    public static function create(?bool $rk, ?string $authenticatorDisplayName = null): self
+    {
+        return new self($rk, $authenticatorDisplayName);
+    }
+
+    public static function fromExtensions(AuthenticationExtensions $extensions): ?self
+    {
+        if (! $extensions->has('credProps')) {
+            return null;
+        }
+
+        return self::fromExtension($extensions->get('credProps'));
+    }
+
+    public static function fromExtension(AuthenticationExtension $extension): self
+    {
+        $extension->name === 'credProps' || throw AuthenticationExtensionException::create(
+            'The extension is not a "credProps" extension.'
+        );
+
+        $value = $extension->value;
+        if ($value === null) {
+            return new self(null, null);
+        }
+
+        is_array($value) || throw AuthenticationExtensionException::create(
+            'The "credProps" extension output must be an object/array.'
+        );
+
+        $rk = $value['rk'] ?? null;
+        $rk === null || is_bool($rk) || throw AuthenticationExtensionException::create(
+            'The "credProps.rk" output must be a boolean.'
+        );
+
+        $authenticatorDisplayName = $value['authenticatorDisplayName'] ?? null;
+        $authenticatorDisplayName === null || is_string(
+            $authenticatorDisplayName
+        ) || throw AuthenticationExtensionException::create(
+            'The "credProps.authenticatorDisplayName" output must be a string.'
+        );
+
+        return new self($rk, $authenticatorDisplayName);
+    }
+}

--- a/src/webauthn/src/AuthenticationExtensions/CredentialPropertiesOutputChecker.php
+++ b/src/webauthn/src/AuthenticationExtensions/CredentialPropertiesOutputChecker.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\AuthenticationExtensions;
+
+use function is_array;
+use function is_bool;
+use function is_string;
+use Webauthn\Exception\AuthenticatorResponseVerificationException;
+
+/**
+ * Validates the structure of the `credProps` client extension OUTPUT.
+ *
+ * Per W3C WebAuthn L3 §10.1.3 the output is a {@code CredentialPropertiesOutput}
+ * dictionary that may carry:
+ *  - `rk`: boolean — whether the credential is a discoverable credential
+ *    (passkey).
+ *  - `authenticatorDisplayName`: string — a human-readable label suggested
+ *    by the authenticator for the credential (added in Level 3).
+ *
+ * Both members are optional. The user agent may omit the extension output
+ * entirely if it does not support `credProps`; that is allowed and the
+ * checker stays silent in that case. When the output IS returned, this
+ * checker enforces that each present field has the right type so callers
+ * can rely on {@see CredentialPropertiesOutput} for typed access.
+ */
+final readonly class CredentialPropertiesOutputChecker implements ExtensionOutputChecker
+{
+    public function check(AuthenticationExtensions $inputs, AuthenticationExtensions $outputs): void
+    {
+        if (! $inputs->has('credProps')) {
+            return;
+        }
+
+        if (! $outputs->has('credProps')) {
+            return;
+        }
+
+        $rawOutput = $outputs->get('credProps')
+            ->value;
+        if ($rawOutput === null) {
+            return;
+        }
+
+        if (! is_array($rawOutput)) {
+            throw AuthenticatorResponseVerificationException::create('Invalid credProps extension output format.');
+        }
+
+        if (isset($rawOutput['rk']) && ! is_bool($rawOutput['rk'])) {
+            throw AuthenticatorResponseVerificationException::create(
+                'The credProps extension output "rk" field must be a boolean.',
+            );
+        }
+
+        if (isset($rawOutput['authenticatorDisplayName']) && ! is_string($rawOutput['authenticatorDisplayName'])) {
+            throw AuthenticatorResponseVerificationException::create(
+                'The credProps extension output "authenticatorDisplayName" field must be a string.',
+            );
+        }
+    }
+}

--- a/tests/library/Unit/AuthenticationExtensions/CredentialPropertiesOutputCheckerTest.php
+++ b/tests/library/Unit/AuthenticationExtensions/CredentialPropertiesOutputCheckerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Unit\AuthenticationExtensions;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Webauthn\AuthenticationExtensions\AuthenticationExtension;
+use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
+use Webauthn\AuthenticationExtensions\CredentialPropertiesInputExtension;
+use Webauthn\AuthenticationExtensions\CredentialPropertiesOutputChecker;
+use Webauthn\Exception\AuthenticatorResponseVerificationException;
+
+/**
+ * @internal
+ */
+final class CredentialPropertiesOutputCheckerTest extends TestCase
+{
+    #[Test]
+    public function credPropsNotRequestedShouldPass(): void
+    {
+        (new CredentialPropertiesOutputChecker())->check(
+            new AuthenticationExtensions([]),
+            new AuthenticationExtensions([
+                AuthenticationExtension::create('credProps', [
+                    'rk' => 'invalid-but-ignored',
+                ]),
+            ]),
+        );
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function credPropsRequestedButNotReturnedShouldPass(): void
+    {
+        (new CredentialPropertiesOutputChecker())->check(
+            new AuthenticationExtensions([CredentialPropertiesInputExtension::enable()]),
+            new AuthenticationExtensions([]),
+        );
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function credPropsOutputWithNullValueShouldPass(): void
+    {
+        (new CredentialPropertiesOutputChecker())->check(
+            new AuthenticationExtensions([CredentialPropertiesInputExtension::enable()]),
+            new AuthenticationExtensions([AuthenticationExtension::create('credProps', null)]),
+        );
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function nonArrayOutputShouldFail(): void
+    {
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+        $this->expectExceptionMessage('Invalid credProps extension output format');
+
+        (new CredentialPropertiesOutputChecker())->check(
+            new AuthenticationExtensions([CredentialPropertiesInputExtension::enable()]),
+            new AuthenticationExtensions([AuthenticationExtension::create('credProps', 'plain-string')]),
+        );
+    }
+
+    #[Test]
+    public function nonBooleanRkShouldFail(): void
+    {
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+        $this->expectExceptionMessage('"rk"');
+
+        (new CredentialPropertiesOutputChecker())->check(
+            new AuthenticationExtensions([CredentialPropertiesInputExtension::enable()]),
+            new AuthenticationExtensions([
+                AuthenticationExtension::create('credProps', [
+                    'rk' => 1,
+                ]),
+            ]),
+        );
+    }
+
+    #[Test]
+    public function nonStringAuthenticatorDisplayNameShouldFail(): void
+    {
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+        $this->expectExceptionMessage('"authenticatorDisplayName"');
+
+        (new CredentialPropertiesOutputChecker())->check(
+            new AuthenticationExtensions([CredentialPropertiesInputExtension::enable()]),
+            new AuthenticationExtensions([
+                AuthenticationExtension::create('credProps', [
+                    'rk' => true,
+                    'authenticatorDisplayName' => ['nope'],
+                ]),
+            ]),
+        );
+    }
+
+    #[Test]
+    public function fullyValidOutputShouldPass(): void
+    {
+        (new CredentialPropertiesOutputChecker())->check(
+            new AuthenticationExtensions([CredentialPropertiesInputExtension::enable()]),
+            new AuthenticationExtensions([
+                AuthenticationExtension::create('credProps', [
+                    'rk' => true,
+                    'authenticatorDisplayName' => 'Pixel 8',
+                ]),
+            ]),
+        );
+        $this->expectNotToPerformAssertions();
+    }
+}

--- a/tests/library/Unit/AuthenticationExtensions/CredentialPropertiesOutputTest.php
+++ b/tests/library/Unit/AuthenticationExtensions/CredentialPropertiesOutputTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Unit\AuthenticationExtensions;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Webauthn\AuthenticationExtensions\AuthenticationExtension;
+use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
+use Webauthn\AuthenticationExtensions\CredentialPropertiesOutput;
+use Webauthn\Exception\AuthenticationExtensionException;
+
+/**
+ * @internal
+ */
+final class CredentialPropertiesOutputTest extends TestCase
+{
+    #[Test]
+    public function fromExtensionsReturnsNullWhenCredPropsAbsent(): void
+    {
+        $extensions = new AuthenticationExtensions([]);
+
+        static::assertNull(CredentialPropertiesOutput::fromExtensions($extensions));
+    }
+
+    #[Test]
+    public function fromExtensionsParsesRkOnly(): void
+    {
+        $extensions = new AuthenticationExtensions([
+            AuthenticationExtension::create('credProps', [
+                'rk' => true,
+            ]),
+        ]);
+
+        $output = CredentialPropertiesOutput::fromExtensions($extensions);
+
+        static::assertNotNull($output);
+        static::assertTrue($output->rk);
+        static::assertNull($output->authenticatorDisplayName);
+    }
+
+    #[Test]
+    public function fromExtensionsParsesAuthenticatorDisplayName(): void
+    {
+        $extensions = new AuthenticationExtensions([
+            AuthenticationExtension::create('credProps', [
+                'rk' => true,
+                'authenticatorDisplayName' => 'My Phone',
+            ]),
+        ]);
+
+        $output = CredentialPropertiesOutput::fromExtensions($extensions);
+
+        static::assertNotNull($output);
+        static::assertTrue($output->rk);
+        static::assertSame('My Phone', $output->authenticatorDisplayName);
+    }
+
+    #[Test]
+    public function fromExtensionAcceptsAuthenticatorDisplayNameWithoutRk(): void
+    {
+        $output = CredentialPropertiesOutput::fromExtension(
+            AuthenticationExtension::create('credProps', [
+                'authenticatorDisplayName' => 'iCloud Keychain',
+            ]),
+        );
+
+        static::assertNull($output->rk);
+        static::assertSame('iCloud Keychain', $output->authenticatorDisplayName);
+    }
+
+    #[Test]
+    public function fromExtensionWithNullValueReturnsEmptyOutput(): void
+    {
+        $output = CredentialPropertiesOutput::fromExtension(AuthenticationExtension::create('credProps', null));
+
+        static::assertNull($output->rk);
+        static::assertNull($output->authenticatorDisplayName);
+    }
+
+    #[Test]
+    public function fromExtensionRejectsNonCredPropsExtension(): void
+    {
+        $this->expectException(AuthenticationExtensionException::class);
+        $this->expectExceptionMessage('not a "credProps"');
+
+        CredentialPropertiesOutput::fromExtension(AuthenticationExtension::create('appid', true));
+    }
+
+    #[Test]
+    public function fromExtensionRejectsScalarValue(): void
+    {
+        $this->expectException(AuthenticationExtensionException::class);
+        $this->expectExceptionMessage('object/array');
+
+        CredentialPropertiesOutput::fromExtension(AuthenticationExtension::create('credProps', 'oops'));
+    }
+
+    #[Test]
+    public function fromExtensionRejectsNonBooleanRk(): void
+    {
+        $this->expectException(AuthenticationExtensionException::class);
+        $this->expectExceptionMessage('"credProps.rk"');
+
+        CredentialPropertiesOutput::fromExtension(
+            AuthenticationExtension::create('credProps', [
+                'rk' => 'yes',
+            ]),
+        );
+    }
+
+    #[Test]
+    public function fromExtensionRejectsNonStringAuthenticatorDisplayName(): void
+    {
+        $this->expectException(AuthenticationExtensionException::class);
+        $this->expectExceptionMessage('"credProps.authenticatorDisplayName"');
+
+        CredentialPropertiesOutput::fromExtension(
+            AuthenticationExtension::create('credProps', [
+                'rk' => true,
+                'authenticatorDisplayName' => 12345,
+            ]),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #857.

WebAuthn L3 §10.1.3 added `authenticatorDisplayName` to the `credProps`
client extension output, alongside the existing `rk` flag (a friendly
name suggested by the authenticator for the credential).

This PR exposes both fields:

- **`CredentialPropertiesOutput`** — typed value object with `rk: ?bool`
  and `authenticatorDisplayName: ?string`. Static factories
  `fromExtensions(AuthenticationExtensions)` and
  `fromExtension(AuthenticationExtension)` materialise it from the raw
  client extension bag and reject malformed values.
- **`CredentialPropertiesOutputChecker`** — implements
  `ExtensionOutputChecker` and structurally validates the credProps
  output when the extension was requested. Mirrors the
  `PaymentExtensionOutputChecker` style. Stays silent when the user
  agent omits the output (allowed by the spec).

Both members are optional per spec, so the checker only enforces types
on the fields that are actually present.

A follow-up will document the use on the Stimulus / persistence side.

## Reference

https://www.w3.org/TR/webauthn-3/#sctn-authenticator-credential-properties-extension