### PR TITLE
fix(ci): drop PHPStan baseline entries that don't fire on PHP 8.4

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -175,12 +175,6 @@ parameters:
 			path: ../src/webauthn/src/AuthenticatorAssertionResponseValidator.php
 
 		-
-			rawMessage: 'Parameter #1 $codepoint of function chr expects int<0, 255>, int given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/webauthn/src/AuthenticatorDataLoader.php
-
-		-
 			rawMessage: '''
 				Instanceof references deprecated class Webauthn\PublicKeyCredentialSource:
 				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
@@ -383,12 +377,6 @@ parameters:
 			identifier: instanceof.deprecatedClass
 			count: 1
 			path: ../src/webauthn/src/Counter/ThrowExceptionIfInvalid.php
-
-		-
-			rawMessage: 'Parameter #1 $codepoint of function chr expects int<0, 255>, int given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/webauthn/src/Denormalizer/AuthenticatorDataDenormalizer.php
 
 		-
 			rawMessage: 'Parameter #3 $context of method Webauthn\Denormalizer\CollectedClientAdditionalPaymentDataDenormalizer::denormalizeLogo() expects array<string, mixed>, array<mixed> given.'


### PR DESCRIPTION
The PHPStan baseline regenerated in #868 was generated on a PHP 8.5
host. PHP 8.5 narrows \`chr()\`'s byte argument more strictly than
8.4, so the baseline picked up two entries that simply do not surface
on PHP 8.4 (which is what CI runs):

- \`src/webauthn/src/AuthenticatorDataLoader.php\`
- \`src/webauthn/src/Denormalizer/AuthenticatorDataDenormalizer.php\`

\`reportUnmatchedIgnoredErrors\` then trips CI:

\`\`\`
Error: Ignored error \"Parameter #1 \$codepoint of function chr expects int<0, 255>, int given.\"
       (argument.type) in path .../AuthenticatorDataLoader.php was not matched in reported errors.
\`\`\`

Removes those two stale entries. Verified with
\`PHP_VERSION=8.4 castor phpstan\` — exit 0.

For my own future hygiene (added to my notes): regenerate PHPStan
baselines on the same PHP version as CI uses, otherwise version-gated
errors pollute the baseline.