### PR TITLE
feat(extensions): support credProtect extension (CTAP 2.1 §12.1)

### DIFF
--- a/src/webauthn/src/AuthenticationExtensions/CredentialProtectionInputExtension.php
+++ b/src/webauthn/src/AuthenticationExtensions/CredentialProtectionInputExtension.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\AuthenticationExtensions;
+
+/**
+ * CTAP 2.1 §12.1: `credProtect` authenticator extension input.
+ *
+ * The relying party uses this extension to request a specific credential
+ * protection policy at registration time. The W3C WebAuthn binding exposes
+ * it on the client side as `credentialProtectionPolicy` (a string), with an
+ * optional companion `enforceCredentialProtectionPolicy` boolean — the user
+ * agent translates both to the CTAP `credProtect` authenticator extension
+ * (uint 1, 2 or 3) when talking to the authenticator.
+ *
+ * Use {@see self::userVerificationOptional()},
+ * {@see self::userVerificationOptionalWithCredentialIDList()} or
+ * {@see self::userVerificationRequired()} to attach the policy. Add
+ * {@see self::enforce()} alongside it when you want the user agent to fail
+ * registration rather than silently downgrade the policy on authenticators
+ * that do not honour `credProtect`.
+ *
+ * @see https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#sctn-credProtect-extension
+ */
+final class CredentialProtectionInputExtension extends AuthenticationExtension
+{
+    public const POLICY_USER_VERIFICATION_OPTIONAL = 'userVerificationOptional';
+
+    public const POLICY_USER_VERIFICATION_OPTIONAL_WITH_CREDENTIAL_ID_LIST = 'userVerificationOptionalWithCredentialIDList';
+
+    public const POLICY_USER_VERIFICATION_REQUIRED = 'userVerificationRequired';
+
+    public const POLICIES = [
+        self::POLICY_USER_VERIFICATION_OPTIONAL,
+        self::POLICY_USER_VERIFICATION_OPTIONAL_WITH_CREDENTIAL_ID_LIST,
+        self::POLICY_USER_VERIFICATION_REQUIRED,
+    ];
+
+    public static function userVerificationOptional(): AuthenticationExtension
+    {
+        return self::create('credentialProtectionPolicy', self::POLICY_USER_VERIFICATION_OPTIONAL);
+    }
+
+    public static function userVerificationOptionalWithCredentialIDList(): AuthenticationExtension
+    {
+        return self::create(
+            'credentialProtectionPolicy',
+            self::POLICY_USER_VERIFICATION_OPTIONAL_WITH_CREDENTIAL_ID_LIST,
+        );
+    }
+
+    public static function userVerificationRequired(): AuthenticationExtension
+    {
+        return self::create('credentialProtectionPolicy', self::POLICY_USER_VERIFICATION_REQUIRED);
+    }
+
+    /**
+     * Companion `enforceCredentialProtectionPolicy: true` extension. Add this
+     * alongside the policy extension when registration must fail rather than
+     * silently downgrade on authenticators that do not honour `credProtect`.
+     */
+    public static function enforce(): AuthenticationExtension
+    {
+        return self::create('enforceCredentialProtectionPolicy', true);
+    }
+}

--- a/src/webauthn/src/AuthenticationExtensions/CredentialProtectionOutput.php
+++ b/src/webauthn/src/AuthenticationExtensions/CredentialProtectionOutput.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\AuthenticationExtensions;
+
+use function in_array;
+use function is_int;
+use Webauthn\Exception\AuthenticationExtensionException;
+
+/**
+ * CTAP 2.1 §12.1: typed view of the `credProtect` authenticator extension
+ * output.
+ *
+ * The authenticator returns the protection policy it actually applied to the
+ * newly created credential as a CBOR unsigned integer (1, 2 or 3) inside
+ * `authData.extensions.credProtect`. The relying party can compare this to
+ * the value it requested via {@see CredentialProtectionInputExtension} to
+ * detect silent downgrades on authenticators that do not enforce the policy.
+ *
+ * Use {@see fromExtensions()} or {@see fromExtension()} to materialise the
+ * value object from the extensions bag parsed off `authData`.
+ *
+ * @see https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#sctn-credProtect-extension
+ */
+final readonly class CredentialProtectionOutput
+{
+    public const POLICY_USER_VERIFICATION_OPTIONAL = 1;
+
+    public const POLICY_USER_VERIFICATION_OPTIONAL_WITH_CREDENTIAL_ID_LIST = 2;
+
+    public const POLICY_USER_VERIFICATION_REQUIRED = 3;
+
+    public const POLICIES = [
+        self::POLICY_USER_VERIFICATION_OPTIONAL,
+        self::POLICY_USER_VERIFICATION_OPTIONAL_WITH_CREDENTIAL_ID_LIST,
+        self::POLICY_USER_VERIFICATION_REQUIRED,
+    ];
+
+    public function __construct(
+        public int $policy,
+    ) {
+        in_array($policy, self::POLICIES, true) || throw AuthenticationExtensionException::create(
+            'The "credProtect" output must be 1, 2 or 3.'
+        );
+    }
+
+    public static function create(int $policy): self
+    {
+        return new self($policy);
+    }
+
+    public static function fromExtensions(AuthenticationExtensions $extensions): ?self
+    {
+        if (! $extensions->has('credProtect')) {
+            return null;
+        }
+
+        return self::fromExtension($extensions->get('credProtect'));
+    }
+
+    public static function fromExtension(AuthenticationExtension $extension): self
+    {
+        $extension->name === 'credProtect' || throw AuthenticationExtensionException::create(
+            'The extension is not a "credProtect" extension.'
+        );
+
+        $value = $extension->value;
+        is_int($value) || throw AuthenticationExtensionException::create(
+            'The "credProtect" output must be an integer.'
+        );
+
+        return new self($value);
+    }
+}

--- a/tests/library/Unit/AuthenticationExtensions/CredentialProtectionInputExtensionTest.php
+++ b/tests/library/Unit/AuthenticationExtensions/CredentialProtectionInputExtensionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Unit\AuthenticationExtensions;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Webauthn\AuthenticationExtensions\CredentialProtectionInputExtension;
+
+/**
+ * @internal
+ */
+final class CredentialProtectionInputExtensionTest extends TestCase
+{
+    #[Test]
+    public function userVerificationOptionalProducesPolicyString(): void
+    {
+        $extension = CredentialProtectionInputExtension::userVerificationOptional();
+
+        static::assertSame('credentialProtectionPolicy', $extension->name);
+        static::assertSame('userVerificationOptional', $extension->value);
+    }
+
+    #[Test]
+    public function userVerificationOptionalWithCredentialIDListProducesPolicyString(): void
+    {
+        $extension = CredentialProtectionInputExtension::userVerificationOptionalWithCredentialIDList();
+
+        static::assertSame('credentialProtectionPolicy', $extension->name);
+        static::assertSame('userVerificationOptionalWithCredentialIDList', $extension->value);
+    }
+
+    #[Test]
+    public function userVerificationRequiredProducesPolicyString(): void
+    {
+        $extension = CredentialProtectionInputExtension::userVerificationRequired();
+
+        static::assertSame('credentialProtectionPolicy', $extension->name);
+        static::assertSame('userVerificationRequired', $extension->value);
+    }
+
+    #[Test]
+    public function enforceCompanionExtensionIsBoolean(): void
+    {
+        $extension = CredentialProtectionInputExtension::enforce();
+
+        static::assertSame('enforceCredentialProtectionPolicy', $extension->name);
+        static::assertTrue($extension->value);
+    }
+}

--- a/tests/library/Unit/AuthenticationExtensions/CredentialProtectionOutputTest.php
+++ b/tests/library/Unit/AuthenticationExtensions/CredentialProtectionOutputTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Unit\AuthenticationExtensions;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Webauthn\AuthenticationExtensions\AuthenticationExtension;
+use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
+use Webauthn\AuthenticationExtensions\CredentialProtectionOutput;
+use Webauthn\Exception\AuthenticationExtensionException;
+
+/**
+ * @internal
+ */
+final class CredentialProtectionOutputTest extends TestCase
+{
+    #[Test]
+    public function fromExtensionsReturnsNullWhenAbsent(): void
+    {
+        static::assertNull(CredentialProtectionOutput::fromExtensions(new AuthenticationExtensions([])));
+    }
+
+    #[Test]
+    public function fromExtensionsParsesSupportedPolicies(): void
+    {
+        foreach (CredentialProtectionOutput::POLICIES as $policy) {
+            $output = CredentialProtectionOutput::fromExtensions(new AuthenticationExtensions([
+                AuthenticationExtension::create('credProtect', $policy),
+            ]));
+
+            static::assertNotNull($output);
+            static::assertSame($policy, $output->policy);
+        }
+    }
+
+    #[Test]
+    public function fromExtensionRejectsNonCredProtectExtension(): void
+    {
+        $this->expectException(AuthenticationExtensionException::class);
+        $this->expectExceptionMessage('not a "credProtect"');
+
+        CredentialProtectionOutput::fromExtension(AuthenticationExtension::create('appid', 1));
+    }
+
+    #[Test]
+    public function fromExtensionRejectsNonIntegerValue(): void
+    {
+        $this->expectException(AuthenticationExtensionException::class);
+        $this->expectExceptionMessage('must be an integer');
+
+        CredentialProtectionOutput::fromExtension(AuthenticationExtension::create('credProtect', '1'));
+    }
+
+    #[Test]
+    public function fromExtensionRejectsOutOfRangeValue(): void
+    {
+        $this->expectException(AuthenticationExtensionException::class);
+        $this->expectExceptionMessage('1, 2 or 3');
+
+        CredentialProtectionOutput::fromExtension(AuthenticationExtension::create('credProtect', 4));
+    }
+
+    #[Test]
+    public function constructorRejectsZero(): void
+    {
+        $this->expectException(AuthenticationExtensionException::class);
+        $this->expectExceptionMessage('1, 2 or 3');
+
+        new CredentialProtectionOutput(0);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #850.

Adds first-class support for the FIDO Alliance `credProtect`
authenticator extension. The relying party requests a credential
protection policy at registration time; the authenticator returns the
policy it actually applied so the RP can detect silent downgrades on
authenticators that do not honour `credProtect`.

The W3C WebAuthn binding splits the input into two top-level
extension keys (`credentialProtectionPolicy` string and the optional
`enforceCredentialProtectionPolicy` boolean), which the user agent
translates to the CTAP `credProtect` uint when talking to the
authenticator.

### Changes

- **`CredentialProtectionInputExtension`** — static factories for the
  three policy levels:
  - `userVerificationOptional()`
  - `userVerificationOptionalWithCredentialIDList()`
  - `userVerificationRequired()`
  Plus `enforce()` for the optional companion that asks the user agent
  to fail rather than silently downgrade. Constants exposed for direct
  use.
- **`CredentialProtectionOutput`** — typed value object that parses
  the uint policy from `authData.extensions.credProtect`.
  `fromExtensions()` returns null when absent. Validates the value is
  one of 1, 2, 3.

### Tests

- 10 new unit tests covering the three policies, the `enforce` flag,
  present/absent parsing, and rejection of non-integer / out-of-range
  / wrong-name extension values.

### Note

The TODO line about a "profile-based options builder" is intentionally
out of scope: bundle profiles are deprecated in 5.4. Consumers should
attach the extension via a `PublicKeyCredentialCreationOptionsBuilder`
implementation instead.

### Reference

https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#sctn-credProtect-extension