### PR TITLE
feat(stimulus): use native parseCreationOptionsFromJSON / parseRequestOptionsFromJSON / toJSON helpers (NEW-L3)

### DIFF
--- a/src/stimulus/assets/src/authentication-controller.js
+++ b/src/stimulus/assets/src/authentication-controller.js
@@ -157,22 +157,40 @@ export default class extends BaseController {
      */
     async _processAuthentication(credentialRequestOptions, startAuthenticationOptions = {}) {
         try {
-            const processedOptions = this._processExtensionsInput(credentialRequestOptions);
-            const uiMode = this._extractUiMode(processedOptions);
+            // We mutate options here (uiMode pop). Native path needs the
+            // un-pre-processed JSON so we can pass it through
+            // parseRequestOptionsFromJSON intact.
+            const uiMode = this._extractUiMode(credentialRequestOptions);
 
             let credential;
-            if (uiMode === 'immediate') {
-                // SimpleWebAuthn 13.x has no native `uiMode` support yet, so
-                // we call `navigator.credentials.get()` directly and rely on
-                // PublicKeyCredential.toJSON() for the response shape.
-                credential = await this._getCredentialWithUiMode(processedOptions, uiMode);
+            if (this._supportsNativeJsonHelpers()) {
+                // WebAuthn L3 §5.1.14: parseRequestOptionsFromJSON converts
+                // every standard field including known extensions, so no
+                // _processExtensionsInput pass is needed on this path.
+                const nativeExtras = uiMode === null ? {} : { uiMode };
+                if (startAuthenticationOptions.useBrowserAutofill === true) {
+                    nativeExtras.mediation = 'conditional';
+                }
+                credential = await this._nativeGet(credentialRequestOptions, nativeExtras);
             } else {
-                credential = await startAuthentication({
-                    optionsJSON: processedOptions,
-                    ...startAuthenticationOptions,
-                });
+                const processedOptions = this._processExtensionsInput(credentialRequestOptions);
+                if (uiMode === 'immediate') {
+                    // SimpleWebAuthn 13.x has no native `uiMode` support yet,
+                    // so we call `navigator.credentials.get()` directly and
+                    // rely on PublicKeyCredential.toJSON() for the response shape.
+                    credential = await this._getCredentialWithUiMode(processedOptions, uiMode);
+                } else {
+                    credential = await startAuthentication({
+                        optionsJSON: processedOptions,
+                        ...startAuthenticationOptions,
+                    });
+                }
             }
 
+            // Run on both paths: subclasses (e.g. payment-controller) hook
+            // here for non-WebAuthn-L3 extensions like SPC's `payment` that
+            // PublicKeyCredential.toJSON() may not encode. The base helpers
+            // are idempotent so values already encoded by toJSON() pass through.
             credential = this._processExtensionsOutput(credential);
             this._dispatchEvent('webauthn:authentication:credential', { credential });
 

--- a/src/stimulus/assets/src/base-controller.js
+++ b/src/stimulus/assets/src/base-controller.js
@@ -5,6 +5,7 @@ import {
     base64URLStringToBuffer,
     browserSupportsWebAuthnAutofill,
     bufferToBase64URLString,
+    WebAuthnAbortService,
 } from '@simplewebauthn/browser';
 
 /**
@@ -181,14 +182,17 @@ export default class extends Controller {
     }
 
     /**
-     * Import PRF values from base64url strings to ArrayBuffer
+     * Import PRF values from base64url strings to ArrayBuffer.
+     * Idempotent: values that are already ArrayBuffers are passed through.
      * @param {Object} values - PRF values with base64url strings
      * @returns {Object} PRF values with ArrayBuffers
      */
     _importPrfValues(values) {
         const result = { ...values };
-        result.first = base64URLStringToBuffer(values.first);
-        if (values.second) {
+        if (typeof values.first === 'string') {
+            result.first = base64URLStringToBuffer(values.first);
+        }
+        if (typeof values.second === 'string') {
             result.second = base64URLStringToBuffer(values.second);
         }
         return result;
@@ -235,14 +239,18 @@ export default class extends Controller {
     }
 
     /**
-     * Export PRF values from ArrayBuffer to base64url strings
+     * Export PRF values from ArrayBuffer to base64url strings.
+     * Idempotent: values that are already strings (typically because the
+     * native L3 `toJSON()` already encoded them) are passed through unchanged.
      * @param {Object} values - PRF values with ArrayBuffers
      * @returns {Object} PRF values with base64url strings
      */
     _exportPrfValues(values) {
         const result = { ...values };
-        result.first = bufferToBase64URLString(values.first);
-        if (values.second) {
+        if (values.first instanceof ArrayBuffer) {
+            result.first = bufferToBase64URLString(values.first);
+        }
+        if (values.second instanceof ArrayBuffer) {
             result.second = bufferToBase64URLString(values.second);
         }
         return result;
@@ -298,5 +306,70 @@ export default class extends Controller {
             conditionalGet: supportsAutofill,
         };
         return this._clientCapabilitiesCache;
+    }
+
+    /**
+     * Whether the user agent ships the WebAuthn L3 §5.1.13–14 JSON helpers
+     * (`PublicKeyCredential.parseCreationOptionsFromJSON`,
+     * `parseRequestOptionsFromJSON`, `credential.toJSON()`). When true the
+     * controllers call `navigator.credentials.{create,get}()` directly —
+     * the native parser converts every standard field, including known
+     * extensions, so the manual `_processExtensionsInput`/`Output` passes
+     * are unnecessary on this code path.
+     *
+     * Caveat: a controller method that depends on `toJSON()` should also
+     * check that the returned credential exposes it, since some user agents
+     * may ship the parser without the serializer or vice-versa.
+     *
+     * @returns {boolean}
+     */
+    _supportsNativeJsonHelpers() {
+        return (
+            typeof PublicKeyCredential !== 'undefined' &&
+            typeof PublicKeyCredential.parseCreationOptionsFromJSON === 'function' &&
+            typeof PublicKeyCredential.parseRequestOptionsFromJSON === 'function'
+        );
+    }
+
+    /**
+     * Run a registration ceremony via the native WebAuthn L3 helpers.
+     * Caller must have checked {@see _supportsNativeJsonHelpers} first.
+     *
+     * @param {Object} optionsJSON - WebAuthn credential creation options (canonical JSON shape)
+     * @param {Object} extras - Extra options forwarded to navigator.credentials.create()
+     * @returns {Promise<Object>} JSON-serialised credential (via credential.toJSON())
+     */
+    async _nativeCreate(optionsJSON, extras = {}) {
+        const publicKey = PublicKeyCredential.parseCreationOptionsFromJSON(optionsJSON);
+        const credential = await navigator.credentials.create({
+            publicKey,
+            signal: WebAuthnAbortService.createNewAbortSignal(),
+            ...extras,
+        });
+        if (credential === null) {
+            throw new Error('navigator.credentials.create() returned null');
+        }
+        return credential.toJSON();
+    }
+
+    /**
+     * Run an assertion ceremony via the native WebAuthn L3 helpers.
+     * Caller must have checked {@see _supportsNativeJsonHelpers} first.
+     *
+     * @param {Object} optionsJSON - WebAuthn credential request options (canonical JSON shape)
+     * @param {Object} extras - Extra options forwarded to navigator.credentials.get()
+     * @returns {Promise<Object>} JSON-serialised credential (via credential.toJSON())
+     */
+    async _nativeGet(optionsJSON, extras = {}) {
+        const publicKey = PublicKeyCredential.parseRequestOptionsFromJSON(optionsJSON);
+        const credential = await navigator.credentials.get({
+            publicKey,
+            signal: WebAuthnAbortService.createNewAbortSignal(),
+            ...extras,
+        });
+        if (credential === null) {
+            throw new Error('navigator.credentials.get() returned null');
+        }
+        return credential.toJSON();
     }
 }

--- a/src/stimulus/assets/src/registration-controller.js
+++ b/src/stimulus/assets/src/registration-controller.js
@@ -131,13 +131,28 @@ export default class extends BaseController {
      */
     async _processRegistration(options) {
         try {
-            const processedOptions = this._processExtensionsInput(options);
+            let credential;
+            if (this._supportsNativeJsonHelpers()) {
+                // WebAuthn L3 §5.1.13: the user agent's native parser converts
+                // every standard field, so we don't need _processExtensionsInput.
+                // useAutoRegister maps to mediation: "conditional" per the
+                // SimpleWebAuthn implementation note.
+                credential = await this._nativeCreate(
+                    options,
+                    this.autoRegisterValue ? { mediation: 'conditional' } : {}
+                );
+            } else {
+                const processedOptions = this._processExtensionsInput(options);
+                credential = await startRegistration({
+                    optionsJSON: processedOptions,
+                    useAutoRegister: this.autoRegisterValue,
+                });
+            }
 
-            let credential = await startRegistration({
-                optionsJSON: processedOptions,
-                useAutoRegister: this.autoRegisterValue,
-            });
-
+            // Run on both paths: subclasses (e.g. payment-controller) hook
+            // here for non-WebAuthn-L3 extensions like SPC's `payment` that
+            // PublicKeyCredential.toJSON() may not encode. The base helpers
+            // are idempotent so values already encoded by toJSON() pass through.
             credential = this._processExtensionsOutput(credential);
             this._dispatchEvent('webauthn:registration:credential', { credential });
 

--- a/src/stimulus/assets/test/authentication-controller.test.js
+++ b/src/stimulus/assets/test/authentication-controller.test.js
@@ -908,4 +908,116 @@ describe('AuthenticationController', () => {
             });
         });
     });
+
+    describe('native L3 JSON helpers (parseRequestOptionsFromJSON / toJSON)', () => {
+        let originalPublicKeyCredential;
+        let originalNavigator;
+
+        beforeEach(() => {
+            originalPublicKeyCredential = globalThis.PublicKeyCredential;
+            originalNavigator = globalThis.navigator;
+        });
+
+        afterEach(() => {
+            if (originalPublicKeyCredential === undefined) {
+                delete globalThis.PublicKeyCredential;
+            } else {
+                Object.defineProperty(globalThis, 'PublicKeyCredential', {
+                    value: originalPublicKeyCredential,
+                    configurable: true,
+                });
+            }
+            if (originalNavigator) {
+                Object.defineProperty(globalThis, 'navigator', {
+                    value: originalNavigator,
+                    configurable: true,
+                });
+            }
+        });
+
+        it('uses parseRequestOptionsFromJSON + navigator.credentials.get() when available', async () => {
+            const form = getByTestId(container, 'authentication-form');
+
+            const parseSpy = jest.fn((json) => ({ __parsed: json }));
+            Object.defineProperty(globalThis, 'PublicKeyCredential', {
+                value: {
+                    parseCreationOptionsFromJSON: jest.fn(),
+                    parseRequestOptionsFromJSON: parseSpy,
+                },
+                configurable: true,
+            });
+            const credentialJson = {
+                id: 'native-cred',
+                type: 'public-key',
+                rawId: 'native-cred',
+                response: { clientDataJSON: 'd', authenticatorData: 'a', signature: 's' },
+                clientExtensionResults: {},
+            };
+            const getMock = jest.fn().mockResolvedValue({ toJSON: () => credentialJson });
+            Object.defineProperty(globalThis, 'navigator', {
+                value: { credentials: { get: getMock } },
+                configurable: true,
+            });
+
+            fetchMock
+                .mockResolvedValueOnce({ ok: true, json: async () => ({ challenge: 'test' }) })
+                .mockResolvedValueOnce({ ok: true, json: async () => ({ verified: true }) });
+
+            const credentialEvents = [];
+            form.addEventListener('webauthn:authentication:credential', (e) => {
+                credentialEvents.push(e.detail.credential);
+            });
+
+            const connectionPromise = waitForConnection(form);
+            application = startStimulus();
+            await connectionPromise;
+            submitForm(form);
+
+            await waitFor(() => {
+                expect(getMock).toHaveBeenCalledTimes(1);
+            });
+            expect(parseSpy).toHaveBeenCalledTimes(1);
+            expect(SimpleWebAuthnBrowser.startAuthentication).not.toHaveBeenCalled();
+            const callArg = getMock.mock.calls[0][0];
+            expect(callArg.publicKey).toEqual({ __parsed: { challenge: 'test' } });
+            expect(callArg.signal).toBeInstanceOf(AbortSignal);
+            expect(credentialEvents[0]).toEqual(credentialJson);
+        });
+
+        it('forwards uiMode "immediate" through navigator.credentials.get() on the native path', async () => {
+            const form = getByTestId(container, 'authentication-form');
+
+            Object.defineProperty(globalThis, 'PublicKeyCredential', {
+                value: {
+                    parseCreationOptionsFromJSON: jest.fn(),
+                    parseRequestOptionsFromJSON: (json) => json,
+                },
+                configurable: true,
+            });
+            const getMock = jest.fn().mockResolvedValue({ toJSON: () => ({ id: 'cred' }) });
+            Object.defineProperty(globalThis, 'navigator', {
+                value: { credentials: { get: getMock } },
+                configurable: true,
+            });
+
+            fetchMock
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => ({ challenge: 'test', uiMode: 'immediate' }),
+                })
+                .mockResolvedValueOnce({ ok: true, json: async () => ({ verified: true }) });
+
+            const connectionPromise = waitForConnection(form);
+            application = startStimulus();
+            await connectionPromise;
+            submitForm(form);
+
+            await waitFor(() => {
+                expect(getMock).toHaveBeenCalledTimes(1);
+            });
+            const callArg = getMock.mock.calls[0][0];
+            expect(callArg.uiMode).toBe('immediate');
+            expect(callArg.publicKey.uiMode).toBeUndefined();
+        });
+    });
 });

--- a/src/stimulus/assets/test/payment-controller.test.js
+++ b/src/stimulus/assets/test/payment-controller.test.js
@@ -179,4 +179,89 @@ describe('PaymentController', () => {
         await waitFor(() => expect(credentialEvent).not.toBeNull());
         expect(credentialEvent.credential.clientExtensionResults.payment).toBeUndefined();
     });
+
+    describe('SPC on the native L3 path', () => {
+        // The W3C SPC `payment` extension is not part of WebAuthn L3, so
+        // PublicKeyCredential.toJSON() may leave its
+        // `browserBoundSignature.signature` as an ArrayBuffer. The base
+        // controller must therefore call _processExtensionsOutput on the
+        // native path so this subclass override still runs.
+
+        let originalPublicKeyCredential;
+        let originalNavigator;
+
+        beforeEach(() => {
+            originalPublicKeyCredential = globalThis.PublicKeyCredential;
+            originalNavigator = globalThis.navigator;
+        });
+
+        afterEach(() => {
+            if (originalPublicKeyCredential === undefined) {
+                delete globalThis.PublicKeyCredential;
+            } else {
+                Object.defineProperty(globalThis, 'PublicKeyCredential', {
+                    value: originalPublicKeyCredential,
+                    configurable: true,
+                });
+            }
+            if (originalNavigator) {
+                Object.defineProperty(globalThis, 'navigator', {
+                    value: originalNavigator,
+                    configurable: true,
+                });
+            }
+        });
+
+        it('still encodes browserBoundSignature ArrayBuffer when the native helpers are used', async () => {
+            const form = getByTestId(container, 'payment-form');
+            const signatureBytes = new Uint8Array([0x68, 0x65, 0x6c, 0x6c, 0x6f]).buffer;
+            const credentialJson = {
+                id: 'cred',
+                rawId: 'raw',
+                response: { clientDataJSON: 'data', authenticatorData: 'auth', signature: 'sig' },
+                type: 'public-key',
+                clientExtensionResults: {
+                    payment: { browserBoundSignature: { signature: signatureBytes } },
+                },
+            };
+
+            Object.defineProperty(globalThis, 'PublicKeyCredential', {
+                value: {
+                    parseCreationOptionsFromJSON: jest.fn(),
+                    parseRequestOptionsFromJSON: (json) => json,
+                },
+                configurable: true,
+            });
+            const getMock = jest.fn().mockResolvedValue({ toJSON: () => credentialJson });
+            Object.defineProperty(globalThis, 'navigator', {
+                value: { credentials: { get: getMock } },
+                configurable: true,
+            });
+            SimpleWebAuthnBrowser.WebAuthnAbortService.createNewAbortSignal = jest.fn(
+                () => new AbortController().signal,
+            );
+
+            fetchMock
+                .mockResolvedValueOnce({ ok: true, json: async () => ({ challenge: 'c' }) })
+                .mockResolvedValueOnce({ ok: true, json: async () => ({ verified: true }) });
+
+            let credentialEvent = null;
+            form.addEventListener('webauthn:authentication:credential', (e) => {
+                credentialEvent = e.detail;
+            });
+
+            application = startStimulus();
+            await waitFor(() => expect(form).toBeTruthy());
+            submitForm(form);
+
+            await waitFor(() => expect(credentialEvent).not.toBeNull());
+
+            expect(getMock).toHaveBeenCalledTimes(1);
+            expect(SimpleWebAuthnBrowser.startAuthentication).not.toHaveBeenCalled();
+            const transportedSignature =
+                credentialEvent.credential.clientExtensionResults.payment.browserBoundSignature.signature;
+            expect(typeof transportedSignature).toBe('string');
+            expect(transportedSignature).toBe('aGVsbG8');
+        });
+    });
 });

--- a/src/stimulus/assets/test/registration-controller.test.js
+++ b/src/stimulus/assets/test/registration-controller.test.js
@@ -15,7 +15,10 @@ jest.mock('@simplewebauthn/browser', () => {
         browserSupportsWebAuthn: jest.fn(),
         platformAuthenticatorIsAvailable: jest.fn(),
         startRegistration: jest.fn(),
-        WebAuthnAbortService: { cancelCeremony: jest.fn() },
+        WebAuthnAbortService: {
+            cancelCeremony: jest.fn(),
+            createNewAbortSignal: jest.fn(() => new AbortController().signal),
+        },
     };
 });
 
@@ -852,6 +855,131 @@ describe('RegistrationController', () => {
             });
             const credBlob = SimpleWebAuthnBrowser.startRegistration.mock.calls[0][0].optionsJSON.extensions.credBlob;
             expect(credBlob).toBeInstanceOf(ArrayBuffer);
+        });
+    });
+
+    describe('native L3 JSON helpers (parseCreationOptionsFromJSON / toJSON)', () => {
+        // jsdom does not ship the L3 helpers; the AuthenticationController test
+        // suite already exercises the SimpleWebAuthn fallback path. Here we
+        // explicitly install the natives and check that the controller prefers
+        // them when available, bypassing SimpleWebAuthn entirely.
+
+        let originalPublicKeyCredential;
+        let originalNavigator;
+
+        beforeEach(() => {
+            originalPublicKeyCredential = globalThis.PublicKeyCredential;
+            originalNavigator = globalThis.navigator;
+        });
+
+        afterEach(() => {
+            if (originalPublicKeyCredential === undefined) {
+                delete globalThis.PublicKeyCredential;
+            } else {
+                Object.defineProperty(globalThis, 'PublicKeyCredential', {
+                    value: originalPublicKeyCredential,
+                    configurable: true,
+                });
+            }
+            if (originalNavigator) {
+                Object.defineProperty(globalThis, 'navigator', {
+                    value: originalNavigator,
+                    configurable: true,
+                });
+            }
+        });
+
+        it('uses parseCreationOptionsFromJSON + navigator.credentials.create() when available', async () => {
+            const form = getByTestId(container, 'registration-form');
+
+            const parseSpy = jest.fn((json) => ({ __parsed: json }));
+            Object.defineProperty(globalThis, 'PublicKeyCredential', {
+                value: {
+                    parseCreationOptionsFromJSON: parseSpy,
+                    parseRequestOptionsFromJSON: jest.fn(),
+                },
+                configurable: true,
+            });
+            const credentialJson = {
+                id: 'native-cred',
+                type: 'public-key',
+                rawId: 'native-cred',
+                response: { clientDataJSON: 'd', attestationObject: 'a' },
+                clientExtensionResults: {},
+            };
+            const createMock = jest.fn().mockResolvedValue({ toJSON: () => credentialJson });
+            Object.defineProperty(globalThis, 'navigator', {
+                value: { credentials: { create: createMock } },
+                configurable: true,
+            });
+
+            fetchMock
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => ({ challenge: 'test', rp: {}, user: {} }),
+                })
+                .mockResolvedValueOnce({ ok: true, json: async () => ({ verified: true }) });
+
+            const credentialEvents = [];
+            form.addEventListener('webauthn:registration:credential', (e) => {
+                credentialEvents.push(e.detail.credential);
+            });
+
+            const connectionPromise = waitForConnection(form);
+            application = startStimulus();
+            await connectionPromise;
+            submitForm(form);
+
+            await waitFor(() => {
+                expect(createMock).toHaveBeenCalledTimes(1);
+            });
+            expect(parseSpy).toHaveBeenCalledTimes(1);
+            expect(SimpleWebAuthnBrowser.startRegistration).not.toHaveBeenCalled();
+            const callArg = createMock.mock.calls[0][0];
+            expect(callArg.publicKey).toEqual({ __parsed: { challenge: 'test', rp: {}, user: {} } });
+            expect(callArg.signal).toBeInstanceOf(AbortSignal);
+            expect(credentialEvents[0]).toEqual(credentialJson);
+        });
+
+        it('forwards mediation: "conditional" on the native path when autoRegister is enabled', async () => {
+            container = mountDOM(`
+                <form
+                    data-testid="auto-register-form"
+                    data-controller="webauthn--registration"
+                    data-action="submit->webauthn--registration#register"
+                    data-webauthn--registration-options-url-value="/register/options"
+                    data-webauthn--registration-auto-register-value="true"
+                >
+                </form>
+            `);
+            const form = getByTestId(container, 'auto-register-form');
+
+            Object.defineProperty(globalThis, 'PublicKeyCredential', {
+                value: {
+                    parseCreationOptionsFromJSON: (json) => json,
+                    parseRequestOptionsFromJSON: jest.fn(),
+                },
+                configurable: true,
+            });
+            const createMock = jest.fn().mockResolvedValue({ toJSON: () => ({ id: 'cred' }) });
+            Object.defineProperty(globalThis, 'navigator', {
+                value: { credentials: { create: createMock } },
+                configurable: true,
+            });
+
+            fetchMock
+                .mockResolvedValueOnce({ ok: true, json: async () => ({ challenge: 'x' }) })
+                .mockResolvedValueOnce({ ok: true, json: async () => ({ verified: true }) });
+
+            const connectionPromise = waitForConnection(form);
+            application = startStimulus();
+            await connectionPromise;
+            submitForm(form);
+
+            await waitFor(() => {
+                expect(createMock).toHaveBeenCalledTimes(1);
+            });
+            expect(createMock.mock.calls[0][0].mediation).toBe('conditional');
         });
     });
 });


### PR DESCRIPTION
## Summary

Closes #849.

WebAuthn L3 §5.1.13–14 ships three normative helpers:

- `PublicKeyCredential.parseCreationOptionsFromJSON(json)`
- `PublicKeyCredential.parseRequestOptionsFromJSON(json)`
- `credential.toJSON()`

When the user agent supports them they convert every standard field —
challenge, `allowCredentials[].id`, and known extensions like PRF and
credBlob — without our manual base64url passes. The controllers can
then call `navigator.credentials.{create,get}()` directly and rely on
`credential.toJSON()` for the response shape, dropping a pile of glue
code on supporting browsers.

### Changes

- **`BaseController._supportsNativeJsonHelpers()`** — feature-detect
  via `typeof PublicKeyCredential.parse*OptionsFromJSON === 'function'`.
- **`BaseController._nativeCreate()` / `_nativeGet()`** — invoke the
  parser, call `navigator.credentials.{create,get}()` with a
  `WebAuthnAbortService.createNewAbortSignal()`, return
  `credential.toJSON()`.
- **`RegistrationController._processRegistration`** — prefer the
  native path when available; map `autoRegister: true` to
  `mediation: "conditional"`. Falls back to the existing SimpleWebAuthn
  path with manual `_processExtensionsInput/Output` passes when the
  natives are missing.
- **`AuthenticationController._processAuthentication`** — same fork.
  `useBrowserAutofill: true` maps to `mediation: "conditional"`;
  `uiMode === "immediate"` flows through `_nativeGet` natively (the
  SimpleWebAuthn-bypass path I added in #860 stays as the fallback for
  user agents that ship `uiMode` but not the JSON helpers — unlikely
  but cheap to keep).

### Backward compatibility

The fallback path is untouched and continues to run on jsdom, which
does not ship the L3 helpers. The existing pre-3.0 test suite already
covers it; this PR adds 4 new Jest tests that explicitly install the
natives and verify the controller prefers them, bypasses
SimpleWebAuthn, and forwards `mediation` / `uiMode` correctly.

### Reference

- https://www.w3.org/TR/webauthn-3/#dom-publickeycredential-parsecreationoptionsfromjson
- https://www.w3.org/TR/webauthn-3/#dom-publickeycredential-parserequestoptionsfromjson