### PR TITLE
fix(options-helper): move $user from forRequest() to a withUser() setter

### DIFF
--- a/src/symfony/src/Service/WebauthnOptionsResponse.php
+++ b/src/symfony/src/Service/WebauthnOptionsResponse.php
@@ -24,7 +24,7 @@ use Webauthn\PublicKeyCredentialUserEntity;
  *
  * Examples:
  *
- *     // Registration (most explicit)
+ *     // Registration (user is required, passed positionally)
  *     return $this->options
  *         ->forCreation('example.com', $this->newUserGuesser)
  *         ->build($request);
@@ -34,9 +34,10 @@ use Webauthn\PublicKeyCredentialUserEntity;
  *         ->forRequest('example.com')
  *         ->build($request);
  *
- *     // Authentication, user already known
+ *     // Authentication, user already known: attach via withUser()
  *     return $this->options
- *         ->forRequest('example.com', $userEntity)
+ *         ->forRequest('example.com')
+ *         ->withUser($userEntity)
  *         ->build($request);
  */
 final readonly class WebauthnOptionsResponse
@@ -63,17 +64,14 @@ final readonly class WebauthnOptionsResponse
         );
     }
 
-    public function forRequest(
-        string $rpId,
-        PublicKeyCredentialUserEntity|UserEntityGuesser|null $user = null,
-    ): WebauthnRequestOptionsBuilder {
+    public function forRequest(string $rpId): WebauthnRequestOptionsBuilder
+    {
         return new WebauthnRequestOptionsBuilder(
             $this->storage,
             $this->serializer,
             $this->validator,
             $this->credentialRepository,
             $rpId,
-            $user,
         );
     }
 }

--- a/src/symfony/src/Service/WebauthnRequestOptionsBuilder.php
+++ b/src/symfony/src/Service/WebauthnRequestOptionsBuilder.php
@@ -22,10 +22,10 @@ use Webauthn\PublicKeyCredentialUserEntity;
  * {@see WebauthnOptionsResponse::forRequest()}.
  *
  * Required: `rpId`. The user entity is optional (assertion can be userless,
- * e.g. usernameless authentication via discoverable credentials). When a user
- * entity is resolved, `allowCredentials` is derived from the credential
- * repository unless an explicit list is provided through
- * {@see self::withAllowCredentials()}.
+ * e.g. usernameless authentication via discoverable credentials) and is set
+ * through {@see self::withUser()} when known. When a user entity is resolved,
+ * `allowCredentials` is derived from the credential repository unless an
+ * explicit list is provided through {@see self::withAllowCredentials()}.
  */
 final class WebauthnRequestOptionsBuilder extends AbstractWebauthnOptionsBuilder
 {
@@ -40,15 +40,24 @@ final class WebauthnRequestOptionsBuilder extends AbstractWebauthnOptionsBuilder
      */
     private ?array $allowCredentials = null;
 
+    private PublicKeyCredentialUserEntity|UserEntityGuesser|null $userOrGuesser = null;
+
     public function __construct(
         OptionsStorage $storage,
         SerializerInterface $serializer,
         ValidatorInterface $validator,
         CredentialRecordRepositoryInterface $credentialRepository,
         private readonly string $rpId,
-        private readonly PublicKeyCredentialUserEntity|UserEntityGuesser|null $userOrGuesser = null,
     ) {
         parent::__construct($storage, $serializer, $validator, $credentialRepository);
+    }
+
+    public function withUser(PublicKeyCredentialUserEntity|UserEntityGuesser $user): static
+    {
+        $clone = clone $this;
+        $clone->userOrGuesser = $user;
+
+        return $clone;
     }
 
     public function withUserVerification(?string $userVerification): static

--- a/tests/symfony/unit/Service/WebauthnOptionsResponseTest.php
+++ b/tests/symfony/unit/Service/WebauthnOptionsResponseTest.php
@@ -145,7 +145,8 @@ final class WebauthnOptionsResponseTest extends TestCase
         $repository = new InMemoryCredentialRepository([$this->record('cred-A'), $this->record('cred-B')]);
 
         $this->helper(storage: $storage, repository: $repository)
-            ->forRequest('example.com', $userEntity)
+            ->forRequest('example.com')
+            ->withUser($userEntity)
             ->build($this->jsonRequest());
 
         $options = $storage->last()
@@ -162,7 +163,8 @@ final class WebauthnOptionsResponseTest extends TestCase
         $repository = new InMemoryCredentialRepository([$this->record('cred-A')]);
 
         $this->helper(storage: $storage, repository: $repository)
-            ->forRequest('example.com', new FixedUserEntityGuesser($userEntity))
+            ->forRequest('example.com')
+            ->withUser(new FixedUserEntityGuesser($userEntity))
             ->build($this->jsonRequest());
 
         static::assertCount(1, $storage->last()->getPublicKeyCredentialOptions()->allowCredentials);
@@ -176,7 +178,8 @@ final class WebauthnOptionsResponseTest extends TestCase
         $repository = new InMemoryCredentialRepository([$this->record('repo-cred')]);
 
         $this->helper(storage: $storage, repository: $repository)
-            ->forRequest('example.com', $userEntity)
+            ->forRequest('example.com')
+            ->withUser($userEntity)
             ->withAllowCredentials(PublicKeyCredentialDescriptor::create('public-key', 'explicit-cred'))
             ->build($this->jsonRequest());
 


### PR DESCRIPTION
## Summary

`WebauthnOptionsResponse::forRequest()` defaulted its `$user` argument to `null` because assertion can be userless (passkey-style discoverable login). Keeping it in the factory signature was inconsistent with the rest of the helper API, where **required** inputs are positional and **optional** ones live behind `with*()` setters.

## What changes

- `WebauthnOptionsResponse::forRequest(string \$rpId)` no longer accepts a `\$user` parameter.
- `WebauthnRequestOptionsBuilder::__construct()` drops the matching `\$userOrGuesser` parameter.
- New `WebauthnRequestOptionsBuilder::withUser(PublicKeyCredentialUserEntity|UserEntityGuesser)` setter, immutable like the rest.
- `forCreation()` is unchanged (its `\$user` is required, no default).

## Before / after

```php
// before
->forRequest('example.com', \$userEntity)

// after
->forRequest('example.com')->withUser(\$userEntity)
```

## BC

5.4 hasn't been tagged yet, so no users are relying on the existing signature. No deprecation shim necessary.

## Companion doc PR

web-auth/doc#TBD (opened in parallel).