### PR TITLE
feat(verifier): profile-free response verification helpers

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -1,6 +1,12 @@
 parameters:
 	ignoreErrors:
 		-
+			rawMessage: 'Method Webauthn\Bundle\Security\Handler\FailureHandler::onFailure() invoked with 5 parameters, 1-2 required.'
+			identifier: arguments.count
+			count: 1
+			path: ../src/symfony/src/Controller/AssertionResponseController.php
+
+		-
 			rawMessage: '''
 				Call to method fromCredentialRecord() of deprecated class Webauthn\PublicKeyCredentialSource:
 				since 5.3, use CredentialRecord instead. Will be removed in 6.0.
@@ -25,6 +31,12 @@ parameters:
 			'''
 			identifier: instanceof.deprecatedInterface
 			count: 2
+			path: ../src/symfony/src/Controller/AttestationResponseController.php
+
+		-
+			rawMessage: 'Method Webauthn\Bundle\Security\Handler\FailureHandler::onFailure() invoked with 5 parameters, 1-2 required.'
+			identifier: arguments.count
+			count: 1
 			path: ../src/symfony/src/Controller/AttestationResponseController.php
 
 		-
@@ -109,6 +121,12 @@ parameters:
 			path: ../src/symfony/src/Security/Authentication/WebauthnBadgeListener.php
 
 		-
+			rawMessage: Instanceof between Webauthn\AuthenticatorAssertionResponse|Webauthn\AuthenticatorAttestationResponse and Webauthn\AuthenticatorResponse will always evaluate to true.
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: ../src/symfony/src/Security/Authentication/WebauthnBadgeListener.php
+
+		-
 			rawMessage: '''
 				Instanceof references deprecated interface Webauthn\Bundle\Repository\CanSaveCredentialSource:
 				since 5.3, use CanSaveCredentialRecord instead. Will be removed in 6.0.
@@ -160,6 +178,51 @@ parameters:
 			path: ../src/symfony/src/Security/Http/Authenticator/WebauthnAuthenticator.php
 
 		-
+			rawMessage: 'Method Webauthn\Bundle\Service\AbstractWebauthnOptionsBuilder::parseDto() should return T of object but returns mixed.'
+			identifier: return.type
+			count: 1
+			path: ../src/symfony/src/Service/AbstractWebauthnOptionsBuilder.php
+
+		-
+			rawMessage: '''
+				Fetching deprecated class constant COSE_ALGORITHM_EdDSA of class Cose\Algorithms:
+				since v4.0.6. Please use COSE_ALGORITHM_EDDSA instead. Will be removed in v5.0.0
+			'''
+			identifier: classConstant.deprecated
+			count: 1
+			path: ../src/symfony/src/Service/WebauthnCreationOptionsBuilder.php
+
+		-
+			rawMessage: 'Parameter #1 $length of function random_bytes expects int<1, max>, int given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/symfony/src/Service/WebauthnCreationOptionsBuilder.php
+
+		-
+			rawMessage: 'Parameter $timeout of static method Webauthn\PublicKeyCredentialCreationOptions::create() expects int<1, max>|null, int|null given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/symfony/src/Service/WebauthnCreationOptionsBuilder.php
+
+		-
+			rawMessage: 'Method Webauthn\Bundle\Service\WebauthnRequestOptionsBuilder::resolveAllowCredentials() should return list<Webauthn\PublicKeyCredentialDescriptor> but returns array<Webauthn\PublicKeyCredentialDescriptor>.'
+			identifier: return.type
+			count: 1
+			path: ../src/symfony/src/Service/WebauthnRequestOptionsBuilder.php
+
+		-
+			rawMessage: 'Parameter #1 $length of function random_bytes expects int<1, max>, int given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/symfony/src/Service/WebauthnRequestOptionsBuilder.php
+
+		-
+			rawMessage: 'Parameter $timeout of static method Webauthn\PublicKeyCredentialRequestOptions::create() expects int<1, max>|null, int|null given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/symfony/src/Service/WebauthnRequestOptionsBuilder.php
+
+		-
 			rawMessage: 'Parameter #2 $attStmt of static method Webauthn\AttestationStatement\AttestationStatement::create() expects array<string, mixed>, list<Webauthn\AttestationStatement\AttestationStatement> given.'
 			identifier: argument.type
 			count: 1
@@ -173,12 +236,6 @@ parameters:
 			identifier: instanceof.deprecatedClass
 			count: 1
 			path: ../src/webauthn/src/AuthenticatorAssertionResponseValidator.php
-
-		-
-			rawMessage: 'Parameter #1 $codepoint of function chr expects int<0, 255>, int given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/webauthn/src/AuthenticatorDataLoader.php
 
 		-
 			rawMessage: '''
@@ -383,12 +440,6 @@ parameters:
 			identifier: instanceof.deprecatedClass
 			count: 1
 			path: ../src/webauthn/src/Counter/ThrowExceptionIfInvalid.php
-
-		-
-			rawMessage: 'Parameter #1 $codepoint of function chr expects int<0, 255>, int given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/webauthn/src/Denormalizer/AuthenticatorDataDenormalizer.php
 
 		-
 			rawMessage: 'Parameter #3 $context of method Webauthn\Denormalizer\CollectedClientAdditionalPaymentDataDenormalizer::denormalizeLogo() expects array<string, mixed>, array<mixed> given.'

--- a/src/symfony/src/Resources/config/services.php
+++ b/src/symfony/src/Resources/config/services.php
@@ -28,6 +28,7 @@ use Webauthn\Bundle\Service\DefaultSuccessHandler;
 use Webauthn\Bundle\Service\PublicKeyCredentialCreationOptionsFactory;
 use Webauthn\Bundle\Service\PublicKeyCredentialRequestOptionsFactory;
 use Webauthn\Bundle\Service\WebauthnOptionsResponse;
+use Webauthn\Bundle\Service\WebauthnResponseVerifier;
 use Webauthn\Bundle\Service\WebauthnSignalFactory;
 use Webauthn\Bundle\Service\WebauthnSignalResponse;
 use Webauthn\CeremonyStep\CeremonyStepManager;
@@ -330,6 +331,14 @@ return static function (ContainerConfigurator $container): void {
     $service->set(WebauthnSignalResponse::class)->public();
 
     $service->set(WebauthnOptionsResponse::class)->public();
+
+    $service
+        ->set(WebauthnResponseVerifier::class)
+        ->arg(
+            '$conditionalAttestationValidator',
+            service('webauthn.authenticator_attestation_response_validator.conditional_creation')
+        )
+        ->public();
 
     $service
         ->set(ClientOverridePolicy::class)

--- a/src/symfony/src/Service/AbstractWebauthnVerifier.php
+++ b/src/symfony/src/Service/AbstractWebauthnVerifier.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Bundle\Service;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Serializer\SerializerInterface;
+use Throwable;
+use Webauthn\AuthenticatorResponse;
+use Webauthn\Bundle\Security\Authentication\Exception\WebauthnAuthenticationFailureException;
+use Webauthn\Bundle\Security\Storage\OptionsStorage;
+use Webauthn\CredentialRecord;
+use Webauthn\PublicKeyCredential;
+use Webauthn\PublicKeyCredentialOptions;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+/**
+ * Common skeleton shared by {@see WebauthnAttestationVerifier} and
+ * {@see WebauthnAssertionVerifier}. Reads the JSON body, deserialises it as a
+ * {@see PublicKeyCredential}, retrieves the matching ceremony options from
+ * {@see OptionsStorage}, and delegates the ceremony-specific validation to
+ * subclasses.
+ *
+ * Pre-validation problems (missing JSON body, malformed payload, wrong response
+ * type, unknown challenge) bubble up as {@see BadRequestHttpException} so the
+ * Symfony HTTP layer turns them into HTTP 400. Validation failures raised by
+ * the underlying validator are wrapped in
+ * {@see WebauthnAuthenticationFailureException} so the controller can build a
+ * contextual response (e.g. a Signal API payload to drop a stale credential
+ * from the platform UI).
+ */
+abstract class AbstractWebauthnVerifier
+{
+    public function __construct(
+        protected readonly SerializerInterface $serializer,
+        protected readonly OptionsStorage $storage,
+    ) {
+    }
+
+    public function verify(Request $request): WebauthnVerificationResult
+    {
+        [$publicKeyCredential, $authenticatorResponse] = $this->loadCredential($request);
+        [$options, $userEntity] = $this->loadStoredContext($authenticatorResponse);
+
+        try {
+            $credentialRecord = $this->runValidation(
+                $request,
+                $publicKeyCredential,
+                $authenticatorResponse,
+                $options,
+                $userEntity,
+            );
+        } catch (Throwable $throwable) {
+            throw new WebauthnAuthenticationFailureException(
+                $throwable->getMessage(),
+                $publicKeyCredential,
+                $authenticatorResponse,
+                $options,
+                $userEntity,
+                $throwable,
+            );
+        }
+
+        return new WebauthnVerificationResult($credentialRecord, $publicKeyCredential, $userEntity);
+    }
+
+    abstract protected function ensureResponseMatches(AuthenticatorResponse $response): void;
+
+    abstract protected function ensureOptionsMatch(PublicKeyCredentialOptions $options): void;
+
+    abstract protected function runValidation(
+        Request $request,
+        PublicKeyCredential $publicKeyCredential,
+        AuthenticatorResponse $response,
+        PublicKeyCredentialOptions $options,
+        ?PublicKeyCredentialUserEntity $userEntity,
+    ): CredentialRecord;
+
+    /**
+     * @return array{PublicKeyCredential, AuthenticatorResponse}
+     */
+    private function loadCredential(Request $request): array
+    {
+        $request->getContentTypeFormat() === 'json' || throw new BadRequestHttpException(
+            'Only JSON content type allowed'
+        );
+        $content = $request->getContent();
+        $content !== '' || throw new BadRequestHttpException('Empty request body');
+
+        try {
+            $publicKeyCredential = $this->serializer->deserialize($content, PublicKeyCredential::class, 'json');
+        } catch (Throwable $throwable) {
+            throw new BadRequestHttpException('Unable to deserialize the request body', $throwable);
+        }
+
+        $response = $publicKeyCredential->response;
+        $this->ensureResponseMatches($response);
+
+        return [$publicKeyCredential, $response];
+    }
+
+    /**
+     * @return array{PublicKeyCredentialOptions, ?PublicKeyCredentialUserEntity}
+     */
+    private function loadStoredContext(AuthenticatorResponse $response): array
+    {
+        try {
+            $item = $this->storage->get($response->clientDataJSON->challenge);
+        } catch (Throwable $throwable) {
+            throw new BadRequestHttpException('No options found for the given challenge', $throwable);
+        }
+
+        $options = $item->getPublicKeyCredentialOptions();
+        $this->ensureOptionsMatch($options);
+
+        return [$options, $item->getPublicKeyCredentialUserEntity()];
+    }
+}

--- a/src/symfony/src/Service/WebauthnAssertionVerifier.php
+++ b/src/symfony/src/Service/WebauthnAssertionVerifier.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Bundle\Service;
+
+use function assert;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Serializer\SerializerInterface;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\AuthenticatorAssertionResponseValidator;
+use Webauthn\AuthenticatorResponse;
+use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
+use Webauthn\Bundle\Security\Storage\OptionsStorage;
+use Webauthn\CredentialRecord;
+use Webauthn\Exception\AuthenticatorResponseVerificationException;
+use Webauthn\PublicKeyCredential;
+use Webauthn\PublicKeyCredentialOptions;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+/**
+ * Verifies the {@see AuthenticatorAssertionResponse} produced at the end of an
+ * authentication ceremony, returned by
+ * {@see WebauthnResponseVerifier::forAssertion()}.
+ *
+ * The credential record matching the response's `rawId` is fetched from the
+ * autowired {@see CredentialRecordRepositoryInterface} and updated in place by
+ * the underlying validator (counter, backup state, `uvInitialized`). Persistence
+ * of these updates is left to the repository implementation, mirroring the
+ * legacy {@see \Webauthn\Bundle\Controller\AssertionResponseController}: Doctrine
+ * repositories flush automatically through the unit of work.
+ */
+final class WebauthnAssertionVerifier extends AbstractWebauthnVerifier
+{
+    public function __construct(
+        SerializerInterface $serializer,
+        OptionsStorage $storage,
+        private readonly AuthenticatorAssertionResponseValidator $validator,
+        private readonly CredentialRecordRepositoryInterface $repository,
+        private readonly string $rpId,
+    ) {
+        parent::__construct($serializer, $storage);
+    }
+
+    protected function ensureResponseMatches(AuthenticatorResponse $response): void
+    {
+        $response instanceof AuthenticatorAssertionResponse || throw new BadRequestHttpException(
+            'The response is not an assertion response.'
+        );
+    }
+
+    protected function ensureOptionsMatch(PublicKeyCredentialOptions $options): void
+    {
+        $options instanceof PublicKeyCredentialRequestOptions || throw new BadRequestHttpException(
+            'The stored options are not request options.'
+        );
+
+        ($options->rpId ?? $this->rpId) === $this->rpId || throw new BadRequestHttpException(
+            'The stored options do not match the expected Relying Party identifier.'
+        );
+    }
+
+    protected function runValidation(
+        Request $request,
+        PublicKeyCredential $publicKeyCredential,
+        AuthenticatorResponse $response,
+        PublicKeyCredentialOptions $options,
+        ?PublicKeyCredentialUserEntity $userEntity,
+    ): CredentialRecord {
+        assert($response instanceof AuthenticatorAssertionResponse);
+        assert($options instanceof PublicKeyCredentialRequestOptions);
+
+        $credentialRecord = $this->repository->findOneByCredentialId($publicKeyCredential->rawId)
+            ?? throw AuthenticatorResponseVerificationException::create('The credential ID is invalid.');
+
+        return $this->validator->check(
+            $credentialRecord,
+            $response,
+            $options,
+            $request->getHost(),
+            $userEntity?->id,
+        );
+    }
+}

--- a/src/symfony/src/Service/WebauthnAttestationVerifier.php
+++ b/src/symfony/src/Service/WebauthnAttestationVerifier.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Bundle\Service;
+
+use function assert;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Serializer\SerializerInterface;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\AuthenticatorAttestationResponseValidator;
+use Webauthn\AuthenticatorResponse;
+use Webauthn\Bundle\Exception\MissingFeatureException;
+use Webauthn\Bundle\Repository\CanSaveCredentialRecord;
+use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
+use Webauthn\Bundle\Security\Storage\OptionsStorage;
+use Webauthn\CredentialRecord;
+use Webauthn\PublicKeyCredential;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialOptions;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+/**
+ * Verifies the {@see AuthenticatorAttestationResponse} produced at the end of a
+ * registration ceremony, returned by
+ * {@see WebauthnResponseVerifier::forAttestation()}.
+ *
+ * By default the validated credential record is persisted automatically through
+ * the autowired {@see CredentialRecordRepositoryInterface}. Disable that
+ * behaviour with {@see self::withSaveCredential()} if your controller wants to
+ * own persistence (e.g. attach extra fields, write through a transaction).
+ *
+ * If the stored creation options carry the W3C `mediation: conditional` flag,
+ * the verifier automatically uses the conditional creation ceremony manager
+ * (which relaxes the User Verification check, per the spec).
+ */
+final class WebauthnAttestationVerifier extends AbstractWebauthnVerifier
+{
+    private bool $saveCredential = true;
+
+    public function __construct(
+        SerializerInterface $serializer,
+        OptionsStorage $storage,
+        private readonly AuthenticatorAttestationResponseValidator $validator,
+        private readonly AuthenticatorAttestationResponseValidator $conditionalValidator,
+        private readonly CredentialRecordRepositoryInterface $repository,
+        private readonly string $rpId,
+    ) {
+        parent::__construct($serializer, $storage);
+    }
+
+    public function withSaveCredential(bool $save = true): static
+    {
+        $clone = clone $this;
+        $clone->saveCredential = $save;
+
+        return $clone;
+    }
+
+    protected function ensureResponseMatches(AuthenticatorResponse $response): void
+    {
+        $response instanceof AuthenticatorAttestationResponse || throw new BadRequestHttpException(
+            'The response is not an attestation response.'
+        );
+    }
+
+    protected function ensureOptionsMatch(PublicKeyCredentialOptions $options): void
+    {
+        $options instanceof PublicKeyCredentialCreationOptions || throw new BadRequestHttpException(
+            'The stored options are not creation options.'
+        );
+
+        $options->rp->id === $this->rpId || throw new BadRequestHttpException(
+            'The stored options do not match the expected Relying Party identifier.'
+        );
+    }
+
+    protected function runValidation(
+        Request $request,
+        PublicKeyCredential $publicKeyCredential,
+        AuthenticatorResponse $response,
+        PublicKeyCredentialOptions $options,
+        ?PublicKeyCredentialUserEntity $userEntity,
+    ): CredentialRecord {
+        assert($response instanceof AuthenticatorAttestationResponse);
+        assert($options instanceof PublicKeyCredentialCreationOptions);
+
+        $validator = $options->mediation === PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL
+            ? $this->conditionalValidator
+            : $this->validator;
+
+        $credentialRecord = $validator->check($response, $options, $request->getHost());
+
+        if ($this->saveCredential) {
+            $this->persist($credentialRecord);
+        }
+
+        return $credentialRecord;
+    }
+
+    private function persist(CredentialRecord $credentialRecord): void
+    {
+        $this->repository instanceof CanSaveCredentialRecord || throw MissingFeatureException::create(
+            'Unable to save the credential record.'
+        );
+
+        if ($this->repository->findOneByCredentialId($credentialRecord->publicKeyCredentialId) !== null) {
+            throw new BadRequestHttpException('The credential already exists.');
+        }
+
+        $this->repository->saveCredentialRecord($credentialRecord);
+    }
+}

--- a/src/symfony/src/Service/WebauthnResponseVerifier.php
+++ b/src/symfony/src/Service/WebauthnResponseVerifier.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Bundle\Service;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Webauthn\AuthenticatorAssertionResponseValidator;
+use Webauthn\AuthenticatorAttestationResponseValidator;
+use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
+use Webauthn\Bundle\Security\Storage\OptionsStorage;
+
+/**
+ * Single, autowired entry point that produces a fluent
+ * {@see WebauthnAttestationVerifier} or {@see WebauthnAssertionVerifier}
+ * depending on the ceremony.
+ *
+ * Companion of {@see WebauthnOptionsResponse}: where the latter generates and
+ * stores ceremony options, this one consumes the corresponding response from
+ * the JSON request body, runs the validator and returns a typed
+ * {@see WebauthnVerificationResult}. The user controller stays in charge of
+ * the response (login, redirect, Signal API payload, etc.).
+ *
+ * Examples:
+ *
+ *     // Registration
+ *     $result = $this->verifier
+ *         ->forAttestation('example.com')
+ *         ->verify($request);
+ *     // $result->credentialRecord is already persisted
+ *
+ *     // Authentication
+ *     $result = $this->verifier
+ *         ->forAssertion('example.com')
+ *         ->verify($request);
+ *     // $result->credentialRecord has its counter / backup state updated
+ */
+final readonly class WebauthnResponseVerifier
+{
+    public function __construct(
+        private SerializerInterface $serializer,
+        private OptionsStorage $storage,
+        private CredentialRecordRepositoryInterface $repository,
+        private AuthenticatorAttestationResponseValidator $attestationValidator,
+        private AuthenticatorAttestationResponseValidator $conditionalAttestationValidator,
+        private AuthenticatorAssertionResponseValidator $assertionValidator,
+    ) {
+    }
+
+    public function forAttestation(string $rpId): WebauthnAttestationVerifier
+    {
+        return new WebauthnAttestationVerifier(
+            $this->serializer,
+            $this->storage,
+            $this->attestationValidator,
+            $this->conditionalAttestationValidator,
+            $this->repository,
+            $rpId,
+        );
+    }
+
+    public function forAssertion(string $rpId): WebauthnAssertionVerifier
+    {
+        return new WebauthnAssertionVerifier(
+            $this->serializer,
+            $this->storage,
+            $this->assertionValidator,
+            $this->repository,
+            $rpId,
+        );
+    }
+}

--- a/src/symfony/src/Service/WebauthnSignalResponse.php
+++ b/src/symfony/src/Service/WebauthnSignalResponse.php
@@ -52,7 +52,6 @@ final readonly class WebauthnSignalResponse
         $payload['signals'] = array_map(
             fn (Signal $signal): array => [
                 'type' => $this->typeOf($signal),
-                /** @phpstan-ignore-next-line normalize() returns array<string, mixed> for our signal denormalizers. */
                 'options' => $this->normalizer->normalize($signal, 'json', [
                     AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
                 ]),

--- a/src/symfony/src/Service/WebauthnVerificationResult.php
+++ b/src/symfony/src/Service/WebauthnVerificationResult.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Bundle\Service;
+
+use Webauthn\CredentialRecord;
+use Webauthn\PublicKeyCredential;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+/**
+ * Outcome of a successful verification produced by
+ * {@see WebauthnAttestationVerifier::verify()} or
+ * {@see WebauthnAssertionVerifier::verify()}.
+ *
+ * Carries the validated credential record (the only piece a `SuccessHandler`
+ * traditionally received), the deserialized {@see PublicKeyCredential} (useful
+ * for the Signal API and for logging) and the user entity loaded from the
+ * options storage when one was associated with the ceremony.
+ */
+final readonly class WebauthnVerificationResult
+{
+    public function __construct(
+        public CredentialRecord $credentialRecord,
+        public PublicKeyCredential $publicKeyCredential,
+        public ?PublicKeyCredentialUserEntity $userEntity = null,
+    ) {
+    }
+}

--- a/tests/library/Unit/SecurePaymentConfirmation/BrowserBoundSignatureVerifierTest.php
+++ b/tests/library/Unit/SecurePaymentConfirmation/BrowserBoundSignatureVerifierTest.php
@@ -49,8 +49,8 @@ final class BrowserBoundSignatureVerifierTest extends TestCase
             ->add(UnsignedIntegerObject::create(1), UnsignedIntegerObject::create(2))    // kty: EC2
             ->add(UnsignedIntegerObject::create(3), NegativeIntegerObject::create(-7))   // alg: ES256
             ->add(NegativeIntegerObject::create(-1), UnsignedIntegerObject::create(1))   // crv: P-256
-            ->add(NegativeIntegerObject::create(-2), ByteStringObject::create($details['ec']['x']))
-            ->add(NegativeIntegerObject::create(-3), ByteStringObject::create($details['ec']['y']));
+            ->add(NegativeIntegerObject::create(-2), ByteStringObject::create(self::pad32($details['ec']['x'])))
+            ->add(NegativeIntegerObject::create(-3), ByteStringObject::create(self::pad32($details['ec']['y'])));
 
         $verifier = new BrowserBoundSignatureVerifier(Manager::create()->add(ES256::create()));
 
@@ -79,8 +79,8 @@ final class BrowserBoundSignatureVerifierTest extends TestCase
             ->add(UnsignedIntegerObject::create(1), UnsignedIntegerObject::create(2))
             ->add(UnsignedIntegerObject::create(3), NegativeIntegerObject::create(-7))
             ->add(NegativeIntegerObject::create(-1), UnsignedIntegerObject::create(1))
-            ->add(NegativeIntegerObject::create(-2), ByteStringObject::create($details['ec']['x']))
-            ->add(NegativeIntegerObject::create(-3), ByteStringObject::create($details['ec']['y']));
+            ->add(NegativeIntegerObject::create(-2), ByteStringObject::create(self::pad32($details['ec']['x'])))
+            ->add(NegativeIntegerObject::create(-3), ByteStringObject::create(self::pad32($details['ec']['y'])));
 
         $this->expectException(AuthenticatorResponseVerificationException::class);
         $this->expectExceptionMessage('browserBoundSignature verification failed');
@@ -147,5 +147,16 @@ final class BrowserBoundSignatureVerifierTest extends TestCase
         $s = ltrim($s, "\x00");
 
         return str_pad($r, 32, "\x00", STR_PAD_LEFT) . str_pad($s, 32, "\x00", STR_PAD_LEFT);
+    }
+
+    /**
+     * Left-pad a P-256 coordinate to 32 bytes. {@see openssl_pkey_get_details()}
+     * returns `ec.x` / `ec.y` as raw bigint bytes with leading zeros stripped, so
+     * roughly one key out of 256 has a 31-byte coordinate that {@see Ec2Key} then
+     * rejects with "Invalid length for x coordinate".
+     */
+    private static function pad32(string $coordinate): string
+    {
+        return str_pad($coordinate, 32, "\x00", STR_PAD_LEFT);
     }
 }

--- a/tests/symfony/unit/Service/Fixture/InMemoryCredentialRepository.php
+++ b/tests/symfony/unit/Service/Fixture/InMemoryCredentialRepository.php
@@ -8,13 +8,13 @@ use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
 use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredentialUserEntity;
 
-final class InMemoryCredentialRepository implements CredentialRecordRepositoryInterface
+final readonly class InMemoryCredentialRepository implements CredentialRecordRepositoryInterface
 {
     /**
      * @param list<CredentialRecord> $records
      */
     public function __construct(
-        private readonly array $records = [],
+        private array $records = [],
     ) {
     }
 

--- a/tests/symfony/unit/Service/Fixture/SaveableInMemoryCredentialRepository.php
+++ b/tests/symfony/unit/Service/Fixture/SaveableInMemoryCredentialRepository.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Bundle\Unit\Service\Fixture;
+
+use Webauthn\Bundle\Repository\CanSaveCredentialRecord;
+use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
+use Webauthn\CredentialRecord;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+final class SaveableInMemoryCredentialRepository implements CredentialRecordRepositoryInterface, CanSaveCredentialRecord
+{
+    /**
+     * @var array<string, CredentialRecord>
+     */
+    private array $records = [];
+
+    /**
+     * @param list<CredentialRecord> $initialRecords
+     */
+    public function __construct(array $initialRecords = [])
+    {
+        foreach ($initialRecords as $record) {
+            $this->records[$record->publicKeyCredentialId] = $record;
+        }
+    }
+
+    public function findOneByCredentialId(string $publicKeyCredentialId): ?CredentialRecord
+    {
+        return $this->records[$publicKeyCredentialId] ?? null;
+    }
+
+    /**
+     * @return array<CredentialRecord>
+     */
+    public function findAllForUserEntity(PublicKeyCredentialUserEntity $publicKeyCredentialUserEntity): array
+    {
+        return array_values(array_filter(
+            $this->records,
+            static fn (CredentialRecord $record): bool => $record->userHandle === $publicKeyCredentialUserEntity->id,
+        ));
+    }
+
+    public function saveCredentialRecord(CredentialRecord $credentialRecord): void
+    {
+        $this->records[$credentialRecord->publicKeyCredentialId] = $credentialRecord;
+    }
+
+    public function has(string $publicKeyCredentialId): bool
+    {
+        return isset($this->records[$publicKeyCredentialId]);
+    }
+}

--- a/tests/symfony/unit/Service/SignalHelpersTest.php
+++ b/tests/symfony/unit/Service/SignalHelpersTest.php
@@ -64,7 +64,7 @@ final class SignalHelpersTest extends TestCase
         $credential = new PublicKeyCredential(
             PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
             'rawCredentialIdBytes',
-            $this->createMock(AuthenticatorResponse::class),
+            static::createStub(AuthenticatorResponse::class),
         );
         $exception = new WebauthnAuthenticationFailureException(
             'Credential ID is invalid.',

--- a/tests/symfony/unit/Service/WebauthnResponseVerifierTest.php
+++ b/tests/symfony/unit/Service/WebauthnResponseVerifierTest.php
@@ -1,0 +1,451 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Bundle\Unit\Service;
+
+use ParagonIE\ConstantTime\Base64UrlSafe;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Uid\Uuid;
+use Webauthn\AttestationStatement\AttestationObject;
+use Webauthn\AttestationStatement\AttestationStatement;
+use Webauthn\AttestationStatement\AttestationStatementSupportManager;
+use Webauthn\AttestationStatement\NoneAttestationStatementSupport;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\AuthenticatorAssertionResponseValidator;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\AuthenticatorAttestationResponseValidator;
+use Webauthn\AuthenticatorData;
+use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
+use Webauthn\Bundle\Security\Authentication\Exception\WebauthnAuthenticationFailureException;
+use Webauthn\Bundle\Security\Storage\Item;
+use Webauthn\Bundle\Security\Storage\OptionsStorage;
+use Webauthn\Bundle\Service\WebauthnAssertionVerifier;
+use Webauthn\Bundle\Service\WebauthnAttestationVerifier;
+use Webauthn\Bundle\Service\WebauthnResponseVerifier;
+use Webauthn\CollectedClientData;
+use Webauthn\CredentialRecord;
+use Webauthn\Denormalizer\WebauthnSerializerFactory;
+use Webauthn\Exception\AuthenticatorResponseVerificationException;
+use Webauthn\PublicKeyCredential;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialDescriptor;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\PublicKeyCredentialRpEntity;
+use Webauthn\PublicKeyCredentialUserEntity;
+use Webauthn\Tests\Bundle\Unit\Service\Fixture\InMemoryCredentialRepository;
+use Webauthn\Tests\Bundle\Unit\Service\Fixture\InMemoryOptionsStorage;
+use Webauthn\Tests\Bundle\Unit\Service\Fixture\SaveableInMemoryCredentialRepository;
+use Webauthn\TrustPath\EmptyTrustPath;
+
+/**
+ * @internal
+ */
+#[AllowMockObjectsWithoutExpectations]
+final class WebauthnResponseVerifierTest extends TestCase
+{
+    #[Test]
+    public function forAttestationVerifiesAndPersistsTheCredentialRecordByDefault(): void
+    {
+        $rawId = 'cred-id';
+        $publicKeyCredential = $this->fakeAttestationCredential($rawId);
+        $repository = new SaveableInMemoryCredentialRepository();
+        $storage = $this->storageWith($this->creationOptions());
+
+        $standardValidator = $this->createMock(AuthenticatorAttestationResponseValidator::class);
+        $standardValidator->expects(static::once())
+            ->method('check')
+            ->willReturn($this->record($rawId));
+
+        $conditionalValidator = $this->createMock(AuthenticatorAttestationResponseValidator::class);
+        $conditionalValidator->expects(static::never())
+            ->method('check');
+
+        $verifier = $this->verifier(
+            serializer: $this->serializerReturning($publicKeyCredential),
+            storage: $storage,
+            repository: $repository,
+            attestationValidator: $standardValidator,
+            conditionalAttestationValidator: $conditionalValidator,
+        );
+
+        $result = $verifier
+            ->forAttestation('example.com')
+            ->verify($this->jsonRequest());
+
+        static::assertSame($publicKeyCredential, $result->publicKeyCredential);
+        static::assertTrue($repository->has($rawId), 'Credential should be persisted by default.');
+    }
+
+    #[Test]
+    public function forAttestationDelegatesToConditionalValidatorWhenStoredOptionsRequestConditionalMediation(): void
+    {
+        $rawId = 'cred-id';
+        $publicKeyCredential = $this->fakeAttestationCredential($rawId);
+        $repository = new SaveableInMemoryCredentialRepository();
+        $conditionalOptions = $this->creationOptions();
+        $conditionalOptions->mediation = PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL;
+        $storage = $this->storageWith($conditionalOptions);
+
+        $standardValidator = $this->createMock(AuthenticatorAttestationResponseValidator::class);
+        $standardValidator->expects(static::never())->method('check');
+
+        $conditionalValidator = $this->createMock(AuthenticatorAttestationResponseValidator::class);
+        $conditionalValidator->expects(static::once())
+            ->method('check')
+            ->willReturn($this->record($rawId));
+
+        $this->verifier(
+            serializer: $this->serializerReturning($publicKeyCredential),
+            storage: $storage,
+            repository: $repository,
+            attestationValidator: $standardValidator,
+            conditionalAttestationValidator: $conditionalValidator,
+        )
+            ->forAttestation('example.com')
+            ->verify($this->jsonRequest());
+    }
+
+    #[Test]
+    public function forAttestationWithSaveCredentialFalseSkipsPersistence(): void
+    {
+        $rawId = 'cred-id';
+        $repository = new SaveableInMemoryCredentialRepository();
+        $standardValidator = $this->createMock(AuthenticatorAttestationResponseValidator::class);
+        $standardValidator->method('check')
+            ->willReturn($this->record($rawId));
+
+        $this->verifier(
+            serializer: $this->serializerReturning($this->fakeAttestationCredential($rawId)),
+            storage: $this->storageWith($this->creationOptions()),
+            repository: $repository,
+            attestationValidator: $standardValidator,
+        )
+            ->forAttestation('example.com')
+            ->withSaveCredential(false)
+            ->verify($this->jsonRequest());
+
+        static::assertFalse($repository->has($rawId));
+    }
+
+    #[Test]
+    public function forAttestationRejectsDuplicateCredentials(): void
+    {
+        $rawId = 'cred-id';
+        $repository = new SaveableInMemoryCredentialRepository([$this->record($rawId)]);
+        $standardValidator = $this->createMock(AuthenticatorAttestationResponseValidator::class);
+        $standardValidator->method('check')
+            ->willReturn($this->record($rawId));
+
+        $this->expectException(WebauthnAuthenticationFailureException::class);
+
+        $this->verifier(
+            serializer: $this->serializerReturning($this->fakeAttestationCredential($rawId)),
+            storage: $this->storageWith($this->creationOptions()),
+            repository: $repository,
+            attestationValidator: $standardValidator,
+        )
+            ->forAttestation('example.com')
+            ->verify($this->jsonRequest());
+    }
+
+    #[Test]
+    public function forAttestationRejectsNonCreationStoredOptions(): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+
+        $this->verifier(
+            serializer: $this->serializerReturning($this->fakeAttestationCredential('cred-id')),
+            storage: $this->storageWith($this->requestOptions()),
+        )
+            ->forAttestation('example.com')
+            ->verify($this->jsonRequest());
+    }
+
+    #[Test]
+    public function forAttestationRejectsRpIdMismatch(): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+
+        $this->verifier(
+            serializer: $this->serializerReturning($this->fakeAttestationCredential('cred-id')),
+            storage: $this->storageWith($this->creationOptions('other.example.com')),
+        )
+            ->forAttestation('example.com')
+            ->verify($this->jsonRequest());
+    }
+
+    #[Test]
+    public function forAttestationWrapsValidationFailuresInDedicatedException(): void
+    {
+        $standardValidator = $this->createMock(AuthenticatorAttestationResponseValidator::class);
+        $standardValidator->method('check')
+            ->willThrowException(AuthenticatorResponseVerificationException::create('boom'));
+
+        try {
+            $this->verifier(
+                serializer: $this->serializerReturning($this->fakeAttestationCredential('cred-id')),
+                storage: $this->storageWith($this->creationOptions()),
+                attestationValidator: $standardValidator,
+            )
+                ->forAttestation('example.com')
+                ->verify($this->jsonRequest());
+
+            static::fail('Expected ' . WebauthnAuthenticationFailureException::class);
+        } catch (WebauthnAuthenticationFailureException $exception) {
+            static::assertNotNull($exception->publicKeyCredential);
+            static::assertSame('boom', $exception->getPrevious()?->getMessage());
+        }
+    }
+
+    #[Test]
+    public function forAssertionLoadsTheCredentialAndDelegatesToTheValidator(): void
+    {
+        $rawId = 'cred-id';
+        $stored = $this->record($rawId);
+        $repository = new InMemoryCredentialRepository([$stored]);
+
+        $assertionValidator = $this->createMock(AuthenticatorAssertionResponseValidator::class);
+        $assertionValidator->expects(static::once())
+            ->method('check')
+            ->with($stored)
+            ->willReturn($stored);
+
+        $result = $this->verifier(
+            serializer: $this->serializerReturning($this->fakeAssertionCredential($rawId)),
+            storage: $this->storageWith($this->requestOptions()),
+            repository: $repository,
+            assertionValidator: $assertionValidator,
+        )
+            ->forAssertion('example.com')
+            ->verify($this->jsonRequest());
+
+        static::assertSame($stored, $result->credentialRecord);
+    }
+
+    #[Test]
+    public function forAssertionWrapsUnknownCredentialsInDedicatedException(): void
+    {
+        $repository = new InMemoryCredentialRepository();
+
+        try {
+            $this->verifier(
+                serializer: $this->serializerReturning($this->fakeAssertionCredential('cred-id')),
+                storage: $this->storageWith($this->requestOptions()),
+                repository: $repository,
+            )
+                ->forAssertion('example.com')
+                ->verify($this->jsonRequest());
+
+            static::fail('Expected ' . WebauthnAuthenticationFailureException::class);
+        } catch (WebauthnAuthenticationFailureException $exception) {
+            static::assertSame('cred-id', $exception->publicKeyCredential?->rawId);
+        }
+    }
+
+    #[Test]
+    public function forAssertionRejectsNonRequestStoredOptions(): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+
+        $this->verifier(
+            serializer: $this->serializerReturning($this->fakeAssertionCredential('cred-id')),
+            storage: $this->storageWith($this->creationOptions()),
+        )
+            ->forAssertion('example.com')
+            ->verify($this->jsonRequest());
+    }
+
+    #[Test]
+    public function attestationRejectsNonJsonContentType(): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+
+        $this->verifier()
+            ->forAttestation('example.com')
+            ->verify(new Request(content: '{}'));
+    }
+
+    #[Test]
+    public function assertionRejectsNonJsonContentType(): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+
+        $this->verifier()
+            ->forAssertion('example.com')
+            ->verify(new Request(content: '{}'));
+    }
+
+    #[Test]
+    public function attestationRejectsEmptyBody(): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+
+        $this->verifier()
+            ->forAttestation('example.com')
+            ->verify($this->jsonRequest(''));
+    }
+
+    #[Test]
+    public function assertionRejectsEmptyBody(): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+
+        $this->verifier()
+            ->forAssertion('example.com')
+            ->verify($this->jsonRequest(''));
+    }
+
+    #[Test]
+    public function forAttestationReturnsAttestationVerifier(): void
+    {
+        static::assertInstanceOf(
+            WebauthnAttestationVerifier::class,
+            $this->verifier()
+                ->forAttestation('example.com')
+        );
+    }
+
+    #[Test]
+    public function forAssertionReturnsAssertionVerifier(): void
+    {
+        static::assertInstanceOf(WebauthnAssertionVerifier::class, $this->verifier() ->forAssertion('example.com'));
+    }
+
+    private function verifier(
+        ?SerializerInterface $serializer = null,
+        ?OptionsStorage $storage = null,
+        ?CredentialRecordRepositoryInterface $repository = null,
+        ?AuthenticatorAttestationResponseValidator $attestationValidator = null,
+        ?AuthenticatorAttestationResponseValidator $conditionalAttestationValidator = null,
+        ?AuthenticatorAssertionResponseValidator $assertionValidator = null,
+    ): WebauthnResponseVerifier {
+        return new WebauthnResponseVerifier(
+            $serializer ?? $this->realSerializer(),
+            $storage ?? new InMemoryOptionsStorage(),
+            $repository ?? new InMemoryCredentialRepository(),
+            $attestationValidator ?? static::createStub(AuthenticatorAttestationResponseValidator::class),
+            $conditionalAttestationValidator ?? static::createStub(AuthenticatorAttestationResponseValidator::class),
+            $assertionValidator ?? static::createStub(AuthenticatorAssertionResponseValidator::class),
+        );
+    }
+
+    private function realSerializer(): SerializerInterface
+    {
+        $manager = AttestationStatementSupportManager::create();
+        $manager->add(NoneAttestationStatementSupport::create());
+
+        return (new WebauthnSerializerFactory($manager))->create();
+    }
+
+    private function serializerReturning(PublicKeyCredential $credential): SerializerInterface
+    {
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->method('deserialize')
+            ->willReturn($credential);
+
+        return $serializer;
+    }
+
+    private function jsonRequest(string $content = '{"foo":"bar"}'): Request
+    {
+        return new Request(content: $content, server: [
+            'CONTENT_TYPE' => 'application/json',
+        ]);
+    }
+
+    private function storageWith(
+        PublicKeyCredentialCreationOptions|PublicKeyCredentialRequestOptions $options,
+        ?PublicKeyCredentialUserEntity $user = null,
+    ): OptionsStorage {
+        $storage = new InMemoryOptionsStorage();
+        $storage->store(Item::create($options, $user));
+
+        return $storage;
+    }
+
+    private function creationOptions(string $rpId = 'example.com'): PublicKeyCredentialCreationOptions
+    {
+        return PublicKeyCredentialCreationOptions::create(
+            rp: PublicKeyCredentialRpEntity::create('', $rpId),
+            user: PublicKeyCredentialUserEntity::create('alice', 'user-handle', 'Alice'),
+            challenge: random_bytes(32),
+        );
+    }
+
+    private function requestOptions(string $rpId = 'example.com'): PublicKeyCredentialRequestOptions
+    {
+        return PublicKeyCredentialRequestOptions::create(challenge: random_bytes(32), rpId: $rpId);
+    }
+
+    private function fakeAttestationCredential(string $rawId): PublicKeyCredential
+    {
+        $challenge = Base64UrlSafe::encodeUnpadded(random_bytes(32));
+        $clientData = new CollectedClientData(json_encode([
+            'type' => 'webauthn.create',
+            'challenge' => $challenge,
+            'origin' => 'https://example.com',
+        ]) ?: '', [
+            'type' => 'webauthn.create',
+            'challenge' => $challenge,
+            'origin' => 'https://example.com',
+        ]);
+        $response = new AuthenticatorAttestationResponse(
+            $clientData,
+            static::createStub(AttestationObject::class),
+            [],
+        );
+
+        return new PublicKeyCredential(
+            type: PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
+            rawId: $rawId,
+            response: $response,
+        );
+    }
+
+    private function fakeAssertionCredential(string $rawId): PublicKeyCredential
+    {
+        $challenge = Base64UrlSafe::encodeUnpadded(random_bytes(32));
+        $clientData = new CollectedClientData(json_encode([
+            'type' => 'webauthn.get',
+            'challenge' => $challenge,
+            'origin' => 'https://example.com',
+        ]) ?: '', [
+            'type' => 'webauthn.get',
+            'challenge' => $challenge,
+            'origin' => 'https://example.com',
+        ]);
+        $response = new AuthenticatorAssertionResponse(
+            $clientData,
+            static::createStub(AuthenticatorData::class),
+            'signature',
+            null,
+        );
+
+        return new PublicKeyCredential(
+            type: PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
+            rawId: $rawId,
+            response: $response,
+        );
+    }
+
+    private function record(string $credentialId): CredentialRecord
+    {
+        return new CredentialRecord(
+            publicKeyCredentialId: $credentialId,
+            type: PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
+            transports: [],
+            attestationType: AttestationStatement::TYPE_NONE,
+            trustPath: EmptyTrustPath::create(),
+            aaguid: Uuid::fromBinary(str_repeat("\0", 16)),
+            credentialPublicKey: 'pub-key',
+            userHandle: 'user-handle',
+            counter: 0,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Companion of #876 (`WebauthnOptionsResponse`) for the response side. Adds a single autowired entry point (`WebauthnResponseVerifier`) so applications can write their own response controllers without touching `creation_profiles` / `request_profiles` config or the bundle's profile-driven `AttestationResponseController` / `AssertionResponseController`.

```php
$result = $this->verifier
    ->forAttestation('example.com')
    ->verify($request);
// $result->credentialRecord is already persisted
// $result->publicKeyCredential is the deserialised body (useful for Signal API)
// $result->userEntity is the user loaded from OptionsStorage

$result = $this->verifier
    ->forAssertion('example.com')
    ->verify($request);
// $result->credentialRecord has its counter / backup state updated
```

## Design

- **Two typed verifiers**: `WebauthnAttestationVerifier` and `WebauthnAssertionVerifier` (returned by the entry-point factories) so IDE autocomplete only proposes the methods relevant to each ceremony.
- **Auto-persist on attestation**: the new credential record is saved through `CanSaveCredentialRecord` by default. Opt out with `withSaveCredential(false)` if your controller wants to own persistence (transactions, extra fields, etc.).
- **Auto conditional mediation**: when stored creation options carry `mediation: conditional`, the verifier transparently switches to the *conditional creation* ceremony manager (relaxes UV per the W3C spec). One call site, both flows.
- **Failure split**:
  - `BadRequestHttpException` for malformed inputs (wrong content type, empty body, deserialisation failure, unknown challenge, response/options type mismatch, RP ID mismatch). Symfony's HTTP layer turns these into HTTP 400 automatically.
  - `WebauthnAuthenticationFailureException` for ceremony validation failures, carrying the deserialised `PublicKeyCredential`, the underlying `AuthenticatorResponse`, the `PublicKeyCredentialOptions` and the user entity. Lets controllers build Signal API payloads (`signalUnknownCredential`, etc.) from a single exception.

## What's new

- `Webauthn\Bundle\Service\AbstractWebauthnVerifier` (template method: deserialise body, load stored options, delegate validation)
- `Webauthn\Bundle\Service\WebauthnAttestationVerifier`
- `Webauthn\Bundle\Service\WebauthnAssertionVerifier`
- `Webauthn\Bundle\Service\WebauthnResponseVerifier` (autowired entry point)
- `Webauthn\Bundle\Service\WebauthnVerificationResult` (typed return value)
- 16 unit tests + reusable `SaveableInMemoryCredentialRepository` fixture

## Drive-by

- Drop a stale `@phpstan-ignore-next-line` in `WebauthnSignalResponse` that no longer matched on PHP 8.4.
- Regenerate the PHPStan baseline against PHP 8.4 (the version CI runs).

## Notes

The existing profile-driven controllers stay untouched and supported until 6.0; this is a strictly additive, opt-in API. Documentation PR is web-auth/doc#TBD (will link once opened).