### PR TITLE
feat(stimulus): adopt PublicKeyCredential.getClientCapabilities() (deprecate isConditionalMediationAvailable usage)

### DIFF
--- a/src/stimulus/assets/src/authentication-controller.js
+++ b/src/stimulus/assets/src/authentication-controller.js
@@ -3,7 +3,6 @@
 import {
     base64URLStringToBuffer,
     browserSupportsWebAuthn,
-    browserSupportsWebAuthnAutofill,
     startAuthentication,
     WebAuthnAbortService,
     WebAuthnError,
@@ -69,18 +68,23 @@ export default class extends BaseController {
     };
 
     async connect() {
+        const capabilities = await this._getClientCapabilities();
         this._dispatchEvent('webauthn:authentication:connect', {
             optionsUrl: this.optionsUrlValue,
             resultUrl: this.resultUrlValue,
             supportsPlatformAuthenticator: await platformAuthenticatorIsAvailable(),
+            capabilities,
         });
 
         if (!this.conditionalUiValue) {
             return;
         }
 
-        const supportsAutofill = await browserSupportsWebAuthnAutofill();
-        if (supportsAutofill) {
+        // WebAuthn L3 §5.1.7: prefer the native capability map over the
+        // deprecated isConditionalMediationAvailable / browserSupportsWebAuthnAutofill
+        // wrapper. _getClientCapabilities falls back to the legacy detector
+        // on user agents that have not shipped getClientCapabilities yet.
+        if (capabilities.conditionalGet === true) {
             await this._startAuthenticationWithConditionalUi();
         }
     }

--- a/src/stimulus/assets/src/base-controller.js
+++ b/src/stimulus/assets/src/base-controller.js
@@ -1,7 +1,11 @@
 'use strict';
 
 import { Controller } from '@hotwired/stimulus';
-import { base64URLStringToBuffer, bufferToBase64URLString } from '@simplewebauthn/browser';
+import {
+    base64URLStringToBuffer,
+    browserSupportsWebAuthnAutofill,
+    bufferToBase64URLString,
+} from '@simplewebauthn/browser';
 
 /**
  * Base controller for WebAuthn operations
@@ -251,5 +255,48 @@ export default class extends Controller {
      */
     _dispatchEvent(name, payload) {
         this.element.dispatchEvent(new CustomEvent(name, { detail: payload, bubbles: true }));
+    }
+
+    /**
+     * Read the WebAuthn L3 §5.1.7 client capability map for the current
+     * user agent. Memoised per controller instance.
+     *
+     * On user agents that do not implement
+     * `PublicKeyCredential.getClientCapabilities()` (everything pre-L3) this
+     * returns a synthetic plain object built from the legacy feature
+     * detectors we still depend on:
+     *
+     *  - `conditionalGet` ← `browserSupportsWebAuthnAutofill()` (which
+     *    itself wraps the deprecated `isConditionalMediationAvailable()`).
+     *
+     * Other capabilities are reported as `false` on the fallback path —
+     * callers that depend on them should treat absence as "unsupported"
+     * rather than "unknown" and either skip the optional behaviour or
+     * surface it to the user.
+     *
+     * @returns {Promise<Object<string, boolean>>}
+     */
+    async _getClientCapabilities() {
+        if (this._clientCapabilitiesCache !== undefined) {
+            return this._clientCapabilitiesCache;
+        }
+
+        if (
+            typeof PublicKeyCredential !== 'undefined' &&
+            typeof PublicKeyCredential.getClientCapabilities === 'function'
+        ) {
+            const native = await PublicKeyCredential.getClientCapabilities();
+            // The spec returns a MapLike. Normalise to a plain object so
+            // callers can treat it like any other JSON payload.
+            this._clientCapabilitiesCache =
+                native instanceof Map ? Object.fromEntries(native.entries()) : { ...native };
+            return this._clientCapabilitiesCache;
+        }
+
+        const supportsAutofill = await browserSupportsWebAuthnAutofill();
+        this._clientCapabilitiesCache = {
+            conditionalGet: supportsAutofill,
+        };
+        return this._clientCapabilitiesCache;
     }
 }

--- a/src/stimulus/assets/src/registration-controller.js
+++ b/src/stimulus/assets/src/registration-controller.js
@@ -74,6 +74,7 @@ export default class extends BaseController {
             optionsUrl: this.optionsUrlValue,
             resultUrl: this.resultUrlValue,
             supportsPlatformAuthenticator: await platformAuthenticatorIsAvailable(),
+            capabilities: await this._getClientCapabilities(),
         });
     }
 

--- a/src/stimulus/assets/test/authentication-controller.test.js
+++ b/src/stimulus/assets/test/authentication-controller.test.js
@@ -790,4 +790,122 @@ describe('AuthenticationController', () => {
             expect(credentialEvents[0].clientExtensionResults.credBlob).toBe('aGkh');
         });
     });
+
+    describe('getClientCapabilities (WebAuthn L3 §5.1.7)', () => {
+        let originalPublicKeyCredential;
+
+        beforeEach(() => {
+            originalPublicKeyCredential = globalThis.PublicKeyCredential;
+        });
+
+        afterEach(() => {
+            if (originalPublicKeyCredential === undefined) {
+                delete globalThis.PublicKeyCredential;
+            } else {
+                Object.defineProperty(globalThis, 'PublicKeyCredential', {
+                    value: originalPublicKeyCredential,
+                    configurable: true,
+                });
+            }
+        });
+
+        it('exposes the native capability map on the connect event when available', async () => {
+            const form = getByTestId(container, 'authentication-form');
+            const nativeCaps = {
+                conditionalGet: true,
+                conditionalCreate: false,
+                relatedOrigins: true,
+            };
+            Object.defineProperty(globalThis, 'PublicKeyCredential', {
+                value: { getClientCapabilities: jest.fn().mockResolvedValue(nativeCaps) },
+                configurable: true,
+            });
+
+            let connectDetail = null;
+            form.addEventListener('webauthn:authentication:connect', (e) => {
+                connectDetail = e.detail;
+            });
+            application = startStimulus();
+
+            await waitFor(() => expect(connectDetail).not.toBeNull());
+            expect(connectDetail.capabilities).toEqual(nativeCaps);
+        });
+
+        it('falls back to a synthetic map when the native API is missing', async () => {
+            // jsdom default state: no PublicKeyCredential, browserSupportsWebAuthnAutofill
+            // is mocked at file scope to resolve false.
+            delete globalThis.PublicKeyCredential;
+
+            const form = getByTestId(container, 'authentication-form');
+            let connectDetail = null;
+            form.addEventListener('webauthn:authentication:connect', (e) => {
+                connectDetail = e.detail;
+            });
+            application = startStimulus();
+
+            await waitFor(() => expect(connectDetail).not.toBeNull());
+            expect(connectDetail.capabilities).toEqual({ conditionalGet: false });
+        });
+
+        it('skips conditional UI when capabilities.conditionalGet is false even if requested', async () => {
+            container = mountDOM(`
+                <form
+                    data-testid="capabilities-cond-form"
+                    data-controller="webauthn--authentication"
+                    data-action="submit->webauthn--authentication#authenticate"
+                    data-webauthn--authentication-conditional-ui-value="true"
+                    data-webauthn--authentication-options-url-value="/auth/options"
+                    data-webauthn--authentication-result-url-value="/auth/verify"
+                >
+                </form>
+            `);
+
+            Object.defineProperty(globalThis, 'PublicKeyCredential', {
+                value: {
+                    getClientCapabilities: jest.fn().mockResolvedValue({ conditionalGet: false }),
+                },
+                configurable: true,
+            });
+
+            const form = getByTestId(container, 'capabilities-cond-form');
+            const connectionPromise = waitForConnection(form);
+            application = startStimulus();
+            await connectionPromise;
+
+            // Give the post-connect conditional-UI branch a tick to no-op.
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(fetchMock).not.toHaveBeenCalled();
+            expect(SimpleWebAuthnBrowser.startAuthentication).not.toHaveBeenCalled();
+        });
+
+        it('starts conditional UI when capabilities.conditionalGet is true', async () => {
+            container = mountDOM(`
+                <form
+                    data-testid="capabilities-cond-form-on"
+                    data-controller="webauthn--authentication"
+                    data-action="submit->webauthn--authentication#authenticate"
+                    data-webauthn--authentication-conditional-ui-value="true"
+                    data-webauthn--authentication-options-url-value="/auth/options"
+                    data-webauthn--authentication-result-url-value="/auth/verify"
+                >
+                </form>
+            `);
+
+            Object.defineProperty(globalThis, 'PublicKeyCredential', {
+                value: {
+                    getClientCapabilities: jest.fn().mockResolvedValue({ conditionalGet: true }),
+                },
+                configurable: true,
+            });
+            fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ challenge: 'c' }) });
+            SimpleWebAuthnBrowser.startAuthentication.mockResolvedValue({ id: 'cred' });
+
+            application = startStimulus();
+
+            await waitFor(() => {
+                expect(SimpleWebAuthnBrowser.startAuthentication).toHaveBeenCalled();
+            });
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Closes #848.

WebAuthn L3 §5.1.7 ships `PublicKeyCredential.getClientCapabilities()`
— a single call returns a `ClientCapability → boolean` map covering
`conditionalCreate`, `conditionalGet`, `hybridTransport`,
`passkeyPlatformAuthenticator`, `userVerifyingPlatformAuthenticator`,
`relatedOrigins`, the three Signal methods, and `extension:<name>`
entries. It supersedes `isConditionalMediationAvailable()` (deprecated
in L3) which `browserSupportsWebAuthnAutofill()` from SimpleWebAuthn
wraps.

### Changes

- **`BaseController._getClientCapabilities()`** — async helper.
  Feature-detects the native API, normalises the spec's MapLike to a
  plain object, and memoises per controller instance. On user agents
  that have not shipped the native API yet (Safari today), falls back
  to a synthetic `{ conditionalGet }` map derived from the legacy
  `browserSupportsWebAuthnAutofill()` so callers don't have to
  feature-test themselves.
- **`AuthenticationController.connect`** — gates the conditional UI
  bootstrap on `capabilities.conditionalGet === true` instead of the
  legacy detector. Adds `capabilities` to the
  `webauthn:authentication:connect` event payload so apps can tailor
  their flow (show/hide passkey buttons, enable RoR-dependent
  affordances, etc.).
- **`RegistrationController.connect`** — exposes the same
  `capabilities` map on `webauthn:registration:connect` for symmetry.

### Notes

- The legacy combined `controller.js` is intentionally untouched. It
  is disabled by default in `package.json` (`"enabled": false`) and
  predates the BaseController split.
- The "Auto-disable Related Origins when unsupported" TODO from the
  issue is moot in this PR: there is no Stimulus-side enable/disable
  for RoR — that side of the feature is server-driven via
  `.well-known/webauthn` (tracked separately in #858). Apps that want
  to gate RoR-dependent UI can read `capabilities.relatedOrigins`
  from the connect event payload.
- Migration of the deprecated `browserSupportsWebAuthnAutofill()`
  call sites is now complete on the maintained controllers (the
  legacy controller still calls it but is opt-in only).

### Tests

4 new Jest tests on `authentication-controller.test.js`:

1. Native capability map flows through to the connect event payload.
2. Synthetic fallback map is built when the native API is missing.
3. Conditional UI is skipped when `conditionalGet === false` even if
   the controller value asks for it.
4. Conditional UI bootstraps when `conditionalGet === true`.

### Reference

https://www.w3.org/TR/webauthn-3/#sctn-getClientCapabilities