### PR TITLE
feat(signal): WebAuthn L3 §5.1.10 helpers (factory + JSON envelope)

### DIFF
--- a/src/stimulus/assets/README.md
+++ b/src/stimulus/assets/README.md
@@ -121,6 +121,34 @@ Combined controller for backward compatibility. Handles both registration and au
 > import { WebauthnController } from '@web-auth/webauthn-stimulus';
 > ```
 
+## Signal API helpers (since 5.4)
+
+Three small helpers wrap the [WebAuthn L3 §5.1.10](https://www.w3.org/TR/webauthn-3/#sctn-signal-methods) signal methods. Each one feature-detects the matching `PublicKeyCredential.signalXxx()` static method, silently no-ops on user agents that do not ship it (Firefox, older Safari) and swallows the spec-defined `TypeError` / `SecurityError` so the application flow never breaks.
+
+```javascript
+import {
+    dispatchUnknownCredential,
+    dispatchAllAcceptedCredentials,
+    dispatchCurrentUserDetails,
+    dispatchSignals,
+} from '@web-auth/webauthn-stimulus';
+
+// One-shot dispatch for a single signal:
+await dispatchUnknownCredential({ rpId: 'example.com', credentialId: 'aabbcc' });
+
+// Or dispatch a `signals: [{type, options}]` envelope produced server-side
+// by `Webauthn\Bundle\Service\WebauthnSignalResponse::withSignals(...)`.
+// The Authentication / Registration controllers call this automatically on
+// the success response of the `resultUrl` endpoint, so you usually do not
+// need to invoke it yourself.
+await dispatchSignals(serverResponse);
+```
+
+`AuthenticationController`, `RegistrationController` and `WebauthnController` all auto-pickup the `signals` envelope after a successful verify call. Privacy gates per W3C §14.6.3:
+
+- `dispatchUnknownCredential` is safe to expose to an unauthenticated caller (the credential id is one the caller already presented).
+- `dispatchAllAcceptedCredentials` and `dispatchCurrentUserDetails` carry PII (full credential id list, user handle plus display strings) and MUST only be emitted for an authenticated user.
+
 ## Configuration Values
 
 ### Common Values (all controllers)

--- a/src/stimulus/assets/README.md
+++ b/src/stimulus/assets/README.md
@@ -235,11 +235,7 @@ Then register the controllers in your Stimulus bootstrap (typically `assets/boot
 
 ```javascript
 import { Application } from '@hotwired/stimulus';
-import {
-    AuthenticationController,
-    RegistrationController,
-    WebauthnController,
-} from '@web-auth/webauthn-stimulus';
+import { AuthenticationController, RegistrationController, WebauthnController } from '@web-auth/webauthn-stimulus';
 
 const app = Application.start();
 app.register('web-auth--webauthn-stimulus--authentication', AuthenticationController);

--- a/src/stimulus/assets/package.json
+++ b/src/stimulus/assets/package.json
@@ -34,7 +34,8 @@
             "@web-auth/webauthn-stimulus": "path:%PACKAGE%/src/index.js",
             "@web-auth/webauthn-stimulus/webauthn": "path:%PACKAGE%/src/controller.js",
             "@web-auth/webauthn-stimulus/authentication": "path:%PACKAGE%/src/authentication-controller.js",
-            "@web-auth/webauthn-stimulus/registration": "path:%PACKAGE%/src/registration-controller.js"
+            "@web-auth/webauthn-stimulus/registration": "path:%PACKAGE%/src/registration-controller.js",
+            "@web-auth/webauthn-stimulus/signals": "path:%PACKAGE%/src/signals.js"
         }
     },
     "peerDependencies": {

--- a/src/stimulus/assets/src/base-controller.js
+++ b/src/stimulus/assets/src/base-controller.js
@@ -8,6 +8,8 @@ import {
     WebAuthnAbortService,
 } from '@simplewebauthn/browser';
 
+import { dispatchSignals } from './signals.js';
+
 /**
  * Base controller for WebAuthn operations
  * Contains shared logic for authentication and registration controllers
@@ -82,6 +84,12 @@ export default class extends Controller {
 
             const result = await response.json();
             this._dispatchEvent(`${eventPrefix}:verify:success`, { result });
+
+            // WebAuthn L3 §5.1.10: when the server response carries a
+            // `signals: [{type, options}]` envelope, forward each entry to
+            // the matching `PublicKeyCredential.signalXxx()` JS API.
+            // Fire-and-forget; failures never break the application flow.
+            await dispatchSignals(result);
 
             return result;
         } catch (error) {

--- a/src/stimulus/assets/src/base-controller.js
+++ b/src/stimulus/assets/src/base-controller.js
@@ -85,10 +85,6 @@ export default class extends Controller {
             const result = await response.json();
             this._dispatchEvent(`${eventPrefix}:verify:success`, { result });
 
-            // WebAuthn L3 §5.1.10: when the server response carries a
-            // `signals: [{type, options}]` envelope, forward each entry to
-            // the matching `PublicKeyCredential.signalXxx()` JS API.
-            // Fire-and-forget; failures never break the application flow.
             await dispatchSignals(result);
 
             return result;

--- a/src/stimulus/assets/src/index.js
+++ b/src/stimulus/assets/src/index.js
@@ -8,3 +8,9 @@ export { default as PaymentController } from './payment-controller.js';
 export { default as RegistrationController } from './registration-controller.js';
 export { default as WebauthnController } from './controller.js';
 export { default as BaseController } from './base-controller.js';
+export {
+    dispatchAllAcceptedCredentials,
+    dispatchCurrentUserDetails,
+    dispatchSignals,
+    dispatchUnknownCredential,
+} from './signals.js';

--- a/src/stimulus/assets/src/signals.js
+++ b/src/stimulus/assets/src/signals.js
@@ -93,6 +93,6 @@ export const dispatchSignals = async (envelope) => {
                 return undefined;
             }
             return dispatch(method, options);
-        }),
+        })
     );
 };

--- a/src/stimulus/assets/src/signals.js
+++ b/src/stimulus/assets/src/signals.js
@@ -1,0 +1,98 @@
+'use strict';
+
+/**
+ * WebAuthn L3 §5.1.10 Signal API:fire-and-forget client-side dispatchers.
+ *
+ * The three exported functions are thin wrappers around the matching
+ * `PublicKeyCredential.signalXxx()` static methods. Each one:
+ *
+ *  - feature-detects the method on the current user agent and silently
+ *    no-ops when it is not present (Firefox, older Safari, etc.);
+ *  - swallows the spec-defined `TypeError` (malformed base64url id) and
+ *    `SecurityError` (RP-ID mismatch) without rejecting, since the spec
+ *    itself is intentionally non-informative on success:a resolved
+ *    promise only means the options object was well formed (W3C §5.1.10);
+ *  - returns a `Promise<void>` for ergonomic chaining but never rejects.
+ *
+ * Per W3C §14.6.3:
+ *  - `dispatchUnknownCredential` is safe to call from an unauthenticated
+ *    page (the credential id is one the caller already presented);
+ *  - `dispatchAllAcceptedCredentials` and `dispatchCurrentUserDetails`
+ *    expose PII (full credential id list / user handle + display strings)
+ *    and MUST only be called for an authenticated user.
+ */
+
+const DISPATCHERS = {
+    unknownCredential: 'signalUnknownCredential',
+    allAcceptedCredentials: 'signalAllAcceptedCredentials',
+    currentUserDetails: 'signalCurrentUserDetails',
+};
+
+const dispatch = async (method, options) => {
+    if (typeof PublicKeyCredential === 'undefined' || typeof PublicKeyCredential[method] !== 'function') {
+        return;
+    }
+    try {
+        await PublicKeyCredential[method](options);
+    } catch (error) {
+        if (error instanceof TypeError || error.name === 'SecurityError') {
+            return;
+        }
+        throw error;
+    }
+};
+
+/**
+ * Notify the user agent that a credential id is no longer recognised by
+ * the relying party.
+ *
+ * @param {{rpId: string, credentialId: string}} options
+ * @returns {Promise<void>}
+ */
+export const dispatchUnknownCredential = (options) => dispatch('signalUnknownCredential', options);
+
+/**
+ * Notify the user agent of the complete list of credential ids currently
+ * accepted by the relying party for `userId`. Credentials missing from
+ * the list MAY be removed or hidden by the authenticator (potentially
+ * irreversibly:see W3C §5.1.10.3).
+ *
+ * @param {{rpId: string, userId: string, allAcceptedCredentialIds: string[]}} options
+ * @returns {Promise<void>}
+ */
+export const dispatchAllAcceptedCredentials = (options) => dispatch('signalAllAcceptedCredentials', options);
+
+/**
+ * Notify the user agent that the user's `name` and `displayName` have
+ * changed, so the password manager can refresh the matching passkey label.
+ *
+ * @param {{rpId: string, userId: string, name: string, displayName: string}} options
+ * @returns {Promise<void>}
+ */
+export const dispatchCurrentUserDetails = (options) => dispatch('signalCurrentUserDetails', options);
+
+/**
+ * Dispatch every entry of a `signals: [{type, options}]` envelope produced
+ * by {@link \Webauthn\Bundle\Service\WebauthnSignalResponse} server-side.
+ *
+ * Unknown `type` values are skipped silently (forward-compatibility: a
+ * future server may emit a type the current client does not understand).
+ *
+ * @param {{signals?: Array<{type: string, options: object}>}|null|undefined} envelope
+ * @returns {Promise<void>}
+ */
+export const dispatchSignals = async (envelope) => {
+    const signals = envelope?.signals;
+    if (!Array.isArray(signals) || signals.length === 0) {
+        return;
+    }
+    await Promise.all(
+        signals.map(({ type, options } = {}) => {
+            const method = DISPATCHERS[type];
+            if (!method || !options) {
+                return undefined;
+            }
+            return dispatch(method, options);
+        }),
+    );
+};

--- a/src/stimulus/assets/test/signals.test.js
+++ b/src/stimulus/assets/test/signals.test.js
@@ -1,0 +1,148 @@
+'use strict';
+
+import {
+    dispatchAllAcceptedCredentials,
+    dispatchCurrentUserDetails,
+    dispatchSignals,
+    dispatchUnknownCredential,
+} from '../src/signals';
+
+describe('signals.js, WebAuthn L3 §5.1.10 dispatchers', () => {
+    beforeEach(() => {
+        // Reset the global PublicKeyCredential surface for each test.
+        globalThis.PublicKeyCredential = {
+            signalUnknownCredential: jest.fn().mockResolvedValue(undefined),
+            signalAllAcceptedCredentials: jest.fn().mockResolvedValue(undefined),
+            signalCurrentUserDetails: jest.fn().mockResolvedValue(undefined),
+        };
+    });
+
+    afterEach(() => {
+        delete globalThis.PublicKeyCredential;
+    });
+
+    test('dispatchUnknownCredential forwards options to PublicKeyCredential.signalUnknownCredential', async () => {
+        const options = { rpId: 'example.com', credentialId: 'aabbcc' };
+
+        await dispatchUnknownCredential(options);
+
+        expect(globalThis.PublicKeyCredential.signalUnknownCredential).toHaveBeenCalledWith(options);
+        expect(globalThis.PublicKeyCredential.signalAllAcceptedCredentials).not.toHaveBeenCalled();
+        expect(globalThis.PublicKeyCredential.signalCurrentUserDetails).not.toHaveBeenCalled();
+    });
+
+    test('dispatchAllAcceptedCredentials forwards options to the matching method', async () => {
+        const options = { rpId: 'example.com', userId: 'aa', allAcceptedCredentialIds: ['bb', 'cc'] };
+
+        await dispatchAllAcceptedCredentials(options);
+
+        expect(globalThis.PublicKeyCredential.signalAllAcceptedCredentials).toHaveBeenCalledWith(options);
+    });
+
+    test('dispatchCurrentUserDetails forwards options to the matching method', async () => {
+        const options = { rpId: 'example.com', userId: 'aa', name: 'alice', displayName: 'Alice' };
+
+        await dispatchCurrentUserDetails(options);
+
+        expect(globalThis.PublicKeyCredential.signalCurrentUserDetails).toHaveBeenCalledWith(options);
+    });
+
+    test('dispatchers silently no-op when the user agent does not implement the method', async () => {
+        globalThis.PublicKeyCredential = {}; // no signal methods
+
+        await expect(dispatchUnknownCredential({ rpId: 'x', credentialId: 'y' })).resolves.toBeUndefined();
+        await expect(
+            dispatchAllAcceptedCredentials({ rpId: 'x', userId: 'y', allAcceptedCredentialIds: [] })
+        ).resolves.toBeUndefined();
+        await expect(
+            dispatchCurrentUserDetails({ rpId: 'x', userId: 'y', name: 'a', displayName: 'A' })
+        ).resolves.toBeUndefined();
+    });
+
+    test('dispatchers silently no-op when PublicKeyCredential itself is missing', async () => {
+        delete globalThis.PublicKeyCredential;
+
+        await expect(dispatchUnknownCredential({ rpId: 'x', credentialId: 'y' })).resolves.toBeUndefined();
+    });
+
+    test('dispatchers swallow TypeError (malformed base64url) without rejecting', async () => {
+        globalThis.PublicKeyCredential.signalUnknownCredential = jest
+            .fn()
+            .mockRejectedValueOnce(new TypeError('bad base64url'));
+
+        await expect(dispatchUnknownCredential({ rpId: 'x', credentialId: '###' })).resolves.toBeUndefined();
+    });
+
+    test('dispatchers swallow SecurityError (RP-ID mismatch) without rejecting', async () => {
+        const securityError = Object.assign(new Error('RP-ID does not match'), { name: 'SecurityError' });
+        globalThis.PublicKeyCredential.signalAllAcceptedCredentials = jest
+            .fn()
+            .mockRejectedValueOnce(securityError);
+
+        await expect(
+            dispatchAllAcceptedCredentials({ rpId: 'wrong', userId: 'y', allAcceptedCredentialIds: [] })
+        ).resolves.toBeUndefined();
+    });
+
+    test('dispatchers re-throw unrelated errors', async () => {
+        globalThis.PublicKeyCredential.signalCurrentUserDetails = jest
+            .fn()
+            .mockRejectedValueOnce(new Error('something else'));
+
+        await expect(
+            dispatchCurrentUserDetails({ rpId: 'x', userId: 'y', name: 'a', displayName: 'A' })
+        ).rejects.toThrow('something else');
+    });
+
+    describe('dispatchSignals envelope router', () => {
+        test('routes each entry to the matching dispatcher', async () => {
+            const envelope = {
+                signals: [
+                    {
+                        type: 'allAcceptedCredentials',
+                        options: { rpId: 'example.com', userId: 'aa', allAcceptedCredentialIds: ['bb'] },
+                    },
+                    {
+                        type: 'currentUserDetails',
+                        options: { rpId: 'example.com', userId: 'aa', name: 'alice', displayName: 'Alice' },
+                    },
+                ],
+            };
+
+            await dispatchSignals(envelope);
+
+            expect(globalThis.PublicKeyCredential.signalAllAcceptedCredentials).toHaveBeenCalledWith(
+                envelope.signals[0].options
+            );
+            expect(globalThis.PublicKeyCredential.signalCurrentUserDetails).toHaveBeenCalledWith(
+                envelope.signals[1].options
+            );
+            expect(globalThis.PublicKeyCredential.signalUnknownCredential).not.toHaveBeenCalled();
+        });
+
+        test('silently skips entries with an unknown type (forward-compat)', async () => {
+            await dispatchSignals({
+                signals: [
+                    { type: 'futureSignal', options: { rpId: 'x' } },
+                    {
+                        type: 'unknownCredential',
+                        options: { rpId: 'example.com', credentialId: 'aabbcc' },
+                    },
+                ],
+            });
+
+            expect(globalThis.PublicKeyCredential.signalUnknownCredential).toHaveBeenCalledTimes(1);
+        });
+
+        test('does nothing on an envelope without a signals array', async () => {
+            await expect(dispatchSignals(null)).resolves.toBeUndefined();
+            await expect(dispatchSignals(undefined)).resolves.toBeUndefined();
+            await expect(dispatchSignals({})).resolves.toBeUndefined();
+            await expect(dispatchSignals({ signals: [] })).resolves.toBeUndefined();
+
+            expect(globalThis.PublicKeyCredential.signalUnknownCredential).not.toHaveBeenCalled();
+            expect(globalThis.PublicKeyCredential.signalAllAcceptedCredentials).not.toHaveBeenCalled();
+            expect(globalThis.PublicKeyCredential.signalCurrentUserDetails).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/stimulus/assets/test/signals.test.js
+++ b/src/stimulus/assets/test/signals.test.js
@@ -75,9 +75,7 @@ describe('signals.js, WebAuthn L3 §5.1.10 dispatchers', () => {
 
     test('dispatchers swallow SecurityError (RP-ID mismatch) without rejecting', async () => {
         const securityError = Object.assign(new Error('RP-ID does not match'), { name: 'SecurityError' });
-        globalThis.PublicKeyCredential.signalAllAcceptedCredentials = jest
-            .fn()
-            .mockRejectedValueOnce(securityError);
+        globalThis.PublicKeyCredential.signalAllAcceptedCredentials = jest.fn().mockRejectedValueOnce(securityError);
 
         await expect(
             dispatchAllAcceptedCredentials({ rpId: 'wrong', userId: 'y', allAcceptedCredentialIds: [] })

--- a/src/symfony/src/Controller/AssertionResponseController.php
+++ b/src/symfony/src/Controller/AssertionResponseController.php
@@ -91,8 +91,6 @@ final readonly class AssertionResponseController
                     new AuthenticationException($throwable->getMessage(), $throwable->getCode(), $throwable)
                 );
             }
-            // PHPDoc-only optional args on FailureHandler::onFailure (will be required in 6.0).
-            // Implementations that haven't updated their signature ignore the extras silently.
             return $this->failureHandler->onFailure(
                 $request,
                 $throwable,

--- a/src/symfony/src/Controller/AssertionResponseController.php
+++ b/src/symfony/src/Controller/AssertionResponseController.php
@@ -37,6 +37,10 @@ final readonly class AssertionResponseController
 
     public function __invoke(Request $request): Response
     {
+        $publicKeyCredential = null;
+        $publicKeyCredentialRequestOptions = null;
+        $userEntity = null;
+
         try {
             $format = $request->getContentTypeFormat();
             $format === 'json' || throw new BadRequestHttpException('Only JSON content type allowed');
@@ -87,7 +91,15 @@ final readonly class AssertionResponseController
                     new AuthenticationException($throwable->getMessage(), $throwable->getCode(), $throwable)
                 );
             }
-            return $this->failureHandler->onFailure($request, $throwable);
+            // PHPDoc-only optional args on FailureHandler::onFailure (will be required in 6.0).
+            // Implementations that haven't updated their signature ignore the extras silently.
+            return $this->failureHandler->onFailure(
+                $request,
+                $throwable,
+                $publicKeyCredential,
+                $publicKeyCredentialRequestOptions,
+                $userEntity,
+            );
         }
     }
 }

--- a/src/symfony/src/Controller/AttestationResponseController.php
+++ b/src/symfony/src/Controller/AttestationResponseController.php
@@ -40,6 +40,10 @@ final readonly class AttestationResponseController
 
     public function __invoke(Request $request): Response
     {
+        $publicKeyCredential = null;
+        $publicKeyCredentialCreationOptions = null;
+        $userEntity = null;
+
         try {
             if (! $this->credentialSourceRepository instanceof CanSaveCredentialRecord
                 && ! $this->credentialSourceRepository instanceof CanSaveCredentialSource) {
@@ -97,7 +101,15 @@ final readonly class AttestationResponseController
             if ($this->failureHandler instanceof AuthenticationFailureHandlerInterface) {
                 return $this->failureHandler->onAuthenticationFailure($request, $exception);
             }
-            return $this->failureHandler->onFailure($request, $exception);
+            // PHPDoc-only optional args on FailureHandler::onFailure (will be required in 6.0).
+            // Implementations that haven't updated their signature ignore the extras silently.
+            return $this->failureHandler->onFailure(
+                $request,
+                $exception,
+                $publicKeyCredential,
+                $publicKeyCredentialCreationOptions,
+                $userEntity,
+            );
         }
     }
 }

--- a/src/symfony/src/Controller/AttestationResponseController.php
+++ b/src/symfony/src/Controller/AttestationResponseController.php
@@ -101,8 +101,6 @@ final readonly class AttestationResponseController
             if ($this->failureHandler instanceof AuthenticationFailureHandlerInterface) {
                 return $this->failureHandler->onAuthenticationFailure($request, $exception);
             }
-            // PHPDoc-only optional args on FailureHandler::onFailure (will be required in 6.0).
-            // Implementations that haven't updated their signature ignore the extras silently.
             return $this->failureHandler->onFailure(
                 $request,
                 $exception,

--- a/src/symfony/src/Resources/config/services.php
+++ b/src/symfony/src/Resources/config/services.php
@@ -27,6 +27,8 @@ use Webauthn\Bundle\Service\DefaultFailureHandler;
 use Webauthn\Bundle\Service\DefaultSuccessHandler;
 use Webauthn\Bundle\Service\PublicKeyCredentialCreationOptionsFactory;
 use Webauthn\Bundle\Service\PublicKeyCredentialRequestOptionsFactory;
+use Webauthn\Bundle\Service\WebauthnSignalFactory;
+use Webauthn\Bundle\Service\WebauthnSignalResponse;
 use Webauthn\CeremonyStep\CeremonyStepManager;
 use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
 use Webauthn\ClientDataCollector\ClientDataCollectorManager;
@@ -320,6 +322,11 @@ return static function (ContainerConfigurator $container): void {
     $service->set(WebauthnSerializerFactory::class);
     $service->set(DefaultFailureHandler::class);
     $service->set(DefaultSuccessHandler::class);
+
+    // WebAuthn L3 §5.1.10 signal helpers — autowired so applications can
+    // request them from a custom SuccessHandler / controller.
+    $service->set(WebauthnSignalFactory::class)->public();
+    $service->set(WebauthnSignalResponse::class)->public();
 
     $service
         ->set(ClientOverridePolicy::class)

--- a/src/symfony/src/Security/Authentication/Exception/WebauthnAuthenticationFailureException.php
+++ b/src/symfony/src/Security/Authentication/Exception/WebauthnAuthenticationFailureException.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Bundle\Security\Authentication\Exception;
+
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Throwable;
+use Webauthn\AuthenticatorResponse;
+use Webauthn\PublicKeyCredential;
+use Webauthn\PublicKeyCredentialOptions;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+/**
+ * Authentication failure raised by {@see \Webauthn\Bundle\Security\Authentication\WebauthnBadgeListener}
+ * when an assertion or attestation ceremony failed to validate.
+ *
+ * Unlike a generic `AuthenticationException`, this one carries the deserialized
+ * pieces of the ceremony so a custom `Authenticator::onAuthenticationFailure()`
+ * can build a contextual response (e.g. a WebAuthn L3 §5.1.10 `signalUnknownCredential`
+ * payload to drop the stale passkey from the platform's UI).
+ *
+ * Pre-deserialization failures (malformed JSON body, missing stored options) keep
+ * the existing "silent fail" behaviour: the badge stays unresolved and Symfony's
+ * pipeline reports a generic auth failure. This class is only raised once the
+ * listener has decided the badge is a real WebAuthn ceremony but its validation
+ * step rejected it.
+ */
+final class WebauthnAuthenticationFailureException extends AuthenticationException
+{
+    public function __construct(
+        string $message,
+        public readonly ?PublicKeyCredential $publicKeyCredential = null,
+        public readonly ?AuthenticatorResponse $authenticatorResponse = null,
+        public readonly ?PublicKeyCredentialOptions $publicKeyCredentialOptions = null,
+        public readonly ?PublicKeyCredentialUserEntity $userEntity = null,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
+
+    public function getMessageKey(): string
+    {
+        return 'Webauthn authentication failed.';
+    }
+}

--- a/src/symfony/src/Security/Authentication/WebauthnBadgeListener.php
+++ b/src/symfony/src/Security/Authentication/WebauthnBadgeListener.php
@@ -15,11 +15,13 @@ use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAssertionResponseValidator;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\AuthenticatorAttestationResponseValidator;
+use Webauthn\AuthenticatorResponse;
 use Webauthn\Bundle\Repository\CanRegisterUserEntity;
 use Webauthn\Bundle\Repository\CanSaveCredentialRecord;
 use Webauthn\Bundle\Repository\CanSaveCredentialSource;
 use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
 use Webauthn\Bundle\Repository\PublicKeyCredentialUserEntityRepositoryInterface;
+use Webauthn\Bundle\Security\Authentication\Exception\WebauthnAuthenticationFailureException;
 use Webauthn\Bundle\Security\Storage\OptionsStorage;
 use Webauthn\CredentialRecord;
 use Webauthn\Exception\InvalidDataException;
@@ -46,6 +48,17 @@ final readonly class WebauthnBadgeListener
     ) {
     }
 
+    /**
+     * The pre-deserialization phase keeps the historical silent-fail behaviour
+     * so other authenticators on the same firewall stay free to handle a
+     * request that turns out not to be a WebAuthn ceremony.
+     *
+     * Once we know the badge IS a WebAuthn ceremony, validation failures are
+     * surfaced through {@see WebauthnAuthenticationFailureException}, which
+     * carries the deserialized credential and options so an Authenticator's
+     * `onAuthenticationFailure()` can build a contextual response (e.g. a W3C
+     * §5.1.10 `signalUnknownCredential` payload).
+     */
     #[AsEventListener(priority: 512)]
     public function checkPassport(CheckPassportEvent $event): void
     {
@@ -73,7 +86,11 @@ final readonly class WebauthnBadgeListener
             $data = $this->optionsStorage->get($response->clientDataJSON->challenge);
             $publicKeyCredentialRequestOptions = $data->getPublicKeyCredentialOptions();
             $userEntity = $data->getPublicKeyCredentialUserEntity();
+        } catch (Throwable) {
+            return;
+        }
 
+        try {
             switch (true) {
                 case $publicKeyCredentialRequestOptions instanceof PublicKeyCredentialRequestOptions && $response instanceof AuthenticatorAssertionResponse:
                     $this->processRequest(
@@ -90,8 +107,17 @@ final readonly class WebauthnBadgeListener
                 default:
                     return;
             }
-        } catch (Throwable) {
-            return;
+        } catch (WebauthnAuthenticationFailureException $exception) {
+            throw $exception;
+        } catch (Throwable $throwable) {
+            throw new WebauthnAuthenticationFailureException(
+                $throwable->getMessage(),
+                publicKeyCredential: $publicKeyCredential,
+                authenticatorResponse: $response instanceof AuthenticatorResponse ? $response : null,
+                publicKeyCredentialOptions: $publicKeyCredentialRequestOptions,
+                userEntity: $userEntity,
+                previous: $throwable,
+            );
         }
     }
 

--- a/src/symfony/src/Security/Handler/FailureHandler.php
+++ b/src/symfony/src/Security/Handler/FailureHandler.php
@@ -11,9 +11,9 @@ use Throwable;
 interface FailureHandler
 {
     /**
-     * Three additional arguments — `?PublicKeyCredential $publicKeyCredential = null`,
+     * Three additional arguments (`?PublicKeyCredential $publicKeyCredential = null`,
      * `?PublicKeyCredentialOptions $publicKeyCredentialOptions = null` and
-     * `?PublicKeyCredentialUserEntity $userEntity = null` — are passed by the bundle's
+     * `?PublicKeyCredentialUserEntity $userEntity = null`) are passed by the bundle's
      * Assertion/Attestation response controllers when they have those values in scope
      * at the failure point (typically: deserialization succeeded but validation failed).
      *

--- a/src/symfony/src/Security/Handler/FailureHandler.php
+++ b/src/symfony/src/Security/Handler/FailureHandler.php
@@ -10,5 +10,25 @@ use Throwable;
 
 interface FailureHandler
 {
-    public function onFailure(Request $request, ?Throwable $exception = null): Response;
+    /**
+     * Three additional arguments — `?PublicKeyCredential $publicKeyCredential = null`,
+     * `?PublicKeyCredentialOptions $publicKeyCredentialOptions = null` and
+     * `?PublicKeyCredentialUserEntity $userEntity = null` — are passed by the bundle's
+     * Assertion/Attestation response controllers when they have those values in scope
+     * at the failure point (typically: deserialization succeeded but validation failed).
+     *
+     * They are declared as a PHPDoc-only argument list in 5.x for backwards compatibility:
+     * existing implementations that have not updated their signature will silently ignore
+     * the extras (PHP allows callers to pass more arguments than the implementation declares).
+     * They will become real, required parameters in 6.0.
+     *
+     * Implementations that want to consume them should add them to their own signature now.
+     */
+    public function onFailure(
+        Request $request,
+        ?Throwable $exception = null,
+        /* ?PublicKeyCredential $publicKeyCredential = null,
+           ?PublicKeyCredentialOptions $publicKeyCredentialOptions = null,
+           ?PublicKeyCredentialUserEntity $userEntity = null, */
+    ): Response;
 }

--- a/src/symfony/src/Service/WebauthnSignalFactory.php
+++ b/src/symfony/src/Service/WebauthnSignalFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Webauthn\Bundle\Service;
 
 use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
+use Webauthn\Bundle\Security\Authentication\Exception\WebauthnAuthenticationFailureException;
 use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredentialDescriptor;
 use Webauthn\PublicKeyCredentialRpEntity;
@@ -41,6 +42,28 @@ final readonly class WebauthnSignalFactory
     public function forUnknownCredential(string $rpId, PublicKeyCredentialDescriptor $credential): UnknownCredential
     {
         return new UnknownCredential($this->rpEntity($rpId), $credential);
+    }
+
+    /**
+     * Convenience companion to {@see self::forUnknownCredential()} for the
+     * Authenticator/Passport/Badge flow: builds the signal from a
+     * {@see WebauthnAuthenticationFailureException} raised by
+     * {@see \Webauthn\Bundle\Security\Authentication\WebauthnBadgeListener}.
+     *
+     * Returns `null` when the exception does not carry a deserialized
+     * credential (e.g. the failure happened before deserialization could
+     * recover the presented `rawId`).
+     */
+    public function forUnknownCredentialFromException(
+        string $rpId,
+        WebauthnAuthenticationFailureException $exception,
+    ): ?UnknownCredential {
+        $credential = $exception->publicKeyCredential;
+        if ($credential === null) {
+            return null;
+        }
+
+        return $this->forUnknownCredential($rpId, $credential->getPublicKeyCredentialDescriptor());
     }
 
     /**

--- a/src/symfony/src/Service/WebauthnSignalFactory.php
+++ b/src/symfony/src/Service/WebauthnSignalFactory.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Bundle\Service;
+
+use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
+use Webauthn\CredentialRecord;
+use Webauthn\PublicKeyCredentialDescriptor;
+use Webauthn\PublicKeyCredentialRpEntity;
+use Webauthn\PublicKeyCredentialUserEntity;
+use Webauthn\Signal\AllAcceptedCredentials;
+use Webauthn\Signal\CurrentUserDetails;
+use Webauthn\Signal\UnknownCredential;
+
+/**
+ * Builds the three W3C WebAuthn L3 §5.1.10 signal payloads from the bundle's own
+ * services so applications do not have to re-derive `rpId`, the descriptor list
+ * or the user PII themselves.
+ *
+ * Use from a custom {@see \Webauthn\Bundle\Security\Handler\SuccessHandler} or
+ * controller, then hand the produced {@see \Webauthn\Signal\Signal} objects to
+ * {@see WebauthnSignalResponse::withSignals()}.
+ *
+ * @see https://www.w3.org/TR/webauthn-3/#sctn-signal-methods
+ */
+final readonly class WebauthnSignalFactory
+{
+    public function __construct(
+        private CredentialRecordRepositoryInterface $credentialRepository,
+    ) {
+    }
+
+    /**
+     * Build a {@see UnknownCredential} signal for an assertion that referenced a credential
+     * the relying party no longer recognises (e.g. it was deleted server-side).
+     *
+     * Per W3C §14.6.3 this signal is safe to expose to an unauthenticated caller — the
+     * credential id is one the caller already presented, so no PII leaks.
+     */
+    public function forUnknownCredential(string $rpId, PublicKeyCredentialDescriptor $credential): UnknownCredential
+    {
+        return new UnknownCredential($this->rpEntity($rpId), $credential);
+    }
+
+    /**
+     * Build an {@see AllAcceptedCredentials} signal containing every credential currently
+     * registered for `$user`. The list is derived exhaustively from
+     * {@see CredentialRecordRepositoryInterface::findAllForUserEntity()} to defuse the
+     * *"potentially irreversible"* deletion warning of W3C §5.1.10.3 (credentials missing
+     * from the list are removed/hidden by the authenticator).
+     *
+     * Per W3C §14.6.3 this signal MUST only be emitted to an authenticated user — the
+     * full credential id list is PII.
+     */
+    public function forAllAccepted(string $rpId, PublicKeyCredentialUserEntity $user): AllAcceptedCredentials
+    {
+        $descriptors = array_map(
+            static fn (CredentialRecord $record): PublicKeyCredentialDescriptor => $record->getPublicKeyCredentialDescriptor(),
+            $this->credentialRepository->findAllForUserEntity($user),
+        );
+
+        return new AllAcceptedCredentials($this->rpEntity($rpId), $user, $descriptors);
+    }
+
+    /**
+     * Build a {@see CurrentUserDetails} signal carrying the user's current `name` and
+     * `displayName` so the password manager can refresh its passkey label.
+     *
+     * Per W3C §14.6.3 this signal MUST only be emitted to an authenticated user —
+     * the user handle plus display strings are PII.
+     */
+    public function forCurrentUser(string $rpId, PublicKeyCredentialUserEntity $user): CurrentUserDetails
+    {
+        return new CurrentUserDetails($this->rpEntity($rpId), $user);
+    }
+
+    private function rpEntity(string $rpId): PublicKeyCredentialRpEntity
+    {
+        return PublicKeyCredentialRpEntity::create(id: $rpId);
+    }
+}

--- a/src/symfony/src/Service/WebauthnSignalFactory.php
+++ b/src/symfony/src/Service/WebauthnSignalFactory.php
@@ -35,7 +35,7 @@ final readonly class WebauthnSignalFactory
      * Build a {@see UnknownCredential} signal for an assertion that referenced a credential
      * the relying party no longer recognises (e.g. it was deleted server-side).
      *
-     * Per W3C §14.6.3 this signal is safe to expose to an unauthenticated caller — the
+     * Per W3C §14.6.3 this signal is safe to expose to an unauthenticated caller: the
      * credential id is one the caller already presented, so no PII leaks.
      */
     public function forUnknownCredential(string $rpId, PublicKeyCredentialDescriptor $credential): UnknownCredential
@@ -50,7 +50,7 @@ final readonly class WebauthnSignalFactory
      * *"potentially irreversible"* deletion warning of W3C §5.1.10.3 (credentials missing
      * from the list are removed/hidden by the authenticator).
      *
-     * Per W3C §14.6.3 this signal MUST only be emitted to an authenticated user — the
+     * Per W3C §14.6.3 this signal MUST only be emitted to an authenticated user: the
      * full credential id list is PII.
      */
     public function forAllAccepted(string $rpId, PublicKeyCredentialUserEntity $user): AllAcceptedCredentials
@@ -67,7 +67,7 @@ final readonly class WebauthnSignalFactory
      * Build a {@see CurrentUserDetails} signal carrying the user's current `name` and
      * `displayName` so the password manager can refresh its passkey label.
      *
-     * Per W3C §14.6.3 this signal MUST only be emitted to an authenticated user —
+     * Per W3C §14.6.3 this signal MUST only be emitted to an authenticated user:
      * the user handle plus display strings are PII.
      */
     public function forCurrentUser(string $rpId, PublicKeyCredentialUserEntity $user): CurrentUserDetails

--- a/src/symfony/src/Service/WebauthnSignalResponse.php
+++ b/src/symfony/src/Service/WebauthnSignalResponse.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Bundle\Service;
+
+use InvalidArgumentException;
+use function sprintf;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Webauthn\Signal\AllAcceptedCredentials;
+use Webauthn\Signal\CurrentUserDetails;
+use Webauthn\Signal\Signal;
+use Webauthn\Signal\UnknownCredential;
+
+/**
+ * JsonResponse helper that wraps an application payload alongside a top-level
+ * `signals` envelope shaped for the Stimulus base controller to dispatch via
+ * `PublicKeyCredential.signalXxx(...)`.
+ *
+ * Each Signal is normalised to its W3C `*Options` dictionary and tagged with
+ * its `type` so the JS side can route to the correct method:
+ *
+ * ```json
+ * {
+ *     "your": "payload",
+ *     "signals": [
+ *         {"type": "allAcceptedCredentials", "options": { "rpId": "...", "userId": "...", "allAcceptedCredentialIds": [...] }},
+ *         {"type": "currentUserDetails",     "options": { "rpId": "...", "userId": "...", "name": "...", "displayName": "..." }}
+ *     ]
+ * }
+ * ```
+ *
+ * The application controls *when* to emit signals — typically from a custom
+ * {@see \Webauthn\Bundle\Security\Handler\SuccessHandler}.
+ *
+ * @see https://www.w3.org/TR/webauthn-3/#sctn-signal-methods
+ */
+final readonly class WebauthnSignalResponse
+{
+    public function __construct(
+        private NormalizerInterface $normalizer,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function withSignals(array $payload, Signal ...$signals): JsonResponse
+    {
+        $payload['signals'] = array_map(
+            fn (Signal $signal): array => [
+                'type' => $this->typeOf($signal),
+                /** @phpstan-ignore-next-line — normalize() returns array<string, mixed> for our signal denormalizers. */
+                'options' => $this->normalizer->normalize($signal, 'json', [
+                    AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+                ]),
+            ],
+            $signals,
+        );
+
+        return new JsonResponse($payload);
+    }
+
+    private function typeOf(Signal $signal): string
+    {
+        return match ($signal::class) {
+            UnknownCredential::class => 'unknownCredential',
+            AllAcceptedCredentials::class => 'allAcceptedCredentials',
+            CurrentUserDetails::class => 'currentUserDetails',
+            default => throw new InvalidArgumentException(sprintf('Unsupported signal type "%s".', $signal::class)),
+        };
+    }
+}

--- a/src/symfony/src/Service/WebauthnSignalResponse.php
+++ b/src/symfony/src/Service/WebauthnSignalResponse.php
@@ -32,7 +32,7 @@ use Webauthn\Signal\UnknownCredential;
  * }
  * ```
  *
- * The application controls *when* to emit signals — typically from a custom
+ * The application controls *when* to emit signals, typically from a custom
  * {@see \Webauthn\Bundle\Security\Handler\SuccessHandler}.
  *
  * @see https://www.w3.org/TR/webauthn-3/#sctn-signal-methods
@@ -52,7 +52,7 @@ final readonly class WebauthnSignalResponse
         $payload['signals'] = array_map(
             fn (Signal $signal): array => [
                 'type' => $this->typeOf($signal),
-                /** @phpstan-ignore-next-line — normalize() returns array<string, mixed> for our signal denormalizers. */
+                /** @phpstan-ignore-next-line normalize() returns array<string, mixed> for our signal denormalizers. */
                 'options' => $this->normalizer->normalize($signal, 'json', [
                     AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
                 ]),

--- a/tests/symfony/unit/Service/SignalHelpersTest.php
+++ b/tests/symfony/unit/Service/SignalHelpersTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Bundle\Unit\Service;
+
+use const JSON_THROW_ON_ERROR;
+use ParagonIE\ConstantTime\Base64UrlSafe;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Uid\Uuid;
+use Webauthn\AttestationStatement\AttestationStatement;
+use Webauthn\AttestationStatement\AttestationStatementSupportManager;
+use Webauthn\AttestationStatement\NoneAttestationStatementSupport;
+use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
+use Webauthn\Bundle\Service\WebauthnSignalFactory;
+use Webauthn\Bundle\Service\WebauthnSignalResponse;
+use Webauthn\CredentialRecord;
+use Webauthn\Denormalizer\WebauthnSerializerFactory;
+use Webauthn\PublicKeyCredentialDescriptor;
+use Webauthn\PublicKeyCredentialUserEntity;
+use Webauthn\Signal\Signal;
+use Webauthn\TrustPath\EmptyTrustPath;
+
+/**
+ * @internal
+ */
+final class SignalHelpersTest extends TestCase
+{
+    #[Test]
+    public function unknownCredentialSignalProducesTheW3CDictionaryShape(): void
+    {
+        $factory = new WebauthnSignalFactory($this->emptyRepository());
+
+        $signal = $factory->forUnknownCredential(
+            'example.com',
+            PublicKeyCredentialDescriptor::create(
+                PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
+                'rawCredentialIdBytes',
+            ),
+        );
+
+        $payload = $this->envelope($signal);
+        static::assertSame([
+            [
+                'type' => 'unknownCredential',
+                'options' => [
+                    'rpId' => 'example.com',
+                    'credentialId' => Base64UrlSafe::encodeUnpadded('rawCredentialIdBytes'),
+                ],
+            ],
+        ], $payload['signals']);
+    }
+
+    #[Test]
+    public function allAcceptedCredentialsListIsDerivedExhaustivelyFromTheRepository(): void
+    {
+        $user = PublicKeyCredentialUserEntity::create(
+            name: 'alice',
+            id: 'user-handle-bytes',
+            displayName: 'Alice',
+        );
+        $factory = new WebauthnSignalFactory($this->repositoryWith([
+            $this->record('cred-A'),
+            $this->record('cred-B'),
+        ]));
+
+        $signal = $factory->forAllAccepted('example.com', $user);
+
+        $payload = $this->envelope($signal);
+        static::assertCount(1, $payload['signals']);
+        static::assertSame('allAcceptedCredentials', $payload['signals'][0]['type']);
+
+        $options = $payload['signals'][0]['options'];
+        static::assertSame('example.com', $options['rpId']);
+        static::assertSame(Base64UrlSafe::encodeUnpadded('user-handle-bytes'), $options['userId']);
+        static::assertSame(
+            [Base64UrlSafe::encodeUnpadded('cred-A'), Base64UrlSafe::encodeUnpadded('cred-B')],
+            $options['allAcceptedCredentialIds'],
+        );
+    }
+
+    #[Test]
+    public function currentUserDetailsCarriesNameAndDisplayName(): void
+    {
+        $factory = new WebauthnSignalFactory($this->emptyRepository());
+        $user = PublicKeyCredentialUserEntity::create(
+            name: 'alice@example.com',
+            id: 'user-handle-bytes',
+            displayName: 'Alice Liddell',
+        );
+
+        $signal = $factory->forCurrentUser('example.com', $user);
+
+        static::assertSame([
+            [
+                'type' => 'currentUserDetails',
+                'options' => [
+                    'rpId' => 'example.com',
+                    'userId' => Base64UrlSafe::encodeUnpadded('user-handle-bytes'),
+                    'name' => 'alice@example.com',
+                    'displayName' => 'Alice Liddell',
+                ],
+            ],
+        ], $this->envelope($signal)['signals']);
+    }
+
+    #[Test]
+    public function withSignalsTagsEachSignalWithItsDispatchTypeAndPreservesTheApplicationPayload(): void
+    {
+        $user = PublicKeyCredentialUserEntity::create(name: 'alice', id: 'h', displayName: 'Alice');
+        $factory = new WebauthnSignalFactory($this->emptyRepository());
+        $response = new WebauthnSignalResponse($this->serializer());
+
+        $jsonResponse = $response->withSignals(
+            [
+                'success' => true,
+                'next' => '/dashboard',
+            ],
+            $factory->forAllAccepted('example.com', $user),
+            $factory->forCurrentUser('example.com', $user),
+        );
+
+        $payload = $this->decode($jsonResponse);
+        static::assertTrue($payload['success']);
+        static::assertSame('/dashboard', $payload['next']);
+        static::assertSame(
+            ['allAcceptedCredentials', 'currentUserDetails'],
+            array_column($payload['signals'], 'type'),
+        );
+    }
+
+    private function record(string $credentialId): CredentialRecord
+    {
+        return new CredentialRecord(
+            publicKeyCredentialId: $credentialId,
+            type: PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
+            transports: [],
+            attestationType: AttestationStatement::TYPE_NONE,
+            trustPath: EmptyTrustPath::create(),
+            aaguid: Uuid::fromBinary(str_repeat("\0", 16)),
+            credentialPublicKey: 'pub-key',
+            userHandle: 'user-handle-bytes',
+            counter: 0,
+        );
+    }
+
+    private function emptyRepository(): CredentialRecordRepositoryInterface
+    {
+        return $this->repositoryWith([]);
+    }
+
+    /**
+     * @param list<CredentialRecord> $records
+     */
+    private function repositoryWith(array $records): CredentialRecordRepositoryInterface
+    {
+        return new class($records) implements CredentialRecordRepositoryInterface {
+            /**
+             * @param list<CredentialRecord> $records
+             */
+            public function __construct(
+                private readonly array $records
+            ) {
+            }
+
+            public function findOneByCredentialId(string $publicKeyCredentialId): ?CredentialRecord
+            {
+                foreach ($this->records as $record) {
+                    if ($record->publicKeyCredentialId === $publicKeyCredentialId) {
+                        return $record;
+                    }
+                }
+
+                return null;
+            }
+
+            /**
+             * @return array<CredentialRecord>
+             */
+            public function findAllForUserEntity(PublicKeyCredentialUserEntity $publicKeyCredentialUserEntity): array
+            {
+                return array_values(array_filter(
+                    $this->records,
+                    static fn (CredentialRecord $r): bool => $r->userHandle === $publicKeyCredentialUserEntity->id,
+                ));
+            }
+        };
+    }
+
+    private function serializer(): Serializer
+    {
+        $manager = AttestationStatementSupportManager::create();
+        $manager->add(NoneAttestationStatementSupport::create());
+
+        return (new WebauthnSerializerFactory($manager))->create();
+    }
+
+    /**
+     * @return array{signals: list<array{type: string, options: array<string, mixed>}>, success?: bool, next?: string}
+     */
+    private function envelope(Signal $signal): array
+    {
+        return $this->decode((new WebauthnSignalResponse($this->serializer()))->withSignals([], $signal));
+    }
+
+    /**
+     * @return array{signals: list<array{type: string, options: array<string, mixed>}>, success?: bool, next?: string}
+     */
+    private function decode(JsonResponse $response): array
+    {
+        return json_decode($response->getContent() ?: '', true, flags: JSON_THROW_ON_ERROR);
+    }
+}

--- a/tests/symfony/unit/Service/SignalHelpersTest.php
+++ b/tests/symfony/unit/Service/SignalHelpersTest.php
@@ -14,11 +14,14 @@ use Symfony\Component\Uid\Uuid;
 use Webauthn\AttestationStatement\AttestationStatement;
 use Webauthn\AttestationStatement\AttestationStatementSupportManager;
 use Webauthn\AttestationStatement\NoneAttestationStatementSupport;
+use Webauthn\AuthenticatorResponse;
 use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
+use Webauthn\Bundle\Security\Authentication\Exception\WebauthnAuthenticationFailureException;
 use Webauthn\Bundle\Service\WebauthnSignalFactory;
 use Webauthn\Bundle\Service\WebauthnSignalResponse;
 use Webauthn\CredentialRecord;
 use Webauthn\Denormalizer\WebauthnSerializerFactory;
+use Webauthn\PublicKeyCredential;
 use Webauthn\PublicKeyCredentialDescriptor;
 use Webauthn\PublicKeyCredentialUserEntity;
 use Webauthn\Signal\Signal;
@@ -52,6 +55,36 @@ final class SignalHelpersTest extends TestCase
                 ],
             ],
         ], $payload['signals']);
+    }
+
+    #[Test]
+    public function unknownCredentialFromExceptionExtractsTheDescriptorFromTheCarriedCredential(): void
+    {
+        $factory = new WebauthnSignalFactory($this->emptyRepository());
+        $credential = new PublicKeyCredential(
+            PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
+            'rawCredentialIdBytes',
+            $this->createMock(AuthenticatorResponse::class),
+        );
+        $exception = new WebauthnAuthenticationFailureException(
+            'Credential ID is invalid.',
+            publicKeyCredential: $credential,
+        );
+
+        $signal = $factory->forUnknownCredentialFromException('example.com', $exception);
+
+        static::assertNotNull($signal);
+        static::assertSame('example.com', $signal->rp->id);
+        static::assertSame('rawCredentialIdBytes', $signal->credential->id);
+    }
+
+    #[Test]
+    public function unknownCredentialFromExceptionReturnsNullWhenNoCredentialIsCarried(): void
+    {
+        $factory = new WebauthnSignalFactory($this->emptyRepository());
+        $exception = new WebauthnAuthenticationFailureException('Credential ID is invalid.');
+
+        static::assertNull($factory->forUnknownCredentialFromException('example.com', $exception));
     }
 
     #[Test]


### PR DESCRIPTION
Refs #846 (Symfony bundle slice — Stimulus + doc shipped separately).

## What

Two helper services so applications opt into emitting the W3C Signal API
payloads from their own \`SuccessHandler\` / \`FailureHandler\` — no new
configuration, no new firewall hook.

- \`WebauthnSignalFactory\` (autowired, public):
  - \`forUnknownCredential(string \$rpId, PublicKeyCredentialDescriptor \$credential): UnknownCredential\`
  - \`forAllAccepted(string \$rpId, PublicKeyCredentialUserEntity \$user): AllAcceptedCredentials\` — derives the descriptor list exhaustively from \`CredentialRecordRepositoryInterface::findAllForUserEntity()\` to defuse the *"potentially irreversible"* deletion warning of W3C §5.1.10.3.
  - \`forCurrentUser(string \$rpId, PublicKeyCredentialUserEntity \$user): CurrentUserDetails\`
- \`WebauthnSignalResponse::withSignals(array \$payload, Signal ...\$signals): JsonResponse\` — wraps an application payload alongside a top-level \`signals: [{type, options}]\` envelope using the existing serializer. The Stimulus base controller picks it up to dispatch \`PublicKeyCredential.signalXxx()\`.

## Side change — \`FailureHandler\` widening

\`FailureHandler::onFailure\` widened with three PHPDoc-only optional arguments (\`?PublicKeyCredential\`, \`?PublicKeyCredentialOptions\`, \`?PublicKeyCredentialUserEntity\`) so the response controllers can hand the deserialized credential / stored options / resolved user entity to the failure handler. Implementations that have not updated their signature ignore the extras silently (PHP allows callers to pass more arguments than the implementation declares). To be promoted to required arguments in 6.0.

This is what makes \`signalUnknownCredential\` ergonomic on the failure path: the handler no longer needs to re-parse the request body to recover the \`rawId\`.

## Privacy gates per W3C §14.6.3

Documented inline on every factory method:
- \`forUnknownCredential\` — safe to expose to an unauthenticated caller (single id, already known to the caller, no PII leak).
- \`forAllAccepted\` / \`forCurrentUser\` — full credential id list / user PII; MUST sit behind an authenticated session.

## Out of scope

- Stimulus side (\`signals.js\` module, auto-pickup in \`AuthenticationController\`) — separate PR.
- Documentation (\`webauthn-doc\` 5.4 branch) — separate PR.