### PR TITLE
feat(options): support attestationFormats + attestation on RequestOptions (NEW-L3)

### DIFF
--- a/src/webauthn/src/CeremonyStep/CheckAttestationFormatIsKnownAndValid.php
+++ b/src/webauthn/src/CeremonyStep/CheckAttestationFormatIsKnownAndValid.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Webauthn\CeremonyStep;
 
+use function in_array;
+use function sprintf;
 use function trigger_deprecation;
 use Webauthn\AttestationStatement\AttestationStatementSupportManager;
 use Webauthn\AuthenticatorAssertionResponse;
@@ -46,6 +48,18 @@ final readonly class CheckAttestationFormatIsKnownAndValid implements CeremonySt
         $this->attestationStatementSupportManager->has(
             $fmt
         ) || throw AuthenticatorResponseVerificationException::create('Unsupported attestation statement format.');
+
+        // WebAuthn L3 §5.4 / §5.5: when the relying party advertised a list of
+        // preferred attestation formats, the format actually emitted by the
+        // authenticator MUST be one of them. An empty list keeps the historical
+        // behaviour (any supported format is accepted).
+        $requestedFormats = $publicKeyCredentialOptions->attestationFormats;
+        if ($requestedFormats !== [] && ! in_array($fmt, $requestedFormats, true)) {
+            throw AuthenticatorResponseVerificationException::create(sprintf(
+                'The attestation statement format "%s" is not in the list requested by the relying party.',
+                $fmt,
+            ));
+        }
 
         $attestationStatementSupport = $this->attestationStatementSupportManager->get($fmt);
         $clientDataJSONHash = hash('sha256', $authenticatorResponse->clientDataJSON ->rawData, true);

--- a/src/webauthn/src/Denormalizer/PublicKeyCredentialOptionsDenormalizer.php
+++ b/src/webauthn/src/Denormalizer/PublicKeyCredentialOptionsDenormalizer.php
@@ -35,7 +35,7 @@ final class PublicKeyCredentialOptionsDenormalizer implements DenormalizerInterf
      */
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        /** @var array{challenge?: string, rp?: array<string, mixed>, user?: array<string, mixed>, pubKeyCredParams?: list<array<string, mixed>>, authenticatorSelection?: array<string, mixed>, attestation?: string, excludeCredentials?: list<array{id: string, type?: string, transports?: list<string>}>, allowCredentials?: list<array{id: string, type?: string, transports?: list<string>}>, timeout?: int<1, max>, extensions?: array<string, mixed>, hints?: list<string>, rpId?: string, userVerification?: string, uiMode?: string} $data */
+        /** @var array{challenge?: string, rp?: array<string, mixed>, user?: array<string, mixed>, pubKeyCredParams?: list<array<string, mixed>>, authenticatorSelection?: array<string, mixed>, attestation?: string, excludeCredentials?: list<array{id: string, type?: string, transports?: list<string>}>, allowCredentials?: list<array{id: string, type?: string, transports?: list<string>}>, timeout?: int<1, max>, extensions?: array<string, mixed>, hints?: list<string>, rpId?: string, userVerification?: string, uiMode?: string, attestationFormats?: list<string>} $data */
         if (array_key_exists('challenge', $data)) {
             $data['challenge'] = Base64UrlSafe::decodeNoPadding($data['challenge']);
         }
@@ -104,6 +104,7 @@ final class PublicKeyCredentialOptionsDenormalizer implements DenormalizerInterf
                 $data['timeout'] ?? null,
                 $extensions,
                 $data['hints'] ?? [],
+                attestationFormats: $data['attestationFormats'] ?? [],
             );
         }
         if ($type === PublicKeyCredentialRequestOptions::class) {
@@ -131,6 +132,8 @@ final class PublicKeyCredentialOptionsDenormalizer implements DenormalizerInterf
                 $extensions,
                 $data['hints'] ?? [],
                 $data['uiMode'] ?? null,
+                $data['attestation'] ?? null,
+                $data['attestationFormats'] ?? [],
             );
         }
         throw new BadMethodCallException('Unsupported type');
@@ -200,6 +203,7 @@ final class PublicKeyCredentialOptionsDenormalizer implements DenormalizerInterf
                     $context
                 ),
                 'attestation' => $object->attestation,
+                'attestationFormats' => count($object->attestationFormats) === 0 ? null : $object->attestationFormats,
                 'excludeCredentials' => $this->normalizer->normalize($object->excludeCredentials, $format, $context),
             ];
         }
@@ -210,6 +214,8 @@ final class PublicKeyCredentialOptionsDenormalizer implements DenormalizerInterf
                 'allowCredentials' => $this->normalizer->normalize($object->allowCredentials, $format, $context),
                 'userVerification' => $object->userVerification,
                 'uiMode' => $object->uiMode,
+                'attestation' => $object->attestation,
+                'attestationFormats' => count($object->attestationFormats) === 0 ? null : $object->attestationFormats,
             ];
         }
 

--- a/src/webauthn/src/PublicKeyCredentialCreationOptions.php
+++ b/src/webauthn/src/PublicKeyCredentialCreationOptions.php
@@ -6,6 +6,7 @@ namespace Webauthn;
 
 use function in_array;
 use InvalidArgumentException;
+use function is_string;
 use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
 use Webauthn\Exception\InvalidDataException;
 
@@ -53,6 +54,7 @@ final class PublicKeyCredentialCreationOptions extends PublicKeyCredentialOption
      * @param PublicKeyCredentialDescriptor[] $excludeCredentials
      * @param null|positive-int $timeout
      * @param string[] $hints
+     * @param string[] $attestationFormats RP-preferred attestation statement formats, in priority order (WebAuthn L3 §5.4).
      */
     public function __construct(
         public readonly PublicKeyCredentialRpEntity $rp,
@@ -66,6 +68,7 @@ final class PublicKeyCredentialCreationOptions extends PublicKeyCredentialOption
         null|AuthenticationExtensions $extensions = null,
         array $hints = [],
         null|string $mediation = null,
+        public array $attestationFormats = [],
     ) {
         foreach ($pubKeyCredParams as $pubKeyCredParam) {
             $pubKeyCredParam instanceof PublicKeyCredentialParameters || throw new InvalidArgumentException(
@@ -75,6 +78,11 @@ final class PublicKeyCredentialCreationOptions extends PublicKeyCredentialOption
         foreach ($excludeCredentials as $excludeCredential) {
             $excludeCredential instanceof PublicKeyCredentialDescriptor || throw new InvalidArgumentException(
                 'Invalid type for $excludeCredentials'
+            );
+        }
+        foreach ($attestationFormats as $attestationFormat) {
+            is_string($attestationFormat) || throw new InvalidArgumentException(
+                'Invalid type for $attestationFormats: each entry must be a string'
             );
         }
         in_array($attestation, self::ATTESTATION_CONVEYANCE_PREFERENCES, true) || throw InvalidDataException::create(
@@ -96,6 +104,7 @@ final class PublicKeyCredentialCreationOptions extends PublicKeyCredentialOption
      * @param PublicKeyCredentialDescriptor[] $excludeCredentials
      * @param null|positive-int $timeout
      * @param string[] $hints
+     * @param string[] $attestationFormats
      */
     public static function create(
         PublicKeyCredentialRpEntity $rp,
@@ -109,6 +118,7 @@ final class PublicKeyCredentialCreationOptions extends PublicKeyCredentialOption
         null|AuthenticationExtensions $extensions = null,
         array $hints = [],
         null|string $mediation = null,
+        array $attestationFormats = [],
     ): self {
         return new self(
             $rp,
@@ -122,6 +132,7 @@ final class PublicKeyCredentialCreationOptions extends PublicKeyCredentialOption
             $extensions,
             $hints,
             $mediation,
+            $attestationFormats,
         );
     }
 }

--- a/src/webauthn/src/PublicKeyCredentialRequestOptions.php
+++ b/src/webauthn/src/PublicKeyCredentialRequestOptions.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Webauthn;
 
 use function in_array;
+use InvalidArgumentException;
+use function is_string;
 use Webauthn\AuthenticationExtensions\AuthenticationExtension;
 use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
 use Webauthn\Exception\InvalidDataException;
@@ -51,6 +53,7 @@ final class PublicKeyCredentialRequestOptions extends PublicKeyCredentialOptions
      * @param PublicKeyCredentialDescriptor[] $allowCredentials
      * @param null|AuthenticationExtensions|array<array-key, AuthenticationExtension> $extensions
      * @param string[] $hints
+     * @param string[] $attestationFormats RP-preferred attestation statement formats, in priority order (WebAuthn L3 §5.5).
      */
     public function __construct(
         string $challenge,
@@ -61,6 +64,8 @@ final class PublicKeyCredentialRequestOptions extends PublicKeyCredentialOptions
         null|array|AuthenticationExtensions $extensions = null,
         array $hints = [],
         public null|string $uiMode = null,
+        public null|string $attestation = null,
+        public array $attestationFormats = [],
     ) {
         in_array($userVerification, self::USER_VERIFICATION_REQUIREMENTS, true) || throw InvalidDataException::create(
             $userVerification,
@@ -70,6 +75,16 @@ final class PublicKeyCredentialRequestOptions extends PublicKeyCredentialOptions
             $uiMode,
             'Invalid UI mode'
         );
+        in_array(
+            $attestation,
+            PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCES,
+            true,
+        ) || throw InvalidDataException::create($attestation, 'Invalid attestation conveyance mode');
+        foreach ($attestationFormats as $attestationFormat) {
+            is_string($attestationFormat) || throw new InvalidArgumentException(
+                'Invalid type for $attestationFormats: each entry must be a string'
+            );
+        }
         parent::__construct(
             $challenge,
             $timeout,
@@ -83,6 +98,7 @@ final class PublicKeyCredentialRequestOptions extends PublicKeyCredentialOptions
      * @param positive-int $timeout
      * @param null|AuthenticationExtensions|array<array-key, AuthenticationExtension> $extensions
      * @param string[] $hints
+     * @param string[] $attestationFormats
      */
     public static function create(
         string $challenge,
@@ -93,6 +109,8 @@ final class PublicKeyCredentialRequestOptions extends PublicKeyCredentialOptions
         null|array|AuthenticationExtensions $extensions = null,
         array $hints = [],
         null|string $uiMode = null,
+        null|string $attestation = null,
+        array $attestationFormats = [],
     ): self {
         return new self(
             $challenge,
@@ -103,6 +121,8 @@ final class PublicKeyCredentialRequestOptions extends PublicKeyCredentialOptions
             $extensions,
             $hints,
             $uiMode,
+            $attestation,
+            $attestationFormats,
         );
     }
 }

--- a/tests/library/Unit/CeremonyStep/CheckAttestationFormatIsKnownAndValidTest.php
+++ b/tests/library/Unit/CeremonyStep/CheckAttestationFormatIsKnownAndValidTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Unit\CeremonyStep;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+use Webauthn\AttestationStatement\AttestationObject;
+use Webauthn\AttestationStatement\AttestationStatement;
+use Webauthn\AttestationStatement\AttestationStatementSupport;
+use Webauthn\AttestationStatement\AttestationStatementSupportManager;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\AuthenticatorData;
+use Webauthn\CeremonyStep\CheckAttestationFormatIsKnownAndValid;
+use Webauthn\CollectedClientData;
+use Webauthn\CredentialRecord;
+use Webauthn\Exception\AuthenticatorResponseVerificationException;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialDescriptor;
+use Webauthn\PublicKeyCredentialRpEntity;
+use Webauthn\PublicKeyCredentialUserEntity;
+use Webauthn\TrustPath\EmptyTrustPath;
+
+/**
+ * @internal
+ */
+final class CheckAttestationFormatIsKnownAndValidTest extends TestCase
+{
+    #[Test]
+    public function emptyAttestationFormatsListAcceptsAnySupportedFormat(): void
+    {
+        $step = new CheckAttestationFormatIsKnownAndValid($this->supportManagerAccepting('packed', valid: true));
+
+        $step->process(
+            $this->credentialRecord(),
+            $this->attestationResponseWithFormat('packed'),
+            $this->creationOptions([]),
+            null,
+            'example.com',
+        );
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function nonEmptyAttestationFormatsListAcceptsMatchingFormat(): void
+    {
+        $step = new CheckAttestationFormatIsKnownAndValid($this->supportManagerAccepting('packed', valid: true));
+
+        $step->process(
+            $this->credentialRecord(),
+            $this->attestationResponseWithFormat('packed'),
+            $this->creationOptions(['packed', 'tpm']),
+            null,
+            'example.com',
+        );
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function nonEmptyAttestationFormatsListRejectsUnrequestedFormat(): void
+    {
+        $step = new CheckAttestationFormatIsKnownAndValid($this->supportManagerAccepting('packed', valid: true));
+
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+        $this->expectExceptionMessage('"packed" is not in the list requested');
+
+        $step->process(
+            $this->credentialRecord(),
+            $this->attestationResponseWithFormat('packed'),
+            $this->creationOptions(['tpm', 'fido-u2f']),
+            null,
+            'example.com',
+        );
+    }
+
+    private function credentialRecord(): CredentialRecord
+    {
+        return CredentialRecord::create(
+            'credential-id',
+            PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
+            [],
+            'none',
+            EmptyTrustPath::create(),
+            Uuid::v4(),
+            'public-key',
+            'user-handle',
+            0,
+        );
+    }
+
+    /**
+     * @param string[] $attestationFormats
+     */
+    private function creationOptions(array $attestationFormats): PublicKeyCredentialCreationOptions
+    {
+        return PublicKeyCredentialCreationOptions::create(
+            PublicKeyCredentialRpEntity::create('Test RP'),
+            PublicKeyCredentialUserEntity::create('alice', 'uid', 'Alice'),
+            'challenge-bytes',
+            attestationFormats: $attestationFormats,
+        );
+    }
+
+    private function attestationResponseWithFormat(string $fmt): AuthenticatorAttestationResponse
+    {
+        $authData = AuthenticatorData::create(
+            authData: '',
+            rpIdHash: str_repeat("\0", 32),
+            flags: "\x01",
+            signCount: 0,
+        );
+
+        return AuthenticatorAttestationResponse::create(
+            CollectedClientData::create('{}', [
+                'type' => 'webauthn.create',
+                'challenge' => 'challenge-bytes',
+                'origin' => 'https://example.com',
+            ]),
+            AttestationObject::create(
+                rawAttestationObject: '',
+                attStmt: AttestationStatement::createNone($fmt, [], EmptyTrustPath::create()),
+                authData: $authData,
+            ),
+        );
+    }
+
+    private function supportManagerAccepting(string $fmt, bool $valid): AttestationStatementSupportManager
+    {
+        /** @var AttestationStatementSupport&MockObject $support */
+        $support = $this->createMock(AttestationStatementSupport::class);
+        $support->method('name')
+            ->willReturn($fmt);
+        $support->method('isValid')
+            ->willReturn($valid);
+
+        $manager = AttestationStatementSupportManager::create();
+        $manager->add($support);
+
+        return $manager;
+    }
+}

--- a/tests/library/Unit/PublicKeyCredentialCreationOptionsTest.php
+++ b/tests/library/Unit/PublicKeyCredentialCreationOptionsTest.php
@@ -274,4 +274,61 @@ final class PublicKeyCredentialCreationOptionsTest extends AbstractTestCase
 
         static::assertSame(PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL, $restored->mediation);
     }
+
+    #[Test]
+    public function attestationFormatsRoundTripToJson(): void
+    {
+        $options = PublicKeyCredentialCreationOptions::create(
+            PublicKeyCredentialRpEntity::create('Test'),
+            PublicKeyCredentialUserEntity::create('alice', 'uid', 'Alice'),
+            'challenge',
+            attestationFormats: ['packed', 'fido-u2f'],
+        );
+
+        $json = $this->getSerializer()
+            ->serialize($options, 'json', [
+                AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+            ]);
+
+        static::assertSame(['packed', 'fido-u2f'], $options->attestationFormats);
+        static::assertStringContainsString('"attestationFormats":["packed","fido-u2f"]', $json);
+
+        /** @var PublicKeyCredentialCreationOptions $deserialized */
+        $deserialized = $this->getSerializer()
+            ->deserialize($json, PublicKeyCredentialCreationOptions::class, 'json');
+        static::assertSame(['packed', 'fido-u2f'], $deserialized->attestationFormats);
+    }
+
+    #[Test]
+    public function emptyAttestationFormatsAreOmittedFromJson(): void
+    {
+        $options = PublicKeyCredentialCreationOptions::create(
+            PublicKeyCredentialRpEntity::create('Test'),
+            PublicKeyCredentialUserEntity::create('alice', 'uid', 'Alice'),
+            'challenge',
+        );
+
+        $json = $this->getSerializer()
+            ->serialize($options, 'json', [
+                AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+            ]);
+
+        static::assertSame([], $options->attestationFormats);
+        static::assertStringNotContainsString('attestationFormats', $json);
+    }
+
+    #[Test]
+    public function attestationFormatsRejectsNonStringEntries(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('each entry must be a string');
+
+        /** @phpstan-ignore-next-line */
+        PublicKeyCredentialCreationOptions::create(
+            PublicKeyCredentialRpEntity::create('Test'),
+            PublicKeyCredentialUserEntity::create('alice', 'uid', 'Alice'),
+            'challenge',
+            attestationFormats: ['packed', 42],
+        );
+    }
 }

--- a/tests/library/Unit/PublicKeyCredentialRequestOptionsTest.php
+++ b/tests/library/Unit/PublicKeyCredentialRequestOptionsTest.php
@@ -214,6 +214,82 @@ final class PublicKeyCredentialRequestOptionsTest extends AbstractTestCase
     }
 
     #[Test]
+    public function attestationFieldRoundTripsToJson(): void
+    {
+        $options = PublicKeyCredentialRequestOptions::create('challenge', attestation: 'direct');
+
+        $json = $this->getSerializer()
+            ->serialize($options, 'json', [
+                AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+            ]);
+
+        static::assertSame('direct', $options->attestation);
+        static::assertJsonStringEqualsJsonString(
+            '{"challenge":"Y2hhbGxlbmdl","allowCredentials":[],"attestation":"direct"}',
+            $json,
+        );
+
+        /** @var PublicKeyCredentialRequestOptions $deserialized */
+        $deserialized = $this->getSerializer()
+            ->deserialize($json, PublicKeyCredentialRequestOptions::class, 'json');
+        static::assertSame('direct', $deserialized->attestation);
+    }
+
+    #[Test]
+    public function attestationFieldRejectsUnknownValue(): void
+    {
+        $this->expectException(InvalidDataException::class);
+        $this->expectExceptionMessage('Invalid attestation conveyance mode');
+
+        PublicKeyCredentialRequestOptions::create('challenge', attestation: 'bogus');
+    }
+
+    #[Test]
+    public function attestationFormatsRoundTripToJson(): void
+    {
+        $options = PublicKeyCredentialRequestOptions::create('challenge', attestationFormats: ['packed', 'tpm']);
+
+        $json = $this->getSerializer()
+            ->serialize($options, 'json', [
+                AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+            ]);
+
+        static::assertSame(['packed', 'tpm'], $options->attestationFormats);
+        static::assertJsonStringEqualsJsonString(
+            '{"challenge":"Y2hhbGxlbmdl","allowCredentials":[],"attestationFormats":["packed","tpm"]}',
+            $json,
+        );
+
+        /** @var PublicKeyCredentialRequestOptions $deserialized */
+        $deserialized = $this->getSerializer()
+            ->deserialize($json, PublicKeyCredentialRequestOptions::class, 'json');
+        static::assertSame(['packed', 'tpm'], $deserialized->attestationFormats);
+    }
+
+    #[Test]
+    public function emptyAttestationFormatsAreOmittedFromJson(): void
+    {
+        $options = PublicKeyCredentialRequestOptions::create('challenge');
+        $json = $this->getSerializer()
+            ->serialize($options, 'json', [
+                AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+            ]);
+
+        static::assertSame([], $options->attestationFormats);
+        static::assertStringNotContainsString('attestationFormats', $json);
+    }
+
+    #[Test]
+    public function attestationFormatsRejectsNonStringEntries(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('each entry must be a string');
+
+        /** @phpstan-ignore-next-line */
+        PublicKeyCredentialRequestOptions::create('challenge', attestationFormats: ['packed', 42]);
+    }
+
+    #[Test]
     public function publicKeyCredentialRequestOptionsWithAllThreeHintsPreservesAllValues(): void
     {
         // Given


### PR DESCRIPTION
## Summary

Closes #847.

WebAuthn L3 §5.4 / §5.5 adds two new options-side fields:

- **`attestationFormats: sequence<DOMString>`** — RP-preferred
  attestation statement formats, in priority order. Now exposed on
  both `PublicKeyCredentialCreationOptions` and
  `PublicKeyCredentialRequestOptions`.
- **`attestation: AttestationConveyancePreference`** is now also
  allowed on request options (assertion conveyance), reusing the same
  enum (`none | indirect | direct | enterprise`) as creation options.

### Changes

- **Options classes** — both gain the new fields with constructor-side
  validation (entry types, enum), empty defaults, and
  named-argument-friendly factories.
- **`PublicKeyCredentialOptionsDenormalizer`** — round-trips both
  fields through JSON in either direction. Empty
  `attestationFormats` lists are omitted from the JSON payload (matches
  the spec's "absent ⇔ empty preference" semantics).
- **`CheckAttestationFormatIsKnownAndValid`** — now cross-checks the
  authenticator's emitted format against the requested list when it is
  non-empty, raising `AuthenticatorResponseVerificationException` on
  mismatch. Empty list keeps the historical "any supported format
  accepted" behaviour, so this is a strict-but-additive change.

### Stimulus

No controller change required. `attestation` and `attestationFormats`
ride along inside `optionsJSON` and reach
`navigator.credentials.{create,get}()` unchanged. Browsers that
implement the L3 dictionary read them; older browsers ignore them.

### Tests

- 4 new unit tests on `PublicKeyCredentialRequestOptionsTest`:
  attestation round-trip, unknown-value rejection,
  attestationFormats round-trip, empty-list omission, and the
  type-rejection guard.
- 3 new unit tests on `PublicKeyCredentialCreationOptionsTest`:
  attestationFormats round-trip, empty-list omission, type rejection.
- New `CheckAttestationFormatIsKnownAndValidTest` covering the three
  branches: empty list (any format), matching list, mismatched list.

### Reference

- https://www.w3.org/TR/webauthn-3/#dictionary-makecredentialoptions
- https://www.w3.org/TR/webauthn-3/#dictionary-assertion-options