### PR TITLE
feat(extensions): support credBlob / getCredBlob extensions (CTAP 2.1 §12.2)

### DIFF
--- a/src/stimulus/assets/src/base-controller.js
+++ b/src/stimulus/assets/src/base-controller.js
@@ -147,6 +147,13 @@ export default class extends Controller {
             options.extensions.prf = this._processPrfInput(options.extensions.prf);
         }
 
+        // CTAP 2.1 §12.2: credBlob ships as base64url over JSON, but the
+        // browser expects a BufferSource. The string form is what
+        // CredentialBlobInputExtension produces server-side.
+        if (typeof options.extensions.credBlob === 'string') {
+            options.extensions.credBlob = base64URLStringToBuffer(options.extensions.credBlob);
+        }
+
         return options;
     }
 
@@ -195,6 +202,15 @@ export default class extends Controller {
 
         if (credential.clientExtensionResults.prf) {
             credential.clientExtensionResults.prf = this._processPrfOutput(credential.clientExtensionResults.prf);
+        }
+
+        // CTAP 2.1 §12.2: getCredBlob assertion output is an ArrayBuffer of
+        // raw bytes — encode to base64url so the JSON we POST back to the
+        // server is round-trippable through CredentialBlobAssertionOutput.
+        if (credential.clientExtensionResults.credBlob instanceof ArrayBuffer) {
+            credential.clientExtensionResults.credBlob = bufferToBase64URLString(
+                credential.clientExtensionResults.credBlob
+            );
         }
 
         return credential;

--- a/src/stimulus/assets/test/authentication-controller.test.js
+++ b/src/stimulus/assets/test/authentication-controller.test.js
@@ -759,4 +759,35 @@ describe('AuthenticationController', () => {
             expect(startCall.optionsJSON.uiMode).toBeUndefined();
         });
     });
+
+    describe('credBlob extension (CTAP 2.1 §12.2)', () => {
+        it('encodes the credBlob assertion output ArrayBuffer back to base64url before dispatch', async () => {
+            const form = getByTestId(container, 'authentication-form');
+            const blobBytes = new Uint8Array([0x68, 0x69, 0x21]).buffer; // base64url("hi!") = "aGkh"
+
+            fetchMock
+                .mockResolvedValueOnce({ ok: true, json: async () => ({ challenge: 'test' }) })
+                .mockResolvedValueOnce({ ok: true, json: async () => ({ verified: true }) });
+
+            SimpleWebAuthnBrowser.startAuthentication.mockResolvedValue({
+                id: 'cred',
+                clientExtensionResults: { credBlob: blobBytes },
+            });
+
+            const credentialEvents = [];
+            form.addEventListener('webauthn:authentication:credential', (e) => {
+                credentialEvents.push(e.detail.credential);
+            });
+
+            const connectionPromise = waitForConnection(form);
+            application = startStimulus();
+            await connectionPromise;
+            submitForm(form);
+
+            await waitFor(() => {
+                expect(credentialEvents).toHaveLength(1);
+            });
+            expect(credentialEvents[0].clientExtensionResults.credBlob).toBe('aGkh');
+        });
+    });
 });

--- a/src/stimulus/assets/test/registration-controller.test.js
+++ b/src/stimulus/assets/test/registration-controller.test.js
@@ -782,8 +782,10 @@ describe('RegistrationController', () => {
             await waitFor(() => {
                 expect(SimpleWebAuthnBrowser.startRegistration).toHaveBeenCalled();
             });
-            const inputs = SimpleWebAuthnBrowser.startRegistration.mock.calls[0][0].optionsJSON
-                .extensions.prf.evalByCredential['cred-1'];
+            const inputs =
+                SimpleWebAuthnBrowser.startRegistration.mock.calls[0][0].optionsJSON.extensions.prf.evalByCredential[
+                    'cred-1'
+                ];
             expect(inputs.first).toBeInstanceOf(ArrayBuffer);
             expect(inputs.second).toBeInstanceOf(ArrayBuffer);
         });
@@ -817,6 +819,39 @@ describe('RegistrationController', () => {
                 expect(credentialEvents).toHaveLength(1);
             });
             expect(credentialEvents[0].clientExtensionResults).toEqual({});
+        });
+    });
+
+    describe('credBlob extension (CTAP 2.1 §12.2)', () => {
+        it('decodes the credBlob input from base64url to ArrayBuffer before calling startRegistration', async () => {
+            const form = getByTestId(container, 'registration-form');
+            // base64url("hi!") = "aGkh"
+            const blobB64 = 'aGkh';
+
+            fetchMock
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => ({
+                        challenge: 'test',
+                        rp: {},
+                        user: {},
+                        extensions: { credBlob: blobB64 },
+                    }),
+                })
+                .mockResolvedValueOnce({ ok: true, json: async () => ({ verified: true }) });
+
+            SimpleWebAuthnBrowser.startRegistration.mockResolvedValue({ id: 'cred' });
+
+            const connectionPromise = waitForConnection(form);
+            application = startStimulus();
+            await connectionPromise;
+            submitForm(form);
+
+            await waitFor(() => {
+                expect(SimpleWebAuthnBrowser.startRegistration).toHaveBeenCalled();
+            });
+            const credBlob = SimpleWebAuthnBrowser.startRegistration.mock.calls[0][0].optionsJSON.extensions.credBlob;
+            expect(credBlob).toBeInstanceOf(ArrayBuffer);
         });
     });
 });

--- a/src/webauthn/src/AuthenticationExtensions/CredentialBlobAssertionOutput.php
+++ b/src/webauthn/src/AuthenticationExtensions/CredentialBlobAssertionOutput.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\AuthenticationExtensions;
+
+use function is_string;
+use function strlen;
+use Webauthn\Exception\AuthenticationExtensionException;
+
+/**
+ * CTAP 2.1 §12.2: typed view of the `credBlob` ASSERTION output.
+ *
+ * When the relying party requested {@see GetCredentialBlobInputExtension} on
+ * an assertion, the authenticator returns the bytes previously stored
+ * against the credential (≤32) as a CBOR byte string inside
+ * `authData.extensions.credBlob`. The bytes arrive here raw — no base64url
+ * decoding required.
+ *
+ * For the registration-side success boolean, see
+ * {@see CredentialBlobRegistrationOutput}.
+ *
+ * @see https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#sctn-credBlob-extension
+ */
+final readonly class CredentialBlobAssertionOutput
+{
+    public function __construct(
+        public string $blob,
+    ) {
+        strlen($blob) <= CredentialBlobInputExtension::MAX_LENGTH || throw AuthenticationExtensionException::create(
+            'The "credBlob" assertion output must not exceed 32 bytes.'
+        );
+    }
+
+    public static function create(string $blob): self
+    {
+        return new self($blob);
+    }
+
+    public static function fromExtensions(AuthenticationExtensions $extensions): ?self
+    {
+        if (! $extensions->has('credBlob')) {
+            return null;
+        }
+
+        return self::fromExtension($extensions->get('credBlob'));
+    }
+
+    public static function fromExtension(AuthenticationExtension $extension): self
+    {
+        $extension->name === 'credBlob' || throw AuthenticationExtensionException::create(
+            'The extension is not a "credBlob" extension.'
+        );
+
+        $value = $extension->value;
+        is_string($value) || throw AuthenticationExtensionException::create(
+            'The "credBlob" assertion output must be a byte string.'
+        );
+
+        return new self($value);
+    }
+}

--- a/src/webauthn/src/AuthenticationExtensions/CredentialBlobInputExtension.php
+++ b/src/webauthn/src/AuthenticationExtensions/CredentialBlobInputExtension.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\AuthenticationExtensions;
+
+use ParagonIE\ConstantTime\Base64UrlSafe;
+use function strlen;
+use Webauthn\Exception\AuthenticationExtensionException;
+
+/**
+ * CTAP 2.1 §12.2: `credBlob` registration input.
+ *
+ * Asks the authenticator to store up to 32 bytes alongside the credential
+ * being created. The blob can later be retrieved during an assertion via
+ * {@see GetCredentialBlobInputExtension}.
+ *
+ * The wire format on the WebAuthn JSON side is base64url; the Stimulus
+ * base controller decodes it back to an `ArrayBuffer` before calling
+ * `navigator.credentials.create()`.
+ *
+ * @see https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#sctn-credBlob-extension
+ */
+final class CredentialBlobInputExtension extends AuthenticationExtension
+{
+    public const MAX_LENGTH = 32;
+
+    /**
+     * @param string $blob Raw bytes (≤32). Encoded to base64url before transport.
+     *
+     * @throws AuthenticationExtensionException if the blob exceeds {@see self::MAX_LENGTH} bytes.
+     */
+    public static function withBlob(string $blob): AuthenticationExtension
+    {
+        strlen($blob) <= self::MAX_LENGTH || throw AuthenticationExtensionException::create(
+            'The "credBlob" payload must not exceed 32 bytes.'
+        );
+
+        return self::create('credBlob', Base64UrlSafe::encodeUnpadded($blob));
+    }
+}

--- a/src/webauthn/src/AuthenticationExtensions/CredentialBlobRegistrationOutput.php
+++ b/src/webauthn/src/AuthenticationExtensions/CredentialBlobRegistrationOutput.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\AuthenticationExtensions;
+
+use function is_bool;
+use Webauthn\Exception\AuthenticationExtensionException;
+
+/**
+ * CTAP 2.1 §12.2: typed view of the `credBlob` REGISTRATION output.
+ *
+ * The authenticator returns a CBOR boolean inside
+ * `authData.extensions.credBlob` indicating whether the blob payload sent
+ * via {@see CredentialBlobInputExtension} was successfully stored. A `false`
+ * (or absent) result means the blob was dropped — typically because the
+ * authenticator does not implement the extension.
+ *
+ * For the assertion side (where the authenticator returns the previously
+ * stored bytes), see {@see CredentialBlobAssertionOutput}.
+ *
+ * @see https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#sctn-credBlob-extension
+ */
+final readonly class CredentialBlobRegistrationOutput
+{
+    public function __construct(
+        public bool $stored,
+    ) {
+    }
+
+    public static function create(bool $stored): self
+    {
+        return new self($stored);
+    }
+
+    public static function fromExtensions(AuthenticationExtensions $extensions): ?self
+    {
+        if (! $extensions->has('credBlob')) {
+            return null;
+        }
+
+        return self::fromExtension($extensions->get('credBlob'));
+    }
+
+    public static function fromExtension(AuthenticationExtension $extension): self
+    {
+        $extension->name === 'credBlob' || throw AuthenticationExtensionException::create(
+            'The extension is not a "credBlob" extension.'
+        );
+
+        $value = $extension->value;
+        is_bool($value) || throw AuthenticationExtensionException::create(
+            'The "credBlob" registration output must be a boolean.'
+        );
+
+        return new self($value);
+    }
+}

--- a/src/webauthn/src/AuthenticationExtensions/GetCredentialBlobInputExtension.php
+++ b/src/webauthn/src/AuthenticationExtensions/GetCredentialBlobInputExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\AuthenticationExtensions;
+
+/**
+ * CTAP 2.1 §12.2: `getCredBlob` assertion input.
+ *
+ * Asks the authenticator to return the blob previously stored against the
+ * asserted credential via {@see CredentialBlobInputExtension}. The retrieved
+ * bytes appear under `credBlob` inside `authData.extensions` — see
+ * {@see CredentialBlobAssertionOutput} for typed access.
+ *
+ * @see https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#sctn-credBlob-extension
+ */
+final class GetCredentialBlobInputExtension extends AuthenticationExtension
+{
+    public static function enable(): AuthenticationExtension
+    {
+        return self::create('getCredBlob', true);
+    }
+
+    public static function disable(): AuthenticationExtension
+    {
+        return self::create('getCredBlob', false);
+    }
+}

--- a/tests/library/Unit/AuthenticationExtensions/CredentialBlobInputExtensionTest.php
+++ b/tests/library/Unit/AuthenticationExtensions/CredentialBlobInputExtensionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Unit\AuthenticationExtensions;
+
+use ParagonIE\ConstantTime\Base64UrlSafe;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Webauthn\AuthenticationExtensions\CredentialBlobInputExtension;
+use Webauthn\AuthenticationExtensions\GetCredentialBlobInputExtension;
+use Webauthn\Exception\AuthenticationExtensionException;
+
+/**
+ * @internal
+ */
+final class CredentialBlobInputExtensionTest extends TestCase
+{
+    #[Test]
+    public function withBlobEncodesPayloadAsBase64Url(): void
+    {
+        $raw = "\x00\x01\x02secret";
+        $extension = CredentialBlobInputExtension::withBlob($raw);
+
+        static::assertSame('credBlob', $extension->name);
+        static::assertSame(Base64UrlSafe::encodeUnpadded($raw), $extension->value);
+    }
+
+    #[Test]
+    public function withBlobAcceptsExactlyMaxLength(): void
+    {
+        $raw = str_repeat('A', CredentialBlobInputExtension::MAX_LENGTH);
+        $extension = CredentialBlobInputExtension::withBlob($raw);
+
+        static::assertSame(Base64UrlSafe::encodeUnpadded($raw), $extension->value);
+    }
+
+    #[Test]
+    public function withBlobRejectsPayloadAbove32Bytes(): void
+    {
+        $this->expectException(AuthenticationExtensionException::class);
+        $this->expectExceptionMessage('must not exceed 32 bytes');
+
+        CredentialBlobInputExtension::withBlob(str_repeat('A', 33));
+    }
+
+    #[Test]
+    public function getCredBlobEnableProducesTrue(): void
+    {
+        $extension = GetCredentialBlobInputExtension::enable();
+
+        static::assertSame('getCredBlob', $extension->name);
+        static::assertTrue($extension->value);
+    }
+
+    #[Test]
+    public function getCredBlobDisableProducesFalse(): void
+    {
+        $extension = GetCredentialBlobInputExtension::disable();
+
+        static::assertSame('getCredBlob', $extension->name);
+        static::assertFalse($extension->value);
+    }
+}

--- a/tests/library/Unit/AuthenticationExtensions/CredentialBlobOutputTest.php
+++ b/tests/library/Unit/AuthenticationExtensions/CredentialBlobOutputTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Unit\AuthenticationExtensions;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Webauthn\AuthenticationExtensions\AuthenticationExtension;
+use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
+use Webauthn\AuthenticationExtensions\CredentialBlobAssertionOutput;
+use Webauthn\AuthenticationExtensions\CredentialBlobRegistrationOutput;
+use Webauthn\Exception\AuthenticationExtensionException;
+
+/**
+ * @internal
+ */
+final class CredentialBlobOutputTest extends TestCase
+{
+    #[Test]
+    public function registrationOutputAbsentReturnsNull(): void
+    {
+        static::assertNull(CredentialBlobRegistrationOutput::fromExtensions(new AuthenticationExtensions([])));
+    }
+
+    #[Test]
+    public function registrationOutputParsesBoolean(): void
+    {
+        $output = CredentialBlobRegistrationOutput::fromExtensions(new AuthenticationExtensions([
+            AuthenticationExtension::create('credBlob', true),
+        ]));
+
+        static::assertNotNull($output);
+        static::assertTrue($output->stored);
+    }
+
+    #[Test]
+    public function registrationOutputRejectsNonBoolean(): void
+    {
+        $this->expectException(AuthenticationExtensionException::class);
+        $this->expectExceptionMessage('must be a boolean');
+
+        CredentialBlobRegistrationOutput::fromExtension(AuthenticationExtension::create('credBlob', 'oops'));
+    }
+
+    #[Test]
+    public function registrationOutputRejectsWrongName(): void
+    {
+        $this->expectException(AuthenticationExtensionException::class);
+        $this->expectExceptionMessage('not a "credBlob"');
+
+        CredentialBlobRegistrationOutput::fromExtension(AuthenticationExtension::create('appid', true));
+    }
+
+    #[Test]
+    public function assertionOutputAbsentReturnsNull(): void
+    {
+        static::assertNull(CredentialBlobAssertionOutput::fromExtensions(new AuthenticationExtensions([])));
+    }
+
+    #[Test]
+    public function assertionOutputParsesBlobBytes(): void
+    {
+        $bytes = "\x10\x20\x30hello";
+        $output = CredentialBlobAssertionOutput::fromExtensions(new AuthenticationExtensions([
+            AuthenticationExtension::create('credBlob', $bytes),
+        ]));
+
+        static::assertNotNull($output);
+        static::assertSame($bytes, $output->blob);
+    }
+
+    #[Test]
+    public function assertionOutputAcceptsEmptyBlob(): void
+    {
+        $output = CredentialBlobAssertionOutput::fromExtension(AuthenticationExtension::create('credBlob', ''));
+
+        static::assertSame('', $output->blob);
+    }
+
+    #[Test]
+    public function assertionOutputRejectsNonString(): void
+    {
+        $this->expectException(AuthenticationExtensionException::class);
+        $this->expectExceptionMessage('must be a byte string');
+
+        CredentialBlobAssertionOutput::fromExtension(AuthenticationExtension::create('credBlob', true));
+    }
+
+    #[Test]
+    public function assertionOutputRejectsBlobOver32Bytes(): void
+    {
+        $this->expectException(AuthenticationExtensionException::class);
+        $this->expectExceptionMessage('must not exceed 32 bytes');
+
+        new CredentialBlobAssertionOutput(str_repeat('A', 33));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #851.

Adds first-class support for the FIDO Alliance `credBlob` /
`getCredBlob` extensions. The relying party can ask the authenticator
to store ≤32 bytes of opaque data alongside a credential at
registration time, then ask for those bytes back during a later
assertion.

### PHP

- **`CredentialBlobInputExtension::withBlob(string $raw)`** —
  registration input. Encodes raw bytes to base64url for transport
  (the JSON wire format). Rejects payloads above 32 bytes via
  `AuthenticationExtensionException`.
- **`GetCredentialBlobInputExtension::enable() / disable()`** —
  boolean assertion input.
- **`CredentialBlobRegistrationOutput`** — typed view of the boolean
  success flag the authenticator returns under
  `authData.extensions.credBlob` after registration. `false` means the
  blob was dropped (typically because the authenticator does not
  implement the extension).
- **`CredentialBlobAssertionOutput`** — typed view of the byte string
  retrieved under `authData.extensions.credBlob` after an assertion.
  Enforces the same ≤32-byte invariant.

### Stimulus

- `_processExtensionsInput` now decodes `extensions.credBlob` from
  base64url to `ArrayBuffer` before calling
  `navigator.credentials.create()` — `BufferSource` is what the
  browser expects.
- `_processExtensionsOutput` now encodes the assertion
  `clientExtensionResults.credBlob` ArrayBuffer back to base64url, so
  the JSON we POST back to the server round-trips through
  `CredentialBlobAssertionOutput`.

### Tests

- 14 new PHP unit tests covering input encoding, the 32-byte cap on
  both directions, the assertion output round-trip, the registration
  boolean parsing, and the three error paths (wrong name / wrong type
  / out-of-bound).
- 2 new Jest tests covering the registration input ArrayBuffer
  conversion and the assertion output base64url encoding.

### Reference

https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#sctn-credBlob-extension