### PR TITLE
feat(options): support uiMode "immediate" on navigator.credentials.get()

### DIFF
--- a/src/stimulus/assets/src/authentication-controller.js
+++ b/src/stimulus/assets/src/authentication-controller.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import {
+    base64URLStringToBuffer,
     browserSupportsWebAuthn,
     browserSupportsWebAuthnAutofill,
     startAuthentication,
@@ -9,6 +10,16 @@ import {
     platformAuthenticatorIsAvailable,
 } from '@simplewebauthn/browser';
 import BaseController from './base-controller.js';
+
+/**
+ * Allowed `CredentialUiMode` values per the W3C Credential Management spec
+ * (editor's draft, §2.3.3). Kept narrow on purpose: forwarding an unknown
+ * value to `navigator.credentials.get()` would silently degrade to default
+ * UA behaviour, which is harder to debug than a controller-side rejection.
+ *
+ * @see https://w3c.github.io/webappsec-credential-management/#enumdef-credentialuimode
+ */
+const ALLOWED_UI_MODES = ['auto', 'immediate'];
 
 /**
  * Stimulus controller for WebAuthn authentication (sign-in)
@@ -143,11 +154,20 @@ export default class extends BaseController {
     async _processAuthentication(credentialRequestOptions, startAuthenticationOptions = {}) {
         try {
             const processedOptions = this._processExtensionsInput(credentialRequestOptions);
+            const uiMode = this._extractUiMode(processedOptions);
 
-            let credential = await startAuthentication({
-                optionsJSON: processedOptions,
-                ...startAuthenticationOptions,
-            });
+            let credential;
+            if (uiMode === 'immediate') {
+                // SimpleWebAuthn 13.x has no native `uiMode` support yet, so
+                // we call `navigator.credentials.get()` directly and rely on
+                // PublicKeyCredential.toJSON() for the response shape.
+                credential = await this._getCredentialWithUiMode(processedOptions, uiMode);
+            } else {
+                credential = await startAuthentication({
+                    optionsJSON: processedOptions,
+                    ...startAuthenticationOptions,
+                });
+            }
 
             credential = this._processExtensionsOutput(credential);
             this._dispatchEvent('webauthn:authentication:credential', { credential });
@@ -181,5 +201,56 @@ export default class extends BaseController {
                 this._dispatchEvent('webauthn:authentication:error', { error });
             }
         }
+    }
+
+    /**
+     * Pop `uiMode` off the options JSON and validate it.
+     * @private
+     * @param {Object} optionsJSON - WebAuthn credential request options (mutated)
+     * @returns {string|null} A validated `CredentialUiMode` value, or null if absent
+     */
+    _extractUiMode(optionsJSON) {
+        if (!optionsJSON || typeof optionsJSON.uiMode === 'undefined' || optionsJSON.uiMode === null) {
+            return null;
+        }
+        const uiMode = optionsJSON.uiMode;
+        delete optionsJSON.uiMode;
+
+        if (typeof uiMode !== 'string' || !ALLOWED_UI_MODES.includes(uiMode)) {
+            throw new TypeError(`Invalid uiMode "${uiMode}". Allowed values: ${ALLOWED_UI_MODES.join(', ')}.`);
+        }
+        return uiMode;
+    }
+
+    /**
+     * Call `navigator.credentials.get()` directly with a `uiMode` option.
+     * Used when SimpleWebAuthn does not natively forward the option.
+     * @private
+     * @param {Object} optionsJSON - WebAuthn credential request options (uiMode already removed)
+     * @param {string} uiMode - Validated CredentialUiMode value
+     * @returns {Promise<Object>} JSON-serialised credential
+     */
+    async _getCredentialWithUiMode(optionsJSON, uiMode) {
+        const publicKey = {
+            ...optionsJSON,
+            challenge: base64URLStringToBuffer(optionsJSON.challenge),
+        };
+        if (Array.isArray(optionsJSON.allowCredentials)) {
+            publicKey.allowCredentials = optionsJSON.allowCredentials.map((descriptor) => ({
+                ...descriptor,
+                id: base64URLStringToBuffer(descriptor.id),
+            }));
+        }
+
+        const credential = await navigator.credentials.get({
+            publicKey,
+            uiMode,
+            signal: WebAuthnAbortService.createNewAbortSignal(),
+        });
+
+        if (credential === null) {
+            throw new Error('navigator.credentials.get() returned null');
+        }
+        return credential.toJSON();
     }
 }

--- a/src/stimulus/assets/test/authentication-controller.test.js
+++ b/src/stimulus/assets/test/authentication-controller.test.js
@@ -16,7 +16,10 @@ jest.mock('@simplewebauthn/browser', () => {
         browserSupportsWebAuthnAutofill: jest.fn(),
         platformAuthenticatorIsAvailable: jest.fn(),
         startAuthentication: jest.fn(),
-        WebAuthnAbortService: { cancelCeremony: jest.fn() },
+        WebAuthnAbortService: {
+            cancelCeremony: jest.fn(),
+            createNewAbortSignal: jest.fn(() => new AbortController().signal),
+        },
     };
 });
 
@@ -554,8 +557,10 @@ describe('AuthenticationController', () => {
                 expect(SimpleWebAuthnBrowser.startAuthentication).toHaveBeenCalled();
             });
 
-            const passed = SimpleWebAuthnBrowser.startAuthentication.mock.calls[0][0].optionsJSON
-                .extensions.prf.evalByCredential['credential-id-base64url'];
+            const passed =
+                SimpleWebAuthnBrowser.startAuthentication.mock.calls[0][0].optionsJSON.extensions.prf.evalByCredential[
+                    'credential-id-base64url'
+                ];
             expect(passed.first).toBeInstanceOf(ArrayBuffer);
             expect(passed.first.byteLength).toBe(32);
         });
@@ -622,6 +627,136 @@ describe('AuthenticationController', () => {
                 expect(credentialEvents).toHaveLength(1);
             });
             expect(credentialEvents[0].clientExtensionResults).toEqual({});
+        });
+    });
+
+    describe('uiMode (Credential Management ED §2.3.3)', () => {
+        // Per spec, when uiMode === "immediate" the user agent must return a
+        // credential immediately available locally or fail with NotAllowedError.
+        // SimpleWebAuthn 13.x has no native support for this option, so the
+        // controller must bypass startAuthentication() and call
+        // navigator.credentials.get() directly.
+
+        let originalNavigator;
+
+        beforeEach(() => {
+            originalNavigator = globalThis.navigator;
+        });
+
+        afterEach(() => {
+            if (originalNavigator) {
+                Object.defineProperty(globalThis, 'navigator', {
+                    value: originalNavigator,
+                    configurable: true,
+                });
+            }
+        });
+
+        it('forwards uiMode "immediate" to navigator.credentials.get() and bypasses SimpleWebAuthn', async () => {
+            const form = getByTestId(container, 'authentication-form');
+
+            // base64url("hello") => "aGVsbG8"
+            const challengeB64 = 'aGVsbG8';
+            // base64url("cred-id") => "Y3JlZC1pZA"
+            const credentialIdB64 = 'Y3JlZC1pZA';
+
+            const credentialJson = {
+                id: credentialIdB64,
+                rawId: credentialIdB64,
+                response: { clientDataJSON: 'data', authenticatorData: 'auth', signature: 'sig' },
+                type: 'public-key',
+            };
+            const credentialsGetMock = jest.fn().mockResolvedValue({
+                toJSON: () => credentialJson,
+            });
+            Object.defineProperty(globalThis, 'navigator', {
+                value: { credentials: { get: credentialsGetMock } },
+                configurable: true,
+            });
+
+            fetchMock
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => ({
+                        challenge: challengeB64,
+                        rpId: 'example.com',
+                        allowCredentials: [{ type: 'public-key', id: credentialIdB64 }],
+                        uiMode: 'immediate',
+                    }),
+                })
+                .mockResolvedValueOnce({ ok: true, json: async () => ({ verified: true }) });
+
+            let credentialEvent = null;
+            form.addEventListener('webauthn:authentication:credential', (e) => {
+                credentialEvent = e.detail;
+            });
+
+            const connectionPromise = waitForConnection(form);
+            application = startStimulus();
+            await connectionPromise;
+            submitForm(form);
+
+            await waitFor(() => {
+                expect(credentialsGetMock).toHaveBeenCalledTimes(1);
+            });
+
+            const callArg = credentialsGetMock.mock.calls[0][0];
+            expect(callArg.uiMode).toBe('immediate');
+            expect(callArg.publicKey.uiMode).toBeUndefined();
+            expect(callArg.publicKey.challenge).toBeInstanceOf(ArrayBuffer);
+            expect(callArg.publicKey.allowCredentials[0].id).toBeInstanceOf(ArrayBuffer);
+            expect(callArg.signal).toBeInstanceOf(AbortSignal);
+
+            expect(SimpleWebAuthnBrowser.startAuthentication).not.toHaveBeenCalled();
+            expect(credentialEvent.credential).toEqual(credentialJson);
+        });
+
+        it('rejects an unknown uiMode value before reaching the browser', async () => {
+            const form = getByTestId(container, 'authentication-form');
+
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ challenge: 'test', uiMode: 'silent' }),
+            });
+
+            let errorDetail = null;
+            form.addEventListener('webauthn:authentication:error', (e) => {
+                errorDetail = e.detail;
+            });
+
+            const connectionPromise = waitForConnection(form);
+            application = startStimulus();
+            await connectionPromise;
+            submitForm(form);
+
+            await waitFor(() => {
+                expect(errorDetail).not.toBeNull();
+            });
+            expect(errorDetail.error).toBeInstanceOf(TypeError);
+            expect(errorDetail.error.message).toContain('Invalid uiMode "silent"');
+            expect(SimpleWebAuthnBrowser.startAuthentication).not.toHaveBeenCalled();
+        });
+
+        it('falls back to startAuthentication when uiMode is absent', async () => {
+            const form = getByTestId(container, 'authentication-form');
+
+            fetchMock
+                .mockResolvedValueOnce({ ok: true, json: async () => ({ challenge: 'test' }) })
+                .mockResolvedValueOnce({ ok: true, json: async () => ({ verified: true }) });
+
+            SimpleWebAuthnBrowser.startAuthentication.mockResolvedValue({ id: 'cred' });
+
+            const connectionPromise = waitForConnection(form);
+            application = startStimulus();
+            await connectionPromise;
+            submitForm(form);
+
+            await waitFor(() => {
+                expect(SimpleWebAuthnBrowser.startAuthentication).toHaveBeenCalledTimes(1);
+            });
+            const startCall = SimpleWebAuthnBrowser.startAuthentication.mock.calls[0][0];
+            expect(startCall.optionsJSON).toEqual({ challenge: 'test' });
+            expect(startCall.optionsJSON.uiMode).toBeUndefined();
         });
     });
 });

--- a/src/webauthn/src/Denormalizer/PublicKeyCredentialOptionsDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/PublicKeyCredentialOptionsDenormalizer.php
@@ -35,7 +35,7 @@ final class PublicKeyCredentialOptionsDenormalizer implements DenormalizerInterf
      */
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        /** @var array{challenge?: string, rp?: array<string, mixed>, user?: array<string, mixed>, pubKeyCredParams?: list<array<string, mixed>>, authenticatorSelection?: array<string, mixed>, attestation?: string, excludeCredentials?: list<array{id: string, type?: string, transports?: list<string>}>, allowCredentials?: list<array{id: string, type?: string, transports?: list<string>}>, timeout?: int<1, max>, extensions?: array<string, mixed>, hints?: list<string>, rpId?: string, userVerification?: string} $data */
+        /** @var array{challenge?: string, rp?: array<string, mixed>, user?: array<string, mixed>, pubKeyCredParams?: list<array<string, mixed>>, authenticatorSelection?: array<string, mixed>, attestation?: string, excludeCredentials?: list<array{id: string, type?: string, transports?: list<string>}>, allowCredentials?: list<array{id: string, type?: string, transports?: list<string>}>, timeout?: int<1, max>, extensions?: array<string, mixed>, hints?: list<string>, rpId?: string, userVerification?: string, uiMode?: string} $data */
         if (array_key_exists('challenge', $data)) {
             $data['challenge'] = Base64UrlSafe::decodeNoPadding($data['challenge']);
         }
@@ -130,6 +130,7 @@ final class PublicKeyCredentialOptionsDenormalizer implements DenormalizerInterf
                 $data['timeout'] ?? null,
                 $extensions,
                 $data['hints'] ?? [],
+                $data['uiMode'] ?? null,
             );
         }
         throw new BadMethodCallException('Unsupported type');
@@ -208,6 +209,7 @@ final class PublicKeyCredentialOptionsDenormalizer implements DenormalizerInterf
                 'rpId' => $object->rpId,
                 'allowCredentials' => $this->normalizer->normalize($object->allowCredentials, $format, $context),
                 'userVerification' => $object->userVerification,
+                'uiMode' => $object->uiMode,
             ];
         }
 

--- a/src/webauthn/src/PublicKeyCredentialRequestOptions.php
+++ b/src/webauthn/src/PublicKeyCredentialRequestOptions.php
@@ -27,6 +27,27 @@ final class PublicKeyCredentialRequestOptions extends PublicKeyCredentialOptions
     ];
 
     /**
+     * `CredentialUiMode` values for `navigator.credentials.get()`. Defined by
+     * the WHATWG/W3C Credential Management spec (editor's draft, §2.3.3).
+     *
+     * - {@see UI_MODE_AUTO} (default) — usual UA flow.
+     * - {@see UI_MODE_IMMEDIATE} — synchronous attempt: the user agent must
+     *   either return a credential immediately available locally or fail
+     *   with `NotAllowedError`. Useful for silent re-auth.
+     *
+     * `uiMode` is a separate dictionary member from `mediation`. It does NOT
+     * belong to `CredentialMediationRequirement` (which stays
+     * `silent | optional | conditional | required`).
+     *
+     * @see https://w3c.github.io/webappsec-credential-management/#enumdef-credentialuimode
+     */
+    public const UI_MODE_AUTO = 'auto';
+
+    public const UI_MODE_IMMEDIATE = 'immediate';
+
+    public const UI_MODES = [self::UI_MODE_AUTO, self::UI_MODE_IMMEDIATE];
+
+    /**
      * @param PublicKeyCredentialDescriptor[] $allowCredentials
      * @param null|AuthenticationExtensions|array<array-key, AuthenticationExtension> $extensions
      * @param string[] $hints
@@ -39,10 +60,15 @@ final class PublicKeyCredentialRequestOptions extends PublicKeyCredentialOptions
         null|int $timeout = null,
         null|array|AuthenticationExtensions $extensions = null,
         array $hints = [],
+        public null|string $uiMode = null,
     ) {
         in_array($userVerification, self::USER_VERIFICATION_REQUIREMENTS, true) || throw InvalidDataException::create(
             $userVerification,
             'Invalid user verification requirement'
+        );
+        $uiMode === null || in_array($uiMode, self::UI_MODES, true) || throw InvalidDataException::create(
+            $uiMode,
+            'Invalid UI mode'
         );
         parent::__construct(
             $challenge,
@@ -66,7 +92,17 @@ final class PublicKeyCredentialRequestOptions extends PublicKeyCredentialOptions
         null|int $timeout = null,
         null|array|AuthenticationExtensions $extensions = null,
         array $hints = [],
+        null|string $uiMode = null,
     ): self {
-        return new self($challenge, $rpId, $allowCredentials, $userVerification, $timeout, $extensions, $hints);
+        return new self(
+            $challenge,
+            $rpId,
+            $allowCredentials,
+            $userVerification,
+            $timeout,
+            $extensions,
+            $hints,
+            $uiMode,
+        );
     }
 }

--- a/tests/library/Unit/PublicKeyCredentialRequestOptionsTest.php
+++ b/tests/library/Unit/PublicKeyCredentialRequestOptionsTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Webauthn\AuthenticationExtensions\AuthenticationExtension;
 use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
+use Webauthn\Exception\InvalidDataException;
 use Webauthn\PublicKeyCredentialDescriptor;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\Tests\AbstractTestCase;
@@ -162,6 +163,54 @@ final class PublicKeyCredentialRequestOptionsTest extends AbstractTestCase
 
         // Then
         static::assertSame([], $publicKeyCredentialRequestOptions->hints);
+    }
+
+    #[Test]
+    public function publicKeyCredentialRequestOptionsWithUiModeImmediateRoundTrips(): void
+    {
+        $options = PublicKeyCredentialRequestOptions::create(
+            'challenge',
+            uiMode: PublicKeyCredentialRequestOptions::UI_MODE_IMMEDIATE,
+        );
+
+        static::assertSame(PublicKeyCredentialRequestOptions::UI_MODE_IMMEDIATE, $options->uiMode);
+
+        $json = $this->getSerializer()
+            ->serialize($options, 'json', [
+                AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+            ]);
+
+        static::assertJsonStringEqualsJsonString(
+            '{"challenge":"Y2hhbGxlbmdl","allowCredentials":[],"uiMode":"immediate"}',
+            $json,
+        );
+
+        /** @var PublicKeyCredentialRequestOptions $deserialized */
+        $deserialized = $this->getSerializer()
+            ->deserialize($json, PublicKeyCredentialRequestOptions::class, 'json');
+        static::assertSame(PublicKeyCredentialRequestOptions::UI_MODE_IMMEDIATE, $deserialized->uiMode);
+    }
+
+    #[Test]
+    public function publicKeyCredentialRequestOptionsWithoutUiModeDoesNotEmitField(): void
+    {
+        $options = PublicKeyCredentialRequestOptions::create('challenge');
+        $json = $this->getSerializer()
+            ->serialize($options, 'json', [
+                AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+            ]);
+
+        static::assertNull($options->uiMode);
+        static::assertStringNotContainsString('uiMode', $json);
+    }
+
+    #[Test]
+    public function creatingPublicKeyCredentialRequestOptionsWithInvalidUiModeThrowsException(): void
+    {
+        $this->expectException(InvalidDataException::class);
+        $this->expectExceptionMessage('Invalid UI mode');
+
+        PublicKeyCredentialRequestOptions::create('challenge', uiMode: 'silent');
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Closes #856.

Adds support for the new `uiMode` dictionary member on
`CredentialRequestOptions` (W3C Credential Management spec, editor's
draft §2.3.3). When set to `"immediate"`, the user agent must return a
credential immediately available locally or reject with
`NotAllowedError` — useful for silent re-auth.

`uiMode` belongs to a separate enum `CredentialUiMode` (`auto | immediate`)
and is distinct from `CredentialMediationRequirement`
(`silent | optional | conditional | required`), which stays untouched.

### PHP

- `PublicKeyCredentialRequestOptions` gains a nullable `uiMode` field,
  `UI_MODE_AUTO` / `UI_MODE_IMMEDIATE` constants and a `UI_MODES`
  whitelist, with constructor-side `InvalidDataException` on unknown
  values.
- `PublicKeyCredentialOptionsDenormalizer` round-trips `uiMode` through
  JSON in both directions.
- The deprecated profile-based `PublicKeyCredentialRequestOptionsFactory`
  is intentionally left alone — consumers wanting `uiMode` should hook
  into a `PublicKeyCredentialRequestOptionsBuilder` (the supported path
  in 5.4).

### Stimulus

- `AuthenticationController` strips and validates `uiMode` from the
  options JSON against the allowed enum, throwing `TypeError` on
  unknown values before reaching the browser.
- When `uiMode === "immediate"` is set, the controller bypasses
  SimpleWebAuthn (which has no native `uiMode` support in 13.x) and
  calls `navigator.credentials.get()` directly, decoding `challenge`
  and `allowCredentials[].id` from base64url and serialising the
  response via `PublicKeyCredential.toJSON()`. Pluggable into the
  existing `WebAuthnAbortService`.
- Default path (no `uiMode`) remains `startAuthentication()` — no
  behavioural change for existing users.

### Tests

- 3 new PHP unit tests on `PublicKeyCredentialRequestOptionsTest`
  covering the round-trip, the absent-field case, and the validation
  failure.
- 3 new Jest tests on `authentication-controller.test.js` covering
  immediate-mode forwarding (publicKey conversion, `signal`,
  `startAuthentication` bypass), invalid-value rejection, and the
  fallback when `uiMode` is absent.

### Reference

https://w3c.github.io/webappsec-credential-management/#enumdef-credentialuimode