### PR TITLE
docs(examples): add extensions-demo (credProps + credProtect + credBlob + minPinLength in one ceremony)

### DIFF
--- a/docs/examples/extensions-demo/.gitignore
+++ b/docs/examples/extensions-demo/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+/composer.lock
+/var/*.json

--- a/docs/examples/extensions-demo/README.md
+++ b/docs/examples/extensions-demo/README.md
@@ -96,7 +96,13 @@ Note where each one lives:
 - **`credProtect` + `enforce`**: with `enforce: true`, an authenticator that
   does not implement `credProtect` will fail registration outright instead of
   silently downgrading. The applied-policy column in the result table lets you
-  spot a downgrade if you remove `enforce`.
+  spot a downgrade if you remove `enforce`. The router only sets
+  `enforce: true` for levels 2 and 3 — pairing it with level 1
+  (`userVerificationOptional`) makes modern passkey-capable authenticators
+  (iCloud Keychain, Windows Hello, Android) refuse with *"Requested
+  protection policy is inconsistent or incongruent with other requested
+  parameters"*: they default to creating a discoverable credential, which
+  forces credProtect ≥ level 2, incompatible with enforcing level 1.
 - **`credProtect` requires consistent `authenticatorSelection`** (CTAP 2.1
   §12.1). The router attaches it automatically:
   - `userVerificationOptionalWithCredentialIDList` → `residentKey: required`

--- a/docs/examples/extensions-demo/README.md
+++ b/docs/examples/extensions-demo/README.md
@@ -97,6 +97,12 @@ Note where each one lives:
   does not implement `credProtect` will fail registration outright instead of
   silently downgrading. The applied-policy column in the result table lets you
   spot a downgrade if you remove `enforce`.
+- **`credProtect` requires consistent `authenticatorSelection`** (CTAP 2.1
+  §12.1). The router attaches it automatically:
+  - `userVerificationOptionalWithCredentialIDList` → `residentKey: required`
+  - `userVerificationRequired` → `residentKey: required` + `userVerification: required`
+  Without these, the authenticator returns *"Requested protection policy is
+  inconsistent or incongruent with other requested parameters."*
 - **Demo storage** is a JSON file under `var/credentials.json` — persistent
   across `./run.sh` invocations but trivially resettable (just delete the
   file). Production code MUST go through

--- a/docs/examples/extensions-demo/README.md
+++ b/docs/examples/extensions-demo/README.md
@@ -1,0 +1,118 @@
+# Authenticator Extensions Demo
+
+A single end-to-end playground that exercises four CTAP / WebAuthn extensions
+that `web-auth/webauthn-lib` 5.4 supports out of the box but which were missing
+a worked example:
+
+| Extension                       | Spec                | What you'll see                                                                                            |
+| ------------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `credProps`                     | WebAuthn L3 §10.1.3 | The `rk` flag and (when supported) `authenticatorDisplayName` reported back by the user agent.             |
+| `credProtect`                   | CTAP 2.1 §12.1      | The protection policy actually applied by the authenticator, with `enforce` to detect silent downgrades.   |
+| `credBlob` / `getCredBlob`      | CTAP 2.1 §12.2      | Up to 32 bytes stored on the authenticator at registration, retrieved during a later assertion.            |
+| `minPinLength`                  | CTAP 2.1 §12.4      | The authenticator's configured minimum PIN length (only emitted on the enterprise allow-list — see notes). |
+
+The four are exercised in **a single ceremony** rather than four separate
+demos. They overlap conceptually (`credProps.rk` tells you whether your
+`credProtect` policy is meaningful), so combining them into one page keeps the
+plumbing minimal and lets you toggle each independently to see what changes.
+
+## Run it
+
+From this directory:
+
+```bash
+./same-origin/run.sh
+```
+
+This installs Composer dependencies (first run only) and starts the PHP
+built-in server on `http://localhost:8000`. Then:
+
+1. <http://localhost:8000/> — overview + table of what each extension does.
+2. <http://localhost:8000/register.html> — pick a username, optionally pick a
+   `credProtect` policy, optionally type a `credBlob` payload (≤32 bytes), and
+   register. The server-parsed extension outputs are summarised in a table.
+3. <http://localhost:8000/assert.html> — authenticate against a previously
+   registered credential. The server uses
+   `CredentialBlobAssertionOutput::fromExtensions()` to parse the bytes the
+   authenticator returned and compares them with what was stored.
+
+## What the server-side code looks like
+
+All four extensions are attached when building the registration options
+(see [`same-origin/router.php`](same-origin/router.php)):
+
+```php
+$extensions = [
+    CredentialPropertiesInputExtension::enable(),
+    MinPinLengthInputExtension::enable(),
+];
+
+if ($policy !== null) {
+    $extensions[] = CredentialProtectionInputExtension::userVerificationRequired();
+    $extensions[] = CredentialProtectionInputExtension::enforce();
+}
+
+if ($blob !== '') {
+    $extensions[] = CredentialBlobInputExtension::withBlob($blob);
+}
+
+$options = PublicKeyCredentialCreationOptions::create(
+    rp: PublicKeyCredentialRpEntity::create(...),
+    user: PublicKeyCredentialUserEntity::create(...),
+    challenge: random_bytes(32),
+    pubKeyCredParams: [...],
+    attestation: PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
+    extensions: AuthenticationExtensions::create($extensions),
+);
+```
+
+After validating the attestation, the server reads each extension output via
+its typed value object:
+
+```php
+$credProps    = CredentialPropertiesOutput::fromExtensions($clientExtensions);
+$minPinLength = MinPinLengthOutput::fromExtensions($authenticatorExtensions);
+$credProtect  = CredentialProtectionOutput::fromExtensions($authenticatorExtensions);
+$credBlobReg  = CredentialBlobRegistrationOutput::fromExtensions($authenticatorExtensions);
+```
+
+Note where each one lives:
+
+- `credProps` is a **client** extension (`clientExtensionResults`) — translated
+  by the user agent, never by the authenticator.
+- `credProtect`, `credBlob`, `minPinLength` are **authenticator** extensions
+  (`authData.extensions`) — emitted by the authenticator itself.
+
+## Notes & caveats
+
+- **Browser support varies.** As of mid-2026, Chrome on Android/Linux honours
+  `credProtect` and `credBlob` end-to-end. Safari ignores most of these.
+  Firefox is in-between. The demo gracefully reports `absent` for any
+  extension the authenticator did not return.
+- **`minPinLength` is gated on the enterprise allow-list** of the authenticator.
+  If your authenticator firmware does not have `localhost` (or your RP id)
+  whitelisted, the response will be absent — that is a feature of the spec,
+  not a demo bug.
+- **`credProtect` + `enforce`**: with `enforce: true`, an authenticator that
+  does not implement `credProtect` will fail registration outright instead of
+  silently downgrading. The applied-policy column in the result table lets you
+  spot a downgrade if you remove `enforce`.
+- **Demo storage** is a JSON file under `var/credentials.json` — persistent
+  across `./run.sh` invocations but trivially resettable (just delete the
+  file). Production code MUST go through
+  `Webauthn\CredentialRecordRepositoryInterface`.
+- **No HTTPS.** The same-origin demo runs on plain HTTP because
+  `localhost` is a [secure context](https://w3c.github.io/webappsec-secure-contexts/#localhost)
+  for WebAuthn purposes. Do not deploy this demo behind anything other than a
+  fresh `php -S` on your laptop.
+
+## Spec references
+
+- WebAuthn L3 §10.1.3 — Credential Properties
+  <https://www.w3.org/TR/webauthn-3/#sctn-authenticator-credential-properties-extension>
+- CTAP 2.1 §12.1 — `credProtect`
+  <https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#sctn-credProtect-extension>
+- CTAP 2.1 §12.2 — `credBlob`
+  <https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#sctn-credBlob-extension>
+- CTAP 2.1 §12.4 — `minPinLength`
+  <https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#sctn-minpinlength-extension>

--- a/docs/examples/extensions-demo/composer.json
+++ b/docs/examples/extensions-demo/composer.json
@@ -1,0 +1,30 @@
+{
+    "name": "web-auth/extensions-demo",
+    "description": "End-to-end demo of CTAP 2.1 + WebAuthn L3 authenticator extensions (credProps, credProtect, credBlob, minPinLength) using web-auth/webauthn-lib",
+    "type": "project",
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../..",
+            "options": {
+                "symlink": true,
+                "versions": {
+                    "web-auth/webauthn-framework": "5.4.x-dev"
+                }
+            }
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "ext-json": "*",
+        "ext-openssl": "*",
+        "web-auth/webauthn-framework": "5.4.x-dev",
+        "symfony/clock": "^6.4 || ^7.0",
+        "symfony/serializer": "^6.4 || ^7.0",
+        "symfony/property-access": "^6.4 || ^7.0",
+        "symfony/property-info": "^6.4 || ^7.0",
+        "symfony/uid": "^6.4 || ^7.0"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/docs/examples/extensions-demo/same-origin/public/assert.html
+++ b/docs/examples/extensions-demo/same-origin/public/assert.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Extensions Demo — Assert</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 760px; margin: 40px auto; padding: 20px; color: #1f2937; line-height: 1.55; }
+        h1 { font-size: 1.6rem; }
+        nav a { color: #2563eb; margin-right: 1rem; }
+        button { margin-top: 1.5rem; padding: 10px 18px; background: #2563eb; color: white; border: 0; border-radius: 6px; font-size: 1rem; cursor: pointer; }
+        button:hover { background: #1d4ed8; }
+        button:disabled { background: #9ca3af; cursor: not-allowed; }
+        code { background: #f3f4f6; padding: 2px 5px; border-radius: 4px; }
+        #status { margin-top: 1.5rem; padding: 12px 16px; border-radius: 6px; }
+        #status.ok { background: #ecfdf5; border-left: 4px solid #10b981; }
+        #status.err { background: #fef2f2; border-left: 4px solid #ef4444; color: #991b1b; }
+        table { border-collapse: collapse; width: 100%; margin-top: 1rem; }
+        th, td { border: 1px solid #e5e7eb; padding: 8px 12px; text-align: left; vertical-align: top; }
+        th { background: #f9fafb; font-weight: 600; }
+        td.muted { color: #6b7280; font-style: italic; }
+    </style>
+</head>
+<body>
+<h1>Assert + retrieve credBlob</h1>
+
+<nav><a href="index.html">← home</a> | <a href="register.html">→ register.html</a></nav>
+
+<p>
+    Asks the authenticator for an assertion against any of the credentials registered earlier,
+    with the <code>getCredBlob</code> extension enabled. The bytes the server sees are surfaced
+    below as base64url and (when valid UTF-8) as plain text.
+</p>
+
+<button id="run" type="button">Authenticate</button>
+
+<div id="status"></div>
+
+<div id="results" hidden>
+    <h2>Results</h2>
+    <table>
+        <thead><tr><th>Field</th><th>Value</th></tr></thead>
+        <tbody id="resultRows"></tbody>
+    </table>
+</div>
+
+<script type="module">
+    const runBtn = document.getElementById('run');
+    const statusEl = document.getElementById('status');
+    const resultsEl = document.getElementById('results');
+    const resultRows = document.getElementById('resultRows');
+
+    function setStatus(msg, ok) {
+        statusEl.textContent = msg;
+        statusEl.className = ok ? 'ok' : 'err';
+    }
+
+    function b64urlToBuffer(s) {
+        const pad = '='.repeat((4 - (s.length % 4)) % 4);
+        const b64 = (s + pad).replace(/-/g, '+').replace(/_/g, '/');
+        const bin = atob(b64);
+        const out = new Uint8Array(bin.length);
+        for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+        return out.buffer;
+    }
+    function bufferToB64url(buf) {
+        const bytes = new Uint8Array(buf);
+        let s = '';
+        for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+        return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+    }
+    function hydrateOptions(json) {
+        const o = { ...json };
+        o.challenge = b64urlToBuffer(json.challenge);
+        if (Array.isArray(json.allowCredentials)) {
+            o.allowCredentials = json.allowCredentials.map((c) => ({ ...c, id: b64urlToBuffer(c.id) }));
+        }
+        return o;
+    }
+    function dehydrateCredential(cred) {
+        if (typeof cred.toJSON === 'function') return cred.toJSON();
+        const r = cred.response;
+        return {
+            id: cred.id,
+            rawId: bufferToB64url(cred.rawId),
+            type: cred.type,
+            response: {
+                clientDataJSON: bufferToB64url(r.clientDataJSON),
+                authenticatorData: bufferToB64url(r.authenticatorData),
+                signature: bufferToB64url(r.signature),
+                userHandle: r.userHandle ? bufferToB64url(r.userHandle) : null,
+            },
+            clientExtensionResults: cred.getClientExtensionResults?.() ?? {},
+        };
+    }
+    function row(name, value) {
+        const tr = document.createElement('tr');
+        const th = document.createElement('td');
+        th.innerHTML = `<code>${name}</code>`;
+        const td = document.createElement('td');
+        if (value === null || value === undefined || value === '') {
+            td.className = 'muted';
+            td.textContent = 'absent';
+        } else {
+            td.textContent = value;
+        }
+        tr.appendChild(th);
+        tr.appendChild(td);
+        return tr;
+    }
+
+    runBtn.addEventListener('click', async () => {
+        if (!('credentials' in navigator)) {
+            setStatus('navigator.credentials is unavailable in this context.', false);
+            return;
+        }
+        runBtn.disabled = true;
+        setStatus('Requesting options…', true);
+        resultsEl.hidden = true;
+
+        try {
+            const optsRes = await fetch('/assert/options', { method: 'POST' });
+            if (!optsRes.ok) {
+                const j = await optsRes.json().catch(() => ({}));
+                throw new Error(j.error ?? `Options HTTP ${optsRes.status}`);
+            }
+            const { options, allowed } = await optsRes.json();
+
+            setStatus('Calling navigator.credentials.get()…', true);
+            const credential = await navigator.credentials.get({ publicKey: hydrateOptions(options) });
+            const credJson = dehydrateCredential(credential);
+
+            setStatus('Verifying with the relying party…', true);
+            const resultRes = await fetch('/assert/result', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(credJson),
+            });
+            const result = await resultRes.json();
+            if (!resultRes.ok || result.error) throw new Error(result.error ?? `Result HTTP ${resultRes.status}`);
+
+            const matched = allowed.find((a) => a.credentialId === btoa(String.fromCharCode(...new Uint8Array(b64urlToBuffer(credJson.rawId)))));
+
+            setStatus('✓ Authenticated.', true);
+            resultRows.innerHTML = '';
+            resultRows.appendChild(row('credBlob (base64url)', result.credBlob));
+            resultRows.appendChild(row('credBlob (UTF-8)', result.credBlobUtf8));
+            resultRows.appendChild(row('Originally stored at registration', matched?.credBlob));
+            resultRows.appendChild(row('Match?', matched?.credBlob && result.credBlobUtf8 === matched.credBlob ? 'yes ✓' : 'no'));
+            resultsEl.hidden = false;
+        } catch (err) {
+            setStatus(`✗ ${err.message}`, false);
+        } finally {
+            runBtn.disabled = false;
+        }
+    });
+</script>
+</body>
+</html>

--- a/docs/examples/extensions-demo/same-origin/public/index.html
+++ b/docs/examples/extensions-demo/same-origin/public/index.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Authenticator Extensions Demo — Home</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 760px; margin: 40px auto; padding: 20px; color: #1f2937; line-height: 1.55; }
+        h1 { font-size: 1.6rem; }
+        h2 { font-size: 1.2rem; margin-top: 1.6rem; }
+        nav a { color: #2563eb; margin-right: 1rem; }
+        code { background: #f3f4f6; padding: 2px 5px; border-radius: 4px; }
+        table { border-collapse: collapse; width: 100%; margin-top: 1rem; }
+        th, td { border: 1px solid #e5e7eb; padding: 8px 12px; text-align: left; vertical-align: top; }
+        th { background: #f9fafb; font-weight: 600; }
+        td.muted { color: #6b7280; font-style: italic; }
+    </style>
+</head>
+<body>
+<h1>WebAuthn / CTAP authenticator extensions — playground</h1>
+
+<p>
+    A minimal end-to-end demo for four extensions <code>web-auth/webauthn-lib</code> exposes:
+    <code>credProps</code>, <code>credProtect</code>, <code>credBlob</code> /
+    <code>getCredBlob</code>, and <code>minPinLength</code>. The
+    <a href="register.html">registration page</a> lets you toggle each one and shows what the
+    user agent / authenticator actually returned. The
+    <a href="assert.html">assertion page</a> exercises <code>getCredBlob</code> to retrieve
+    the bytes you stored at registration.
+</p>
+
+<table>
+    <thead>
+        <tr><th>Extension</th><th>Spec</th><th>What it does</th></tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>credProps</code></td>
+            <td>WebAuthn L3 §10.1.3</td>
+            <td>The user agent reports back <code>rk</code> (true if a discoverable
+                credential / passkey was created) and an optional
+                <code>authenticatorDisplayName</code> hint.</td>
+        </tr>
+        <tr>
+            <td><code>credProtect</code></td>
+            <td>CTAP 2.1 §12.1</td>
+            <td>Pin one of three protection policies on the credential. The authenticator
+                returns the policy it actually applied, so you can detect silent downgrades.
+                Use <code>enforce</code> to fail registration rather than downgrade.</td>
+        </tr>
+        <tr>
+            <td><code>credBlob</code> / <code>getCredBlob</code></td>
+            <td>CTAP 2.1 §12.2</td>
+            <td>Store ≤32 bytes of opaque data alongside the credential at registration time
+                and ask for them back during a later assertion.</td>
+        </tr>
+        <tr>
+            <td><code>minPinLength</code></td>
+            <td>CTAP 2.1 §12.4</td>
+            <td>Retrieve the minimum PIN length configured on the authenticator (only
+                returned when the relying party id is on the authenticator's enterprise
+                allow-list — otherwise <span class="muted">absent</span>).</td>
+        </tr>
+    </tbody>
+</table>
+
+<h2>Walk-through</h2>
+<ol>
+    <li>Open the <a href="register.html">registration page</a>.</li>
+    <li>Pick a username, optionally pick a credProtect policy, and optionally type a credBlob
+        payload (≤32 bytes). All four extensions are requested at the same time; the table at
+        the top of the page summarises what came back.</li>
+    <li>Open the <a href="assert.html">assertion page</a>. Pick the credential you just
+        registered. The authenticator returns the credBlob bytes, decoded and shown as
+        base64url + UTF-8 (when the bytes are valid UTF-8).</li>
+</ol>
+
+<h2>Why a single demo</h2>
+<p>
+    Each of these extensions is a few-line addition to a registration ceremony — a separate
+    demo per extension would mostly duplicate the other one's plumbing. They also pair
+    naturally: <code>credProps.rk</code> tells you whether your <code>credProtect</code>
+    policy is actually meaningful (a non-discoverable credential cannot be enumerated, so
+    <code>userVerificationOptionalWithCredentialIDList</code> is moot), and
+    <code>minPinLength</code> is the only one a relying party can rely on without provisioning
+    additional state.
+</p>
+
+<nav>
+    <a href="register.html">→ register.html</a>
+    <a href="assert.html">→ assert.html</a>
+</nav>
+</body>
+</html>

--- a/docs/examples/extensions-demo/same-origin/public/register.html
+++ b/docs/examples/extensions-demo/same-origin/public/register.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Extensions Demo — Register</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 760px; margin: 40px auto; padding: 20px; color: #1f2937; line-height: 1.55; }
+        h1 { font-size: 1.6rem; }
+        nav a { color: #2563eb; margin-right: 1rem; }
+        label { display: block; margin: 1rem 0 0.3rem; font-weight: 600; }
+        input[type=text], select { width: 100%; padding: 8px 10px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 1rem; }
+        input[type=text]:focus, select:focus { outline: 2px solid #2563eb; outline-offset: -1px; }
+        button { margin-top: 1.5rem; padding: 10px 18px; background: #2563eb; color: white; border: 0; border-radius: 6px; font-size: 1rem; cursor: pointer; }
+        button:hover { background: #1d4ed8; }
+        button:disabled { background: #9ca3af; cursor: not-allowed; }
+        .hint { font-size: 0.85rem; color: #6b7280; margin-top: 0.2rem; }
+        code { background: #f3f4f6; padding: 2px 5px; border-radius: 4px; }
+        #status { margin-top: 1.5rem; padding: 12px 16px; border-radius: 6px; }
+        #status.ok { background: #ecfdf5; border-left: 4px solid #10b981; }
+        #status.err { background: #fef2f2; border-left: 4px solid #ef4444; color: #991b1b; }
+        table { border-collapse: collapse; width: 100%; margin-top: 1rem; }
+        th, td { border: 1px solid #e5e7eb; padding: 8px 12px; text-align: left; vertical-align: top; }
+        th { background: #f9fafb; font-weight: 600; }
+        td.muted { color: #6b7280; font-style: italic; }
+    </style>
+</head>
+<body>
+<h1>Register a credential with extensions</h1>
+
+<nav><a href="index.html">← home</a> | <a href="assert.html">→ assert.html</a></nav>
+
+<form id="form">
+    <label for="username">Username</label>
+    <input id="username" type="text" value="alice" required>
+
+    <label for="credProtect">credProtect policy (optional)</label>
+    <select id="credProtect">
+        <option value="">(do not request)</option>
+        <option value="userVerificationOptional">userVerificationOptional</option>
+        <option value="userVerificationOptionalWithCredentialIDList">userVerificationOptionalWithCredentialIDList</option>
+        <option value="userVerificationRequired">userVerificationRequired</option>
+    </select>
+    <p class="hint">Sent with <code>enforceCredentialProtectionPolicy: true</code>. The
+        authenticator returns the policy actually applied — compare them in the result table
+        below.</p>
+
+    <label for="credBlob">credBlob payload (optional, ≤32 bytes UTF-8)</label>
+    <input id="credBlob" type="text" maxlength="32" placeholder="e.g. session-id-or-flag">
+    <p class="hint">Stored on the authenticator. Retrieved during the assertion via
+        <code>getCredBlob</code>.</p>
+
+    <button id="submit" type="submit">Register</button>
+</form>
+
+<div id="status"></div>
+
+<div id="results" hidden>
+    <h2>Server-parsed extension outputs</h2>
+    <table>
+        <thead><tr><th>Extension</th><th>Value</th></tr></thead>
+        <tbody id="resultRows"></tbody>
+    </table>
+</div>
+
+<script type="module">
+    const form = document.getElementById('form');
+    const statusEl = document.getElementById('status');
+    const submitBtn = document.getElementById('submit');
+    const resultsEl = document.getElementById('results');
+    const resultRows = document.getElementById('resultRows');
+
+    function setStatus(msg, ok) {
+        statusEl.textContent = msg;
+        statusEl.className = ok ? 'ok' : 'err';
+    }
+
+    function b64urlToBuffer(s) {
+        const pad = '='.repeat((4 - (s.length % 4)) % 4);
+        const b64 = (s + pad).replace(/-/g, '+').replace(/_/g, '/');
+        const bin = atob(b64);
+        const out = new Uint8Array(bin.length);
+        for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+        return out.buffer;
+    }
+    function bufferToB64url(buf) {
+        const bytes = new Uint8Array(buf);
+        let s = '';
+        for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+        return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+    }
+    function hydrateOptions(json) {
+        const o = { ...json };
+        o.challenge = b64urlToBuffer(json.challenge);
+        if (Array.isArray(json.user?.id)) {
+            o.user = { ...json.user, id: new Uint8Array(json.user.id).buffer };
+        } else if (typeof json.user?.id === 'string') {
+            o.user = { ...json.user, id: b64urlToBuffer(json.user.id) };
+        }
+        if (Array.isArray(json.excludeCredentials)) {
+            o.excludeCredentials = json.excludeCredentials.map((c) => ({ ...c, id: b64urlToBuffer(c.id) }));
+        }
+        // Convert credBlob to ArrayBuffer for the browser.
+        if (typeof json.extensions?.credBlob === 'string') {
+            o.extensions = { ...json.extensions, credBlob: b64urlToBuffer(json.extensions.credBlob) };
+        }
+        return o;
+    }
+    function dehydrateCredential(cred) {
+        if (typeof cred.toJSON === 'function') return cred.toJSON();
+        return {
+            id: cred.id,
+            rawId: bufferToB64url(cred.rawId),
+            type: cred.type,
+            response: {
+                clientDataJSON: bufferToB64url(cred.response.clientDataJSON),
+                attestationObject: bufferToB64url(cred.response.attestationObject),
+            },
+            clientExtensionResults: cred.getClientExtensionResults?.() ?? {},
+        };
+    }
+    function row(name, value) {
+        const tr = document.createElement('tr');
+        const th = document.createElement('td');
+        th.innerHTML = `<code>${name}</code>`;
+        const td = document.createElement('td');
+        if (value === null || value === undefined) {
+            td.className = 'muted';
+            td.textContent = 'absent (not returned by the authenticator)';
+        } else {
+            td.textContent = typeof value === 'string' ? value : JSON.stringify(value);
+        }
+        tr.appendChild(th);
+        tr.appendChild(td);
+        return tr;
+    }
+
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        if (!('credentials' in navigator)) {
+            setStatus('navigator.credentials is unavailable in this context.', false);
+            return;
+        }
+        submitBtn.disabled = true;
+        setStatus('Requesting options…', true);
+        resultsEl.hidden = true;
+
+        const payload = {
+            username: document.getElementById('username').value.trim(),
+            credProtect: document.getElementById('credProtect').value || null,
+            credBlob: document.getElementById('credBlob').value || '',
+        };
+
+        try {
+            const optsRes = await fetch('/register/options', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+            });
+            if (!optsRes.ok) throw new Error(`Options HTTP ${optsRes.status}`);
+            const { options } = await optsRes.json();
+
+            setStatus('Calling navigator.credentials.create()…', true);
+            const credential = await navigator.credentials.create({ publicKey: hydrateOptions(options) });
+            const credJson = dehydrateCredential(credential);
+
+            setStatus('Verifying with the relying party…', true);
+            const resultRes = await fetch('/register/result', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(credJson),
+            });
+            const result = await resultRes.json();
+            if (!resultRes.ok || result.error) throw new Error(result.error ?? `Result HTTP ${resultRes.status}`);
+
+            setStatus(`✓ Registered. Credential id: ${result.credentialId}`, true);
+
+            const ext = result.extensionOutputs ?? {};
+            resultRows.innerHTML = '';
+            const credProps = ext.credProps ?? null;
+            resultRows.appendChild(row('credProps.rk', credProps?.rk));
+            resultRows.appendChild(row('credProps.authenticatorDisplayName', credProps?.authenticatorDisplayName));
+            resultRows.appendChild(row('credProtect (applied policy)', ext.credProtect));
+            resultRows.appendChild(row('credBlob (stored on authenticator)', ext.credBlob));
+            resultRows.appendChild(row('minPinLength', ext.minPinLength));
+            resultsEl.hidden = false;
+        } catch (err) {
+            setStatus(`✗ ${err.message}`, false);
+        } finally {
+            submitBtn.disabled = false;
+        }
+    });
+</script>
+</body>
+</html>

--- a/docs/examples/extensions-demo/same-origin/public/register.html
+++ b/docs/examples/extensions-demo/same-origin/public/register.html
@@ -22,6 +22,9 @@
         th, td { border: 1px solid #e5e7eb; padding: 8px 12px; text-align: left; vertical-align: top; }
         th { background: #f9fafb; font-weight: 600; }
         td.muted { color: #6b7280; font-style: italic; }
+        details { margin-top: 1rem; }
+        summary { cursor: pointer; color: #2563eb; }
+        pre { background: #f3f4f6; padding: 12px 14px; border-radius: 6px; overflow-x: auto; font-size: 0.85rem; }
     </style>
 </head>
 <body>
@@ -60,6 +63,15 @@
         <thead><tr><th>Extension</th><th>Value</th></tr></thead>
         <tbody id="resultRows"></tbody>
     </table>
+
+    <details>
+        <summary>Raw extension bags as the authenticator and user agent emitted them</summary>
+        <h3><code>authData.extensions</code> (from the authenticator)</h3>
+        <pre id="rawAuth"></pre>
+        <h3><code>clientExtensionResults</code> (from the user agent)</h3>
+        <pre id="rawClient"></pre>
+        <p class="hint">Most platform authenticators (Touch ID, Windows Hello, Android, iCloud Keychain) only return <code>credProps</code> — sometimes nothing on the authenticator side at all. Hardware FIDO2 keys (YubiKey 5 with recent firmware, SoloKey) do echo <code>credProtect</code> and <code>credBlob</code>.</p>
+    </details>
 </div>
 
 <script type="module">
@@ -118,14 +130,18 @@
             clientExtensionResults: cred.getClientExtensionResults?.() ?? {},
         };
     }
-    function row(name, value) {
+    function row(name, value, requested) {
         const tr = document.createElement('tr');
         const th = document.createElement('td');
         th.innerHTML = `<code>${name}</code>`;
         const td = document.createElement('td');
         if (value === null || value === undefined) {
             td.className = 'muted';
-            td.textContent = 'absent (not returned by the authenticator)';
+            if (requested === false || requested === null) {
+                td.textContent = 'not requested';
+            } else {
+                td.textContent = 'requested but the authenticator / UA did not return it';
+            }
         } else {
             td.textContent = typeof value === 'string' ? value : JSON.stringify(value);
         }
@@ -175,13 +191,20 @@
             setStatus(`✓ Registered. Credential id: ${result.credentialId}`, true);
 
             const ext = result.extensionOutputs ?? {};
+            const requested = result.requested ?? {};
             resultRows.innerHTML = '';
             const credProps = ext.credProps ?? null;
-            resultRows.appendChild(row('credProps.rk', credProps?.rk));
-            resultRows.appendChild(row('credProps.authenticatorDisplayName', credProps?.authenticatorDisplayName));
-            resultRows.appendChild(row('credProtect (applied policy)', ext.credProtect));
-            resultRows.appendChild(row('credBlob (stored on authenticator)', ext.credBlob));
-            resultRows.appendChild(row('minPinLength', ext.minPinLength));
+            resultRows.appendChild(row('credProps.rk', credProps?.rk, requested.credProps));
+            resultRows.appendChild(row('credProps.authenticatorDisplayName', credProps?.authenticatorDisplayName, requested.credProps));
+            resultRows.appendChild(row('credProtect (applied policy)', ext.credProtect, requested.credProtect));
+            resultRows.appendChild(row('credBlob (stored on authenticator)', ext.credBlob, requested.credBlob));
+            resultRows.appendChild(row('minPinLength', ext.minPinLength, requested.minPinLength));
+
+            // Raw debug dump so the user can see what really came back from
+            // the authenticator (authData.extensions) and the user agent
+            // (clientExtensionResults).
+            document.getElementById('rawAuth').textContent = JSON.stringify(result.rawAuthenticatorExtensions ?? {}, null, 2);
+            document.getElementById('rawClient').textContent = JSON.stringify(result.rawClientExtensions ?? {}, null, 2);
             resultsEl.hidden = false;
         } catch (err) {
             setStatus(`✗ ${err.message}`, false);

--- a/docs/examples/extensions-demo/same-origin/router.php
+++ b/docs/examples/extensions-demo/same-origin/router.php
@@ -47,10 +47,21 @@ require_once __DIR__ . '/../src/bootstrap.php';
 $container = new Container();
 $container->allowedOrigins = ['http://localhost:8000', 'https://localhost:8000'];
 
-// Let the built-in server serve static files directly.
+// Let the built-in server serve static files directly. Map "/" → "/index.html"
+// so the landing page works without a redirect, and let it handle any other
+// existing file under public/.
 $path = parse_url($_SERVER['REQUEST_URI'], \PHP_URL_PATH);
-if ($_SERVER['REQUEST_METHOD'] === 'GET' && is_file(__DIR__ . '/public' . $path)) {
-    return false;
+if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+    $resolved = $path === '/' || str_ends_with($path, '/') ? rtrim($path, '/') . '/index.html' : $path;
+    if (is_file(__DIR__ . '/public' . $resolved)) {
+        if ($resolved !== $path) {
+            // Have the built-in server serve the resolved file by rewriting
+            // the request before returning false.
+            $_SERVER['REQUEST_URI'] = $resolved;
+            $_SERVER['SCRIPT_NAME'] = $resolved;
+        }
+        return false;
+    }
 }
 
 session_start();

--- a/docs/examples/extensions-demo/same-origin/router.php
+++ b/docs/examples/extensions-demo/same-origin/router.php
@@ -32,6 +32,7 @@ use Webauthn\AuthenticationExtensions\MinPinLengthInputExtension;
 use Webauthn\AuthenticationExtensions\MinPinLengthOutput;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\AuthenticatorSelectionCriteria;
 use Webauthn\Exception\WebauthnException;
 use Webauthn\PublicKeyCredential;
 use Webauthn\PublicKeyCredentialCreationOptions;
@@ -112,6 +113,11 @@ function handleRegistrationOptions(Container $container): array
     $policy = $body['credProtect'] ?? null; // userVerificationOptional | userVerificationOptionalWithCredentialIDList | userVerificationRequired
     $blob = (string) ($body['credBlob'] ?? '');
 
+    // Defensive: another demo on http://localhost may have stored a different
+    // shape under the same session cookie. Reset if it isn't an array.
+    if (! isset($_SESSION['userHandle']) || ! is_array($_SESSION['userHandle'])) {
+        $_SESSION['userHandle'] = [];
+    }
     $userHandle = $_SESSION['userHandle'][$username] ?? random_bytes(16);
     $_SESSION['userHandle'][$username] = $userHandle;
 
@@ -138,6 +144,23 @@ function handleRegistrationOptions(Container $container): array
         $extensions[] = CredentialBlobInputExtension::withBlob($blob);
     }
 
+    // CTAP 2.1 §12.1 — the requested credProtect policy MUST be consistent with
+    // the AuthenticatorSelectionCriteria, otherwise the authenticator returns
+    // CTAP2_ERR_REQUEST_TOO_LARGE / "Requested protection policy is inconsistent":
+    //   - userVerificationOptionalWithCredentialIDList → resident key required
+    //   - userVerificationRequired                     → resident key required + UV required
+    $authenticatorSelection = match ($policy) {
+        CredentialProtectionInputExtension::POLICY_USER_VERIFICATION_OPTIONAL_WITH_CREDENTIAL_ID_LIST => AuthenticatorSelectionCriteria::create(
+            userVerification: AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_PREFERRED,
+            residentKey: AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_REQUIRED,
+        ),
+        CredentialProtectionInputExtension::POLICY_USER_VERIFICATION_REQUIRED => AuthenticatorSelectionCriteria::create(
+            userVerification: AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_REQUIRED,
+            residentKey: AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_REQUIRED,
+        ),
+        default => null,
+    };
+
     $options = PublicKeyCredentialCreationOptions::create(
         rp: PublicKeyCredentialRpEntity::create($container->relyingPartyName, $container->relyingPartyId),
         user: PublicKeyCredentialUserEntity::create($username, $userHandle, $username),
@@ -146,6 +169,7 @@ function handleRegistrationOptions(Container $container): array
             PublicKeyCredentialParameters::create('public-key', -7),  // ES256
             PublicKeyCredentialParameters::create('public-key', -257), // RS256
         ],
+        authenticatorSelection: $authenticatorSelection,
         attestation: PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
         extensions: AuthenticationExtensions::create($extensions),
     );

--- a/docs/examples/extensions-demo/same-origin/router.php
+++ b/docs/examples/extensions-demo/same-origin/router.php
@@ -33,7 +33,6 @@ use Webauthn\AuthenticationExtensions\MinPinLengthOutput;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\AuthenticatorSelectionCriteria;
-use Webauthn\Exception\WebauthnException;
 use Webauthn\PublicKeyCredential;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialDescriptor;
@@ -135,8 +134,17 @@ function handleRegistrationOptions(Container $container): array
             CredentialProtectionInputExtension::POLICY_USER_VERIFICATION_OPTIONAL_WITH_CREDENTIAL_ID_LIST => CredentialProtectionInputExtension::userVerificationOptionalWithCredentialIDList(),
             CredentialProtectionInputExtension::POLICY_USER_VERIFICATION_REQUIRED => CredentialProtectionInputExtension::userVerificationRequired(),
         };
-        // Ask the UA to fail registration rather than silently downgrade.
-        $extensions[] = CredentialProtectionInputExtension::enforce();
+        // Only ask the UA to fail-rather-than-downgrade when we requested a
+        // policy STRONGER than the spec default (level 1). With level 1 +
+        // enforce, modern passkey-capable authenticators (iCloud Keychain,
+        // Windows Hello, Android) refuse with "Requested protection policy
+        // is inconsistent or incongruent with other requested parameters",
+        // because they create a discoverable credential by default and that
+        // requires credProtect ≥ level 2 — incompatible with our enforce on
+        // level 1.
+        if ($policy !== CredentialProtectionInputExtension::POLICY_USER_VERIFICATION_OPTIONAL) {
+            $extensions[] = CredentialProtectionInputExtension::enforce();
+        }
     }
 
     if ($blob !== '') {

--- a/docs/examples/extensions-demo/same-origin/router.php
+++ b/docs/examples/extensions-demo/same-origin/router.php
@@ -200,6 +200,10 @@ function handleRegistrationOptions(Container $container): array
 function handleRegistrationResult(Container $container): array
 {
     $body = readRawBody();
+    $bodyData = json_decode($body, true);
+    if (! is_array($bodyData)) {
+        throw new RuntimeException('Invalid JSON body.');
+    }
     $serialized = $_SESSION['register']['options'] ?? null;
     if ($serialized === null) {
         throw new RuntimeException('No registration in progress.');
@@ -217,9 +221,11 @@ function handleRegistrationResult(Container $container): array
 
     $record = $container->attestationValidator->check($response, $options, $container->relyingPartyId);
 
-    // Parse what the user agent actually returned for each extension we requested.
-    $clientExt = $body['clientExtensionResults'] ?? [];
-    $clientExtAssoc = is_array($clientExt) ? $clientExt : [];
+    // Parse what the user agent actually returned for each extension we
+    // requested. NB: $body is the raw JSON STRING — read clientExtensionResults
+    // off the decoded array, not the string (PHP 8 silently drops the
+    // string-key access on a string and we lose every extension output).
+    $clientExtAssoc = is_array($bodyData['clientExtensionResults'] ?? null) ? $bodyData['clientExtensionResults'] : [];
 
     $clientExtensions = AuthenticationExtensions::create(array_map(
         static fn (string $name, mixed $value): AuthenticationExtension => AuthenticationExtension::create($name, $value),

--- a/docs/examples/extensions-demo/same-origin/router.php
+++ b/docs/examples/extensions-demo/same-origin/router.php
@@ -259,12 +259,33 @@ function handleRegistrationResult(Container $container): array
         $registrationOutputs,
     );
 
+    // What we actually asked the user agent for (so the result page can
+    // distinguish "not requested" from "requested but the authenticator
+    // declined to return it").
+    $requested = [
+        'credProps' => true,
+        'minPinLength' => true,
+        'credProtect' => $_SESSION['register']['requestedCredProtect'],
+        'credBlob' => $_SESSION['register']['credBlob'] !== '',
+    ];
+
+    // Raw extension bags as the authenticator / user agent emitted them.
+    // Surfaced verbatim so the user can see what really came back vs what
+    // the typed value objects parsed.
+    $rawAuthenticator = [];
+    foreach ($authenticatorExtensions as $name => $extension) {
+        $rawAuthenticator[$name] = $extension->value;
+    }
+
     unset($_SESSION['register']);
 
     return [
         'verified' => true,
         'credentialId' => Base64UrlSafe::encodeUnpadded($record->publicKeyCredentialId),
         'extensionOutputs' => $registrationOutputs,
+        'requested' => $requested,
+        'rawAuthenticatorExtensions' => $rawAuthenticator,
+        'rawClientExtensions' => $clientExtAssoc,
     ];
 }
 

--- a/docs/examples/extensions-demo/same-origin/router.php
+++ b/docs/examples/extensions-demo/same-origin/router.php
@@ -1,0 +1,340 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Single-file PHP router for the extensions demo. Run with:
+ *   php -S 0.0.0.0:8000 -t public router.php
+ *
+ * Endpoints:
+ *   POST /register/options     → PublicKeyCredentialCreationOptions JSON
+ *   POST /register/result      → verify the attestation, persist + show outputs
+ *   POST /assert/options       → PublicKeyCredentialRequestOptions JSON
+ *                                 (sets getCredBlob:true to request the blob back)
+ *   POST /assert/result        → verify the assertion, return the retrieved blob
+ *
+ * Static files under public/ are served by the built-in server directly.
+ */
+
+use App\ExtensionsDemo\Container;
+use ParagonIE\ConstantTime\Base64UrlSafe;
+use Webauthn\AuthenticationExtensions\AuthenticationExtension;
+use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
+use Webauthn\AuthenticationExtensions\CredentialBlobInputExtension;
+use Webauthn\AuthenticationExtensions\CredentialBlobAssertionOutput;
+use Webauthn\AuthenticationExtensions\CredentialBlobRegistrationOutput;
+use Webauthn\AuthenticationExtensions\CredentialPropertiesInputExtension;
+use Webauthn\AuthenticationExtensions\CredentialPropertiesOutput;
+use Webauthn\AuthenticationExtensions\CredentialProtectionInputExtension;
+use Webauthn\AuthenticationExtensions\CredentialProtectionOutput;
+use Webauthn\AuthenticationExtensions\GetCredentialBlobInputExtension;
+use Webauthn\AuthenticationExtensions\MinPinLengthInputExtension;
+use Webauthn\AuthenticationExtensions\MinPinLengthOutput;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\Exception\WebauthnException;
+use Webauthn\PublicKeyCredential;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialDescriptor;
+use Webauthn\PublicKeyCredentialParameters;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\PublicKeyCredentialRpEntity;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+require_once __DIR__ . '/../src/CredentialStore.php';
+require_once __DIR__ . '/../src/bootstrap.php';
+
+$container = new Container();
+$container->allowedOrigins = ['http://localhost:8000', 'https://localhost:8000'];
+
+// Let the built-in server serve static files directly.
+$path = parse_url($_SERVER['REQUEST_URI'], \PHP_URL_PATH);
+if ($_SERVER['REQUEST_METHOD'] === 'GET' && is_file(__DIR__ . '/public' . $path)) {
+    return false;
+}
+
+session_start();
+
+header('Content-Type: application/json');
+header('Cache-Control: no-store');
+
+try {
+    if ($path === '/register/options') {
+        echo json_encode(handleRegistrationOptions($container));
+        return;
+    }
+    if ($path === '/register/result') {
+        echo json_encode(handleRegistrationResult($container));
+        return;
+    }
+    if ($path === '/assert/options') {
+        echo json_encode(handleAssertionOptions($container));
+        return;
+    }
+    if ($path === '/assert/result') {
+        echo json_encode(handleAssertionResult($container));
+        return;
+    }
+} catch (Throwable $e) {
+    http_response_code(400);
+    echo json_encode([
+        'error' => $e->getMessage(),
+        'class' => $e::class,
+    ]);
+    return;
+}
+
+http_response_code(404);
+echo json_encode(['error' => 'Not found']);
+
+/* -------------------------------------------------------------------------- */
+/*  Registration                                                              */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @return array{options: array<string, mixed>}
+ */
+function handleRegistrationOptions(Container $container): array
+{
+    $body = readJsonBody();
+    $username = (string) ($body['username'] ?? 'alice');
+    $policy = $body['credProtect'] ?? null; // userVerificationOptional | userVerificationOptionalWithCredentialIDList | userVerificationRequired
+    $blob = (string) ($body['credBlob'] ?? '');
+
+    $userHandle = $_SESSION['userHandle'][$username] ?? random_bytes(16);
+    $_SESSION['userHandle'][$username] = $userHandle;
+
+    $extensions = [
+        // L3 §10.1.3: ask the UA for credProps so we can read back
+        // {rk, authenticatorDisplayName} after registration.
+        CredentialPropertiesInputExtension::enable(),
+        // CTAP 2.1 §12.4: ask the authenticator for its configured min PIN length.
+        MinPinLengthInputExtension::enable(),
+    ];
+
+    if (in_array($policy, CredentialProtectionInputExtension::POLICIES, true)) {
+        $extensions[] = match ($policy) {
+            CredentialProtectionInputExtension::POLICY_USER_VERIFICATION_OPTIONAL => CredentialProtectionInputExtension::userVerificationOptional(),
+            CredentialProtectionInputExtension::POLICY_USER_VERIFICATION_OPTIONAL_WITH_CREDENTIAL_ID_LIST => CredentialProtectionInputExtension::userVerificationOptionalWithCredentialIDList(),
+            CredentialProtectionInputExtension::POLICY_USER_VERIFICATION_REQUIRED => CredentialProtectionInputExtension::userVerificationRequired(),
+        };
+        // Ask the UA to fail registration rather than silently downgrade.
+        $extensions[] = CredentialProtectionInputExtension::enforce();
+    }
+
+    if ($blob !== '') {
+        // CTAP 2.1 §12.2: store ≤32 bytes alongside the credential.
+        $extensions[] = CredentialBlobInputExtension::withBlob($blob);
+    }
+
+    $options = PublicKeyCredentialCreationOptions::create(
+        rp: PublicKeyCredentialRpEntity::create($container->relyingPartyName, $container->relyingPartyId),
+        user: PublicKeyCredentialUserEntity::create($username, $userHandle, $username),
+        challenge: random_bytes(32),
+        pubKeyCredParams: [
+            PublicKeyCredentialParameters::create('public-key', -7),  // ES256
+            PublicKeyCredentialParameters::create('public-key', -257), // RS256
+        ],
+        attestation: PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
+        extensions: AuthenticationExtensions::create($extensions),
+    );
+    $options->timeout = 60_000;
+
+    $_SESSION['register']['options'] = $container->serializer->serialize($options, 'json');
+    $_SESSION['register']['username'] = $username;
+    $_SESSION['register']['userHandle'] = $userHandle;
+    $_SESSION['register']['requestedCredProtect'] = $policy;
+    $_SESSION['register']['credBlob'] = $blob;
+
+    return [
+        'options' => json_decode($container->serializer->serialize($options, 'json'), true),
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function handleRegistrationResult(Container $container): array
+{
+    $body = readRawBody();
+    $serialized = $_SESSION['register']['options'] ?? null;
+    if ($serialized === null) {
+        throw new RuntimeException('No registration in progress.');
+    }
+    /** @var PublicKeyCredentialCreationOptions $options */
+    $options = $container->serializer->deserialize($serialized, PublicKeyCredentialCreationOptions::class, 'json');
+
+    /** @var PublicKeyCredential $credential */
+    $credential = $container->serializer->deserialize($body, PublicKeyCredential::class, 'json');
+
+    $response = $credential->response;
+    if (! $response instanceof AuthenticatorAttestationResponse) {
+        throw new RuntimeException('Expected an attestation response.');
+    }
+
+    $record = $container->attestationValidator->check($response, $options, $container->relyingPartyId);
+
+    // Parse what the user agent actually returned for each extension we requested.
+    $clientExt = $body['clientExtensionResults'] ?? [];
+    $clientExtAssoc = is_array($clientExt) ? $clientExt : [];
+
+    $clientExtensions = AuthenticationExtensions::create(array_map(
+        static fn (string $name, mixed $value): AuthenticationExtension => AuthenticationExtension::create($name, $value),
+        array_keys($clientExtAssoc),
+        array_values($clientExtAssoc),
+    ));
+
+    $authenticatorExtensions = $response->attestationObject->authData->extensions ?? AuthenticationExtensions::create();
+
+    $credProps = CredentialPropertiesOutput::fromExtensions($clientExtensions);
+    $minPinLength = MinPinLengthOutput::fromExtensions($authenticatorExtensions);
+    $credProtect = CredentialProtectionOutput::fromExtensions($authenticatorExtensions);
+    $credBlobReg = CredentialBlobRegistrationOutput::fromExtensions($authenticatorExtensions);
+
+    $registrationOutputs = [
+        'credProps' => $credProps === null ? null : [
+            'rk' => $credProps->rk,
+            'authenticatorDisplayName' => $credProps->authenticatorDisplayName,
+        ],
+        'minPinLength' => $minPinLength?->minPinLength,
+        'credProtect' => $credProtect === null ? null : credProtectLabel($credProtect->policy),
+        'credBlob' => $credBlobReg?->stored,
+    ];
+
+    $container->credentialStore->save(
+        $record,
+        base64_encode($record->publicKeyCredentialId),
+        bin2hex($_SESSION['register']['userHandle']),
+        $_SESSION['register']['requestedCredProtect'],
+        $_SESSION['register']['credBlob'],
+        $registrationOutputs,
+    );
+
+    unset($_SESSION['register']);
+
+    return [
+        'verified' => true,
+        'credentialId' => Base64UrlSafe::encodeUnpadded($record->publicKeyCredentialId),
+        'extensionOutputs' => $registrationOutputs,
+    ];
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Assertion                                                                 */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * @return array{options: array<string, mixed>, allowed: list<array{credentialId: string, requestedCredProtect: ?string, credBlob: string}>}
+ */
+function handleAssertionOptions(Container $container): array
+{
+    $allowed = [];
+    $allowCredentials = [];
+    foreach ($container->credentialStore->all() as $row) {
+        $rawId = (string) base64_decode($row['credentialId'], true);
+        $allowCredentials[] = PublicKeyCredentialDescriptor::create('public-key', $rawId);
+        $allowed[] = [
+            'credentialId' => $row['credentialId'],
+            'requestedCredProtect' => $row['requestedCredProtect'],
+            'credBlob' => $row['credBlob'],
+        ];
+    }
+
+    if ($allowCredentials === []) {
+        throw new RuntimeException('Register a credential first.');
+    }
+
+    $options = PublicKeyCredentialRequestOptions::create(
+        challenge: random_bytes(32),
+        rpId: $container->relyingPartyId,
+        allowCredentials: $allowCredentials,
+        userVerification: PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_PREFERRED,
+        extensions: AuthenticationExtensions::create([
+            // CTAP 2.1 §12.2: ask the authenticator to return the previously stored blob.
+            GetCredentialBlobInputExtension::enable(),
+        ]),
+    );
+    $options->timeout = 60_000;
+
+    $_SESSION['assert']['options'] = $container->serializer->serialize($options, 'json');
+
+    return [
+        'options' => json_decode($container->serializer->serialize($options, 'json'), true),
+        'allowed' => $allowed,
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function handleAssertionResult(Container $container): array
+{
+    $body = readRawBody();
+    $serialized = $_SESSION['assert']['options'] ?? null;
+    if ($serialized === null) {
+        throw new RuntimeException('No assertion in progress.');
+    }
+    /** @var PublicKeyCredentialRequestOptions $options */
+    $options = $container->serializer->deserialize($serialized, PublicKeyCredentialRequestOptions::class, 'json');
+
+    /** @var PublicKeyCredential $credential */
+    $credential = $container->serializer->deserialize($body, PublicKeyCredential::class, 'json');
+
+    $response = $credential->response;
+    if (! $response instanceof AuthenticatorAssertionResponse) {
+        throw new RuntimeException('Expected an assertion response.');
+    }
+
+    $stored = $container->credentialStore->findByCredentialId($credential->rawId);
+    if ($stored === null) {
+        throw new RuntimeException('Unknown credential.');
+    }
+
+    $userHandle = $response->userHandle ?? $stored->userHandle;
+    $updated = $container->assertionValidator->check(
+        $stored,
+        $response,
+        $options,
+        $container->relyingPartyId,
+        $userHandle,
+    );
+    $container->credentialStore->update($updated);
+
+    $authenticatorExtensions = $response->authenticatorData->extensions ?? AuthenticationExtensions::create();
+    $credBlob = CredentialBlobAssertionOutput::fromExtensions($authenticatorExtensions);
+
+    unset($_SESSION['assert']);
+
+    return [
+        'verified' => true,
+        'credBlob' => $credBlob === null ? null : Base64UrlSafe::encodeUnpadded($credBlob->blob),
+        'credBlobUtf8' => $credBlob === null ? null : @mb_convert_encoding($credBlob->blob, 'UTF-8', 'UTF-8'),
+    ];
+}
+
+/* -------------------------------------------------------------------------- */
+
+function credProtectLabel(int $policy): string
+{
+    return match ($policy) {
+        CredentialProtectionOutput::POLICY_USER_VERIFICATION_OPTIONAL => 'userVerificationOptional',
+        CredentialProtectionOutput::POLICY_USER_VERIFICATION_OPTIONAL_WITH_CREDENTIAL_ID_LIST => 'userVerificationOptionalWithCredentialIDList',
+        CredentialProtectionOutput::POLICY_USER_VERIFICATION_REQUIRED => 'userVerificationRequired',
+    };
+}
+
+function readJsonBody(): array
+{
+    $raw = file_get_contents('php://input');
+    if ($raw === '' || $raw === false) {
+        return [];
+    }
+    $data = json_decode($raw, true);
+    return is_array($data) ? $data : [];
+}
+
+function readRawBody(): string
+{
+    $raw = file_get_contents('php://input');
+    return $raw === false ? '' : $raw;
+}

--- a/docs/examples/extensions-demo/same-origin/run.sh
+++ b/docs/examples/extensions-demo/same-origin/run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Boot the same-origin extensions demo on http://localhost:8000.
+# Usage:  ./same-origin/run.sh   (from docs/examples/extensions-demo/)
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [[ ! -d vendor ]]; then
+    echo "▶ vendor/ missing — running composer install"
+    composer install --no-interaction
+fi
+
+PORT=8000
+
+is_busy() { lsof -i ":$1" >/dev/null 2>&1 || ss -ltn 2>/dev/null | grep -q ":$1 "; }
+if is_busy "$PORT"; then
+    echo "✗ Port $PORT already in use. Free it and retry." >&2
+    exit 1
+fi
+
+cleanup() {
+    echo
+    echo "▶ Stopping server…"
+    [[ -n "${PID:-}" ]] && kill "$PID" 2>/dev/null || true
+    wait 2>/dev/null || true
+}
+trap cleanup INT TERM EXIT
+
+echo "▶ Extensions demo (same-origin) → http://localhost:$PORT"
+echo
+echo "Steps:"
+echo "  1. open http://localhost:$PORT/                 (overview)"
+echo "  2. open http://localhost:$PORT/register.html    (register with credProps + credProtect + credBlob + minPinLength)"
+echo "  3. open http://localhost:$PORT/assert.html      (assert + retrieve credBlob via getCredBlob)"
+echo
+echo "Logs follow. Ctrl+C to stop."
+echo "──────────────────────────────────────────────────────"
+
+php -S "localhost:$PORT" -t same-origin/public same-origin/router.php &
+PID=$!
+
+wait

--- a/docs/examples/extensions-demo/src/CredentialStore.php
+++ b/docs/examples/extensions-demo/src/CredentialStore.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ExtensionsDemo;
+
+use Symfony\Component\Serializer\Serializer;
+use Webauthn\CredentialRecord;
+
+/**
+ * Demo-only credential store. Persists CredentialRecords plus the inputs that
+ * were used at registration time (the requested credProtect policy and the
+ * credBlob payload, both echoed back during the assertion page so users can
+ * see the round-trip).
+ *
+ * Production code MUST use a real persistence layer behind
+ * `Webauthn\CredentialRecordRepositoryInterface`.
+ */
+final class CredentialStore
+{
+    public function __construct(
+        private readonly string $file,
+        private readonly Serializer $serializer,
+    ) {
+        $dir = dirname($this->file);
+        if (! is_dir($dir)) {
+            mkdir($dir, 0o755, true);
+        }
+        if (! file_exists($this->file)) {
+            file_put_contents($this->file, '[]');
+        }
+    }
+
+    /**
+     * @return array<string, array{userHandle: string, credentialId: string, source: string, requestedCredProtect: ?string, credBlob: string, registrationOutputs: array<string, mixed>}>
+     */
+    private function readAll(): array
+    {
+        $raw = (string) file_get_contents($this->file);
+        $data = json_decode($raw, true);
+        if (! is_array($data)) {
+            return [];
+        }
+        return $data;
+    }
+
+    /**
+     * @param array<string, array{userHandle: string, credentialId: string, source: string, requestedCredProtect: ?string, credBlob: string, registrationOutputs: array<string, mixed>}> $data
+     */
+    private function writeAll(array $data): void
+    {
+        file_put_contents($this->file, json_encode($data, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+    }
+
+    /**
+     * @param array<string, mixed> $registrationOutputs
+     */
+    public function save(
+        CredentialRecord $record,
+        string $credIdB64,
+        string $userHandle,
+        ?string $requestedCredProtect,
+        string $credBlob,
+        array $registrationOutputs,
+    ): void {
+        $data = $this->readAll();
+        $data[$credIdB64] = [
+            'userHandle' => $userHandle,
+            'credentialId' => $credIdB64,
+            'source' => $this->serializer->serialize($record, 'json'),
+            'requestedCredProtect' => $requestedCredProtect,
+            'credBlob' => $credBlob,
+            'registrationOutputs' => $registrationOutputs,
+        ];
+        $this->writeAll($data);
+    }
+
+    public function findByCredentialId(string $credentialId): ?CredentialRecord
+    {
+        $data = $this->readAll();
+        foreach ($data as $row) {
+            if (base64_decode($row['credentialId'], true) === $credentialId) {
+                return $this->serializer->deserialize($row['source'], CredentialRecord::class, 'json');
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @return array<string, array{userHandle: string, credentialId: string, source: string, requestedCredProtect: ?string, credBlob: string, registrationOutputs: array<string, mixed>}>
+     */
+    public function all(): array
+    {
+        return $this->readAll();
+    }
+
+    public function update(CredentialRecord $record): void
+    {
+        $data = $this->readAll();
+        $credIdB64 = base64_encode($record->publicKeyCredentialId);
+        if (! isset($data[$credIdB64])) {
+            return;
+        }
+        $data[$credIdB64]['source'] = $this->serializer->serialize($record, 'json');
+        $this->writeAll($data);
+    }
+}

--- a/docs/examples/extensions-demo/src/bootstrap.php
+++ b/docs/examples/extensions-demo/src/bootstrap.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ExtensionsDemo;
+
+use Cose\Algorithm\Manager;
+use Cose\Algorithm\Signature\ECDSA\ES256;
+use Cose\Algorithm\Signature\RSA\RS256;
+use Symfony\Component\Serializer\Serializer;
+use Webauthn\AttestationStatement\AttestationStatementSupportManager;
+use Webauthn\AttestationStatement\NoneAttestationStatementSupport;
+use Webauthn\AuthenticatorAssertionResponseValidator;
+use Webauthn\AuthenticatorAttestationResponseValidator;
+use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
+use Webauthn\Denormalizer\WebauthnSerializerFactory;
+
+// Two ways to load the lib:
+//   1. Standalone — `composer install` in this directory pulls
+//      web-auth/webauthn-lib >= 5.4 into ./vendor.
+//   2. Inside the monorepo — fall back to the framework's own
+//      vendor/autoload.php which exposes the lib via PSR-4.
+$autoloads = [
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../../vendor/autoload.php',
+];
+$loaded = false;
+foreach ($autoloads as $autoload) {
+    if (is_file($autoload)) {
+        require_once $autoload;
+        $loaded = true;
+        break;
+    }
+}
+if (! $loaded) {
+    fwrite(\STDERR, "Run `composer install` in docs/examples/extensions-demo/ first.\n");
+    exit(1);
+}
+
+/**
+ * Wires the minimum the demo needs: serializer, attestation/assertion
+ * validators, and a JSON-file credential store. Each registered credential
+ * remembers the requested credProtect policy and the credBlob payload it was
+ * created with so the assertion page can show the round-trip.
+ */
+final class Container
+{
+    public string $relyingPartyId;
+    public string $relyingPartyName;
+    /** @var string[] */
+    public array $allowedOrigins;
+
+    public AttestationStatementSupportManager $attestationManager;
+    public Manager $algorithmManager;
+    public CeremonyStepManagerFactory $ceremonyFactory;
+    public AuthenticatorAttestationResponseValidator $attestationValidator;
+    public AuthenticatorAssertionResponseValidator $assertionValidator;
+    public Serializer $serializer;
+    public CredentialStore $credentialStore;
+
+    public function __construct()
+    {
+        $this->relyingPartyId = $_ENV['RP_ID'] ?? 'localhost';
+        $this->relyingPartyName = 'Extensions Demo';
+        $this->allowedOrigins = explode(',', $_ENV['ALLOWED_ORIGINS'] ?? 'http://localhost:8000');
+
+        $this->attestationManager = new AttestationStatementSupportManager();
+        $this->attestationManager->add(new NoneAttestationStatementSupport());
+
+        $this->algorithmManager = Manager::create()->add(ES256::create(), RS256::create());
+
+        $serializer = (new WebauthnSerializerFactory($this->attestationManager))->create();
+        \assert($serializer instanceof Serializer);
+        $this->serializer = $serializer;
+
+        $this->ceremonyFactory = new CeremonyStepManagerFactory();
+        $this->ceremonyFactory->setAttestationStatementSupportManager($this->attestationManager);
+        $this->ceremonyFactory->setAlgorithmManager($this->algorithmManager);
+        $this->ceremonyFactory->setAllowedOrigins($this->allowedOrigins);
+
+        $this->attestationValidator = AuthenticatorAttestationResponseValidator::create(
+            ceremonyStepManager: $this->ceremonyFactory->creationCeremony(),
+        );
+        $this->assertionValidator = AuthenticatorAssertionResponseValidator::create(
+            ceremonyStepManager: $this->ceremonyFactory->requestCeremony(),
+        );
+
+        $varDir = $_ENV['VAR_DIR'] ?? __DIR__ . '/../var';
+        $this->credentialStore = new CredentialStore($varDir . '/credentials.json', $this->serializer);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a single end-to-end playground that exercises four authenticator
extensions the lib supports out of the box but lacked a worked example:

| Extension                  | Spec                | Demonstrated |
| -------------------------- | ------------------- | ------------ |
| `credProps`                | WebAuthn L3 §10.1.3 | Read back \`rk\` + \`authenticatorDisplayName\` |
| `credProtect`              | CTAP 2.1 §12.1      | Pin a protection policy with \`enforce\`, then check the applied policy server-side |
| `credBlob` / `getCredBlob` | CTAP 2.1 §12.2      | Store ≤32 bytes at registration, retrieve them at the next assertion |
| `minPinLength`             | CTAP 2.1 §12.4      | Surface the configured min PIN length when the RP id is on the enterprise allow-list |

### One demo instead of four

Per discussion, packaged as a **single** mini-app rather than four
parallel ones. The four extensions overlap conceptually
(`credProps.rk` tells you whether your `credProtect` policy is
meaningful, etc.) and bundling them keeps the plumbing minimal — the
registration page lets the user toggle each independently and shows
what each one returned, the assertion page exercises `getCredBlob` to
retrieve what was stored.

### Layout (mirrors prf-demo / spc-demo)

```
docs/examples/extensions-demo/
├── README.md              spec links + caveats per extension
├── composer.json          symlinked path repo to the monorepo
├── src/
│   ├── bootstrap.php      Container with serializer + validators
│   └── CredentialStore.php JSON-file store + per-credential extension state
└── same-origin/
    ├── run.sh             one-shot launcher (php -S :8000)
    ├── router.php         /register/{options,result} + /assert/{options,result}
    └── public/{index,register,assert}.html
```

### Verification

- `composer install` — clean
- `./same-origin/run.sh` boots on `http://localhost:8000`
- `POST /register/options` smoke-tested with
  `{"username":"alice","credProtect":"userVerificationRequired","credBlob":"hello-blob"}`
  returns the expected payload with all 4 extensions correctly
  attached (`credProps:true`, `minPinLength:true`,
  `credentialProtectionPolicy` + `enforceCredentialProtectionPolicy`,
  `credBlob` base64url-encoded).