### PR TITLE
feat(extensions): support minPinLength extension (CTAP 2.1 §12.4)

### DIFF
--- a/src/webauthn/src/AuthenticationExtensions/MinPinLengthInputExtension.php
+++ b/src/webauthn/src/AuthenticationExtensions/MinPinLengthInputExtension.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\AuthenticationExtensions;
+
+/**
+ * CTAP 2.1 §12.4: `minPinLength` authenticator extension input.
+ *
+ * Defined by FIDO Alliance, not by the W3C WebAuthn specification, but
+ * transported through WebAuthn's generic authenticator-extensions mechanism.
+ * The input is a boolean attached to a registration ceremony; when the
+ * relying party is on the authenticator's enterprise allow-list, the
+ * authenticator returns the configured minimum PIN length as a CBOR uint
+ * inside `authData.extensions.minPinLength`. Use {@see MinPinLengthOutput}
+ * for typed access to that value.
+ *
+ * @see https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#sctn-minpinlength-extension
+ */
+final class MinPinLengthInputExtension extends AuthenticationExtension
+{
+    public static function enable(): AuthenticationExtension
+    {
+        return self::create('minPinLength', true);
+    }
+
+    public static function disable(): AuthenticationExtension
+    {
+        return self::create('minPinLength', false);
+    }
+}

--- a/src/webauthn/src/AuthenticationExtensions/MinPinLengthOutput.php
+++ b/src/webauthn/src/AuthenticationExtensions/MinPinLengthOutput.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\AuthenticationExtensions;
+
+use function is_int;
+use Webauthn\Exception\AuthenticationExtensionException;
+
+/**
+ * CTAP 2.1 §12.4: typed view of the `minPinLength` authenticator extension
+ * output.
+ *
+ * The authenticator returns the configured minimum PIN length as a CBOR
+ * unsigned integer inside `authData.extensions.minPinLength`. The value is
+ * only emitted when the relying party id is on the authenticator's enterprise
+ * allow-list; if the RP requested the extension but the authenticator did
+ * not return it, the extension is simply absent from the bag — that is not
+ * an error.
+ *
+ * Use {@see fromExtensions()} or {@see fromExtension()} to materialise the
+ * value object from the raw extensions bag parsed off `authData`.
+ *
+ * @see https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#sctn-minpinlength-extension
+ */
+final readonly class MinPinLengthOutput
+{
+    public function __construct(
+        public int $minPinLength,
+    ) {
+        $minPinLength >= 0 || throw AuthenticationExtensionException::create(
+            'The "minPinLength" output must be a non-negative integer.'
+        );
+    }
+
+    public static function create(int $minPinLength): self
+    {
+        return new self($minPinLength);
+    }
+
+    public static function fromExtensions(AuthenticationExtensions $extensions): ?self
+    {
+        if (! $extensions->has('minPinLength')) {
+            return null;
+        }
+
+        return self::fromExtension($extensions->get('minPinLength'));
+    }
+
+    public static function fromExtension(AuthenticationExtension $extension): self
+    {
+        $extension->name === 'minPinLength' || throw AuthenticationExtensionException::create(
+            'The extension is not a "minPinLength" extension.'
+        );
+
+        $value = $extension->value;
+        is_int($value) || throw AuthenticationExtensionException::create(
+            'The "minPinLength" output must be an integer.'
+        );
+
+        return new self($value);
+    }
+}

--- a/tests/library/Unit/AuthenticationExtensions/MinPinLengthInputExtensionTest.php
+++ b/tests/library/Unit/AuthenticationExtensions/MinPinLengthInputExtensionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Unit\AuthenticationExtensions;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Webauthn\AuthenticationExtensions\MinPinLengthInputExtension;
+
+/**
+ * @internal
+ */
+final class MinPinLengthInputExtensionTest extends TestCase
+{
+    #[Test]
+    public function enableProducesMinPinLengthTrue(): void
+    {
+        $extension = MinPinLengthInputExtension::enable();
+
+        static::assertSame('minPinLength', $extension->name);
+        static::assertTrue($extension->value);
+    }
+
+    #[Test]
+    public function disableProducesMinPinLengthFalse(): void
+    {
+        $extension = MinPinLengthInputExtension::disable();
+
+        static::assertSame('minPinLength', $extension->name);
+        static::assertFalse($extension->value);
+    }
+}

--- a/tests/library/Unit/AuthenticationExtensions/MinPinLengthOutputTest.php
+++ b/tests/library/Unit/AuthenticationExtensions/MinPinLengthOutputTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Unit\AuthenticationExtensions;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Webauthn\AuthenticationExtensions\AuthenticationExtension;
+use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
+use Webauthn\AuthenticationExtensions\MinPinLengthOutput;
+use Webauthn\Exception\AuthenticationExtensionException;
+
+/**
+ * @internal
+ */
+final class MinPinLengthOutputTest extends TestCase
+{
+    #[Test]
+    public function fromExtensionsReturnsNullWhenAbsent(): void
+    {
+        $extensions = new AuthenticationExtensions([]);
+
+        static::assertNull(MinPinLengthOutput::fromExtensions($extensions));
+    }
+
+    #[Test]
+    public function fromExtensionsParsesIntegerValue(): void
+    {
+        $extensions = new AuthenticationExtensions([AuthenticationExtension::create('minPinLength', 6)]);
+
+        $output = MinPinLengthOutput::fromExtensions($extensions);
+
+        static::assertNotNull($output);
+        static::assertSame(6, $output->minPinLength);
+    }
+
+    #[Test]
+    public function fromExtensionAcceptsZero(): void
+    {
+        $output = MinPinLengthOutput::fromExtension(AuthenticationExtension::create('minPinLength', 0));
+
+        static::assertSame(0, $output->minPinLength);
+    }
+
+    #[Test]
+    public function fromExtensionRejectsNonMinPinLengthExtension(): void
+    {
+        $this->expectException(AuthenticationExtensionException::class);
+        $this->expectExceptionMessage('not a "minPinLength"');
+
+        MinPinLengthOutput::fromExtension(AuthenticationExtension::create('appid', 6));
+    }
+
+    #[Test]
+    public function fromExtensionRejectsNonIntegerValue(): void
+    {
+        $this->expectException(AuthenticationExtensionException::class);
+        $this->expectExceptionMessage('must be an integer');
+
+        MinPinLengthOutput::fromExtension(AuthenticationExtension::create('minPinLength', '6'));
+    }
+
+    #[Test]
+    public function constructorRejectsNegativeValue(): void
+    {
+        $this->expectException(AuthenticationExtensionException::class);
+        $this->expectExceptionMessage('non-negative');
+
+        new MinPinLengthOutput(-1);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #852.

Adds first-class support for the FIDO Alliance `minPinLength`
authenticator extension. The extension lets the relying party retrieve
the minimum PIN length configured on the authenticator — useful for
enterprise compliance reporting. Defined by CTAP 2.1 §12.4 (not by
WebAuthn L3 itself), but transported through WebAuthn's generic
authenticator-extensions mechanism.

### Changes

- **`MinPinLengthInputExtension`** — boolean input attached to a
  registration ceremony, following the same `enable()` / `disable()`
  shape as the other authenticator-extension input classes
  (`AppIdInputExtension`, `UvmInputExtension`,
  `CredentialPropertiesInputExtension`).
- **`MinPinLengthOutput`** — typed value object that exposes the
  uint value the authenticator returns in
  `authData.extensions.minPinLength`. `fromExtensions()` returns null
  when the extension is absent (allowed by spec — the authenticator
  only emits the value if the RP is on its enterprise allow-list).
  `fromExtension()` rejects non-integer and negative values.

### Tests

- 8 new unit tests covering enable/disable, present/absent parsing,
  zero acceptance, and the three error paths (wrong extension name,
  non-integer value, negative value).

### Reference

https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#sctn-minpinlength-extension