### PR TITLE
Remove length specification from `publicKeyCredentialId`

### DIFF
--- a/src/symfony/src/Resources/config/doctrine-mapping/CredentialRecord.orm.xml
+++ b/src/symfony/src/Resources/config/doctrine-mapping/CredentialRecord.orm.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd"
 >
     <mapped-superclass name="Webauthn\CredentialRecord">
-        <field name="publicKeyCredentialId" type="base64" unique="true" length="250"/>
+        <field name="publicKeyCredentialId" type="base64"/>
         <field name="type"/>
         <field name="transports" type="json"/>
         <field name="attestationType"/>


### PR DESCRIPTION
Target branch: 5.3.x
Resolves issue #680

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Unfortunately https://github.com/web-auth/webauthn-framework/issues/680 has resurfaced again. The `length` specification was again added to the `publicKeyCredentialId` field in `5.3.x`. This PR removes it again.