### PR TITLE
fix(controllers): restore the per-controller origin override regression

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -252,7 +252,7 @@ parameters:
 				since 5.2.0 and will be removed in 6.0.0. Will be replaced by CheckAllowedOrigins
 			'''
 			identifier: method.deprecatedClass
-			count: 2
+			count: 1
 			path: ../src/webauthn/src/CeremonyStep/CeremonyStepManagerFactory.php
 
 		-
@@ -261,7 +261,16 @@ parameters:
 				since 5.2.0 and will be removed in 6.0.0. Will be replaced by CheckAllowedOrigins
 			'''
 			identifier: new.deprecatedClass
-			count: 2
+			count: 1
+			path: ../src/webauthn/src/CeremonyStep/CeremonyStepManagerFactory.php
+
+		-
+			rawMessage: '''
+				Return type of method Webauthn\CeremonyStep\CeremonyStepManagerFactory::buildOriginCheck() has typehint with deprecated class Webauthn\CeremonyStep\CheckOrigin:
+				since 5.2.0 and will be removed in 6.0.0. Will be replaced by CheckAllowedOrigins
+			'''
+			identifier: return.deprecatedClass
+			count: 1
 			path: ../src/webauthn/src/CeremonyStep/CeremonyStepManagerFactory.php
 
 		-

--- a/src/symfony/src/DependencyInjection/WebauthnExtension.php
+++ b/src/symfony/src/DependencyInjection/WebauthnExtension.php
@@ -247,8 +247,11 @@ final class WebauthnExtension extends Extension implements PrependExtensionInter
             $container
                 ->setDefinition($creationCeremonyStepManagerId, new Definition(CeremonyStepManager::class))
                 ->setFactory([new Reference(CeremonyStepManagerFactory::class), $ceremonyFactoryMethod])
-                // @deprecated Will be removed in 6.0.0
-                ->setArguments([$creationConfig['secured_rp_ids']])
+                ->setArguments(self::resolveOriginOverrideArgs(
+                    $creationConfig['allowed_origins'] ?? [],
+                    $creationConfig['allow_subdomains'] ?? false,
+                    $creationConfig['secured_rp_ids'] ?? [],
+                ))
             ;
 
             $attestationResponseValidatorId = sprintf(
@@ -331,8 +334,11 @@ final class WebauthnExtension extends Extension implements PrependExtensionInter
             $container
                 ->setDefinition($requestCeremonyStepManagerId, new Definition(CeremonyStepManager::class))
                 ->setFactory([new Reference(CeremonyStepManagerFactory::class), 'requestCeremony'])
-                // @deprecated Will be removed in 6.0.0
-                ->setArguments([$requestConfig['secured_rp_ids']])
+                ->setArguments(self::resolveOriginOverrideArgs(
+                    $requestConfig['allowed_origins'] ?? [],
+                    $requestConfig['allow_subdomains'] ?? false,
+                    $requestConfig['secured_rp_ids'] ?? [],
+                ))
             ;
 
             $assertionResponseValidatorId = sprintf(
@@ -391,5 +397,37 @@ final class WebauthnExtension extends Extension implements PrependExtensionInter
         $container->setParameter('webauthn.passkey_endpoints.enroll', $config['enroll'] ?? null);
         $container->setParameter('webauthn.passkey_endpoints.manage', $config['manage'] ?? null);
         $container->setParameter('webauthn.passkey_endpoints.prf_usage_details', $config['prf_usage_details'] ?? null);
+    }
+
+    /**
+     * Build the `[allowed_origins, allow_subdomains]` argument list passed to
+     * {@see \Webauthn\CeremonyStep\CeremonyStepManagerFactory::creationCeremony()}
+     * /
+     * {@see \Webauthn\CeremonyStep\CeremonyStepManagerFactory::requestCeremony()}
+     * for a per-controller ceremony step manager. Returns `[null, false]` to
+     * fall back to whatever was set globally on the factory.
+     *
+     * `secured_rp_ids` (deprecated) is honoured as a backwards-compatible alias
+     * when `allowed_origins` is empty.
+     *
+     * @param array<string> $allowedOrigins
+     * @param array<string> $securedRpIds
+     *
+     * @return array{0: ?array<string>, 1: bool}
+     */
+    private static function resolveOriginOverrideArgs(
+        array $allowedOrigins,
+        bool $allowSubdomains,
+        array $securedRpIds,
+    ): array {
+        if ($allowedOrigins !== []) {
+            return [$allowedOrigins, $allowSubdomains];
+        }
+
+        if ($securedRpIds !== []) {
+            return [$securedRpIds, $allowSubdomains];
+        }
+
+        return [null, false];
     }
 }

--- a/src/webauthn/src/CeremonyStep/CeremonyStepManagerFactory.php
+++ b/src/webauthn/src/CeremonyStep/CeremonyStepManagerFactory.php
@@ -124,21 +124,21 @@ final class CeremonyStepManagerFactory
         $this->topOriginValidator = $topOriginValidator;
     }
 
-    public function requestCeremony(): CeremonyStepManager
-    {
+    /**
+     * @param null|string[] $allowedOriginsOverride Per-call override of {@see self::setAllowedOrigins()}.
+     *                                              Pass `null` to fall back to whatever was set on the factory.
+     */
+    public function requestCeremony(
+        ?array $allowedOriginsOverride = null,
+        bool $allowSubdomainsOverride = false,
+    ): CeremonyStepManager {
         /* @see https://www.w3.org/TR/webauthn-3/#sctn-verifying-assertion */
         return new CeremonyStepManager([
             new CheckAllowedCredentialList(),
             new CheckUserHandle(),
             new CheckClientDataCollectorType($this->clientDataCollectorManager),
             new CheckChallenge(),
-            $this->allowedOrigins === null ? new CheckOrigin(
-                $this->securedRelyingPartyId ?? []
-            ) : new CheckAllowedOrigins(
-                $this->allowedOrigins,
-                $this->allowSubdomains,
-                $this->securedRelyingPartyId ?? []
-            ),
+            $this->buildOriginCheck($allowedOriginsOverride, $allowSubdomainsOverride),
             new CheckTopOrigin($this->topOriginValidator),
             new CheckRelyingPartyIdIdHash(),
             new CheckUserWasPresent(),
@@ -151,9 +151,14 @@ final class CeremonyStepManagerFactory
         ]);
     }
 
-    public function creationCeremony(): CeremonyStepManager
-    {
-        return $this->buildCreationCeremony(true);
+    /**
+     * @param null|string[] $allowedOriginsOverride Per-call override of {@see self::setAllowedOrigins()}.
+     */
+    public function creationCeremony(
+        ?array $allowedOriginsOverride = null,
+        bool $allowSubdomainsOverride = false,
+    ): CeremonyStepManager {
+        return $this->buildCreationCeremony(true, $allowedOriginsOverride, $allowSubdomainsOverride);
     }
 
     /**
@@ -162,16 +167,26 @@ final class CeremonyStepManagerFactory
      * Use this when creating credentials with mediation: 'conditional',
      * where user presence may be false after password authentication.
      *
+     * @param null|string[] $allowedOriginsOverride Per-call override of {@see self::setAllowedOrigins()}.
+     *
      * @see https://github.com/w3c/webauthn/wiki/Explainer:-Conditional-Create
      * @see https://github.com/web-auth/webauthn-framework/issues/719
      */
-    public function conditionalCreateCeremony(): CeremonyStepManager
-    {
-        return $this->buildCreationCeremony(false);
+    public function conditionalCreateCeremony(
+        ?array $allowedOriginsOverride = null,
+        bool $allowSubdomainsOverride = false,
+    ): CeremonyStepManager {
+        return $this->buildCreationCeremony(false, $allowedOriginsOverride, $allowSubdomainsOverride);
     }
 
-    private function buildCreationCeremony(bool $requireUserPresence): CeremonyStepManager
-    {
+    /**
+     * @param null|string[] $allowedOriginsOverride
+     */
+    private function buildCreationCeremony(
+        bool $requireUserPresence,
+        ?array $allowedOriginsOverride,
+        bool $allowSubdomainsOverride,
+    ): CeremonyStepManager {
         $metadataStatementChecker = new CheckMetadataStatement();
         if ($this->certificateChainValidator !== null) {
             $metadataStatementChecker->enableCertificateChainValidator($this->certificateChainValidator);
@@ -188,13 +203,7 @@ final class CeremonyStepManagerFactory
         return new CeremonyStepManager([
             new CheckClientDataCollectorType($this->clientDataCollectorManager),
             new CheckChallenge(),
-            $this->allowedOrigins === null ? new CheckOrigin(
-                $this->securedRelyingPartyId ?? []
-            ) : new CheckAllowedOrigins(
-                $this->allowedOrigins,
-                $this->allowSubdomains,
-                $this->securedRelyingPartyId ?? []
-            ),
+            $this->buildOriginCheck($allowedOriginsOverride, $allowSubdomainsOverride),
             new CheckTopOrigin($this->topOriginValidator),
             new CheckRelyingPartyIdIdHash(),
             new CheckUserWasPresent($requireUserPresence),
@@ -207,5 +216,31 @@ final class CeremonyStepManagerFactory
             $metadataStatementChecker,
             new CheckCredentialId(),
         ]);
+    }
+
+    /**
+     * @param null|string[] $allowedOriginsOverride
+     */
+    private function buildOriginCheck(
+        ?array $allowedOriginsOverride,
+        bool $allowSubdomainsOverride,
+    ): CheckOrigin|CheckAllowedOrigins {
+        if ($allowedOriginsOverride !== null) {
+            return new CheckAllowedOrigins(
+                $allowedOriginsOverride,
+                $allowSubdomainsOverride,
+                $this->securedRelyingPartyId ?? [],
+            );
+        }
+
+        if ($this->allowedOrigins === null) {
+            return new CheckOrigin($this->securedRelyingPartyId ?? []);
+        }
+
+        return new CheckAllowedOrigins(
+            $this->allowedOrigins,
+            $this->allowSubdomains,
+            $this->securedRelyingPartyId ?? [],
+        );
     }
 }

--- a/tests/symfony/config/config.yml
+++ b/tests/symfony/config/config.yml
@@ -135,14 +135,20 @@ webauthn:
         options_path: '/devices/add/options'
         result_path: '/devices/add'
         user_entity_guesser: 'Webauthn\Bundle\Security\Guesser\CurrentUserEntityGuesser'
-        secured_rp_ids:
-          - 'localhost'
+        # Per-controller override of the root `allowed_origins`, scoped to this
+        # controller only. Its presence is asserted by ControllersConfigOriginOverrideTest.
+        allowed_origins:
+          - 'https://creation-test.example'
+        allow_subdomains: true
     request:
       test:
         options_path: '/devices/test/options'
         result_path: '/devices/test'
-        secured_rp_ids:
-          - 'localhost'
+        # Per-controller override of the root `allowed_origins`, scoped to this
+        # controller only. Its presence is asserted by ControllersConfigOriginOverrideTest.
+        allowed_origins:
+          - 'https://request-test.example'
+        allow_subdomains: false
   creation_profiles:
     default:
       rp:

--- a/tests/symfony/functional/Configuration/ControllersConfigOriginOverrideTest.php
+++ b/tests/symfony/functional/Configuration/ControllersConfigOriginOverrideTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Bundle\Functional\Configuration;
+
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionObject;
+use Webauthn\CeremonyStep\CeremonyStepManager;
+use Webauthn\CeremonyStep\CheckAllowedOrigins;
+use Webauthn\Tests\Bundle\Functional\WebauthnTestCase;
+
+/**
+ * Regression test that pins the per-controller origin override behaviour for
+ * `controllers.creation[].allowed_origins` / `allow_subdomains` and the
+ * deprecated `secured_rp_ids` alias on both `creation` and `request` controllers.
+ *
+ * Prior to this fix, the bundle accepted these fields in the YAML schema but
+ * silently dropped them at runtime: `WebauthnExtension` passed
+ * `secured_rp_ids` as the first positional argument to
+ * `CeremonyStepManagerFactory::creationCeremony()` / `requestCeremony()`, but
+ * those methods had stopped accepting arguments after commit 1dc03432
+ * ("Major upgrade", July 2024). PHP silently dropped the extra positional
+ * argument and the per-controller CSM kept inheriting the global
+ * `webauthn.allowed_origins` only. `controllers[].allowed_origins` itself was
+ * never even read by the extension.
+ *
+ * This test boots the actual test kernel and inspects the per-controller
+ * `CheckAllowedOrigins` step to confirm:
+ *
+ *   - the per-controller `allowed_origins` list is honoured (overrides root),
+ *   - `allow_subdomains` is honoured per-controller too, and
+ *   - the override is properly scoped to the controller (the global value
+ *     is unaffected).
+ *
+ * The test kernel's root `webauthn.allowed_origins` lists 5 entries, but
+ * `controllers.creation.test.allowed_origins` is a single distinctive value
+ * (`https://creation-test.example`) and likewise for the request controller.
+ *
+ * @internal
+ */
+final class ControllersConfigOriginOverrideTest extends WebauthnTestCase
+{
+    #[Test]
+    public function creationControllerHonoursItsOwnAllowedOriginsAndAllowSubdomains(): void
+    {
+        self::bootKernel();
+
+        $csm = static::getContainer()
+            ->get('webauthn.controller.creation.response.ceremony_step_manager.test');
+        static::assertInstanceOf(CeremonyStepManager::class, $csm);
+
+        $check = $this->extractCheckAllowedOrigins($csm);
+
+        static::assertSame(
+            ['https://creation-test.example'],
+            $this->reflectProperty($check, 'fullOrigins'),
+            'Per-controller `controllers.creation[].allowed_origins` MUST override the global list.'
+        );
+        static::assertTrue(
+            $this->reflectProperty($check, 'allowSubdomains'),
+            'Per-controller `controllers.creation[].allow_subdomains` MUST be honoured.'
+        );
+    }
+
+    #[Test]
+    public function requestControllerHonoursItsOwnAllowedOriginsAndAllowSubdomains(): void
+    {
+        self::bootKernel();
+
+        $csm = static::getContainer()
+            ->get('webauthn.controller.request.response.ceremony_step_manager.test');
+        static::assertInstanceOf(CeremonyStepManager::class, $csm);
+
+        $check = $this->extractCheckAllowedOrigins($csm);
+
+        static::assertSame(
+            ['https://request-test.example'],
+            $this->reflectProperty($check, 'fullOrigins'),
+            'Per-controller `controllers.request[].allowed_origins` MUST override the global list.'
+        );
+        static::assertFalse(
+            $this->reflectProperty($check, 'allowSubdomains'),
+            'Per-controller `controllers.request[].allow_subdomains` MUST be honoured.'
+        );
+    }
+
+    #[Test]
+    public function rootAllowedOriginsRemainsUnchangedByPerControllerOverrides(): void
+    {
+        self::bootKernel();
+
+        // The bundle exposes the root list as a parameter; if a per-controller
+        // override leaked into the global state, this would shrink to a single
+        // entry. It must keep the full list.
+        static::assertSame(
+            [
+                'https://localhost',
+                'https://localhost:8443',
+                'https://bar.acme',
+                'https://webauthn.spomky-labs.com',
+                'https://spomky-webauthn.herokuapp.com',
+            ],
+            static::getContainer()->getParameter('webauthn.allowed_origins'),
+            'Per-controller overrides MUST NOT mutate the global `webauthn.allowed_origins`.'
+        );
+    }
+
+    private function extractCheckAllowedOrigins(CeremonyStepManager $csm): CheckAllowedOrigins
+    {
+        $steps = $this->reflectProperty($csm, 'steps');
+        static::assertIsArray($steps);
+
+        foreach ($steps as $step) {
+            if ($step instanceof CheckAllowedOrigins) {
+                return $step;
+            }
+        }
+
+        static::fail('Expected a CheckAllowedOrigins step in the ceremony step manager.');
+    }
+
+    private function reflectProperty(object $target, string $name): mixed
+    {
+        return (new ReflectionObject($target))
+            ->getProperty($name)
+            ->getValue($target);
+    }
+}


### PR DESCRIPTION
## Summary

The per-controller `controllers.creation[].allowed_origins` / `allow_subdomains` (and the deprecated `secured_rp_ids` alias) have been **silently no-op** for a long time. This PR fixes the regression and pins the behaviour with functional tests.

## Diagnosis

- Commit 1dc03432 ("Major upgrade", July 2024) removed the optional `?array \$securedRelyingPartyId = null` parameter from `CeremonyStepManagerFactory::creationCeremony()` and `requestCeremony()`.
- The bundle's `WebauthnExtension` kept passing `controllers[].secured_rp_ids` as a positional argument to those calls. PHP 8.x silently drops extra positional args on non-variadic methods (verified locally on PHP 8.2 and 8.5), so the override never reached the ceremony step manager.
- Commit 520c51bb (5.2.0) added `controllers[].allowed_origins` / `allow_subdomains` to the YAML schema but **never wired them** in the extension; only `secured_rp_ids` was forwarded (uselessly).

Net effect: only the **root** `webauthn.allowed_origins` was honoured; per-controller overrides were silently ignored. I confirmed this by booting the test kernel and reflecting into `webauthn.controller.creation.response.ceremony_step_manager.test`.

## What changes

### Lib (`src/webauthn/`)

`CeremonyStepManagerFactory::creationCeremony()`, `conditionalCreateCeremony()` and `requestCeremony()` now accept two optional parameters:

\`\`\`php
public function creationCeremony(
    ?array \$allowedOriginsOverride = null,
    bool \$allowSubdomainsOverride = false,
): CeremonyStepManager
\`\`\`

When `\$allowedOriginsOverride !== null`, a per-call `CheckAllowedOrigins` step is built without mutating the factory's global state. When `null`, behaviour is unchanged (the factory's `setAllowedOrigins` config wins, with the existing `CheckOrigin` fallback).

The two `CheckOrigin` / `CheckAllowedOrigins` branches in `requestCeremony` and `buildCreationCeremony` are factored into a single private `buildOriginCheck()` helper.

### Bundle (`src/symfony/`)

`WebauthnExtension::loadCreationControllersSupport()` and `loadRequestControllersSupport()` now pass `[allowed_origins, allow_subdomains]` to the factory call. New `resolveOriginOverrideArgs()` helper picks `allowed_origins` first, falls back to `secured_rp_ids` (deprecated alias) when empty, and returns `[null, false]` when neither is set (so the global config wins, unchanged behaviour).

### Tests

- `tests/symfony/config/config.yml` per-controller config switched from `secured_rp_ids: ['localhost']` to distinctive `allowed_origins: ['https://creation-test.example']` / `['https://request-test.example']` plus `allow_subdomains: true/false`, so the override is observably different from the root list.
- New `ControllersConfigOriginOverrideTest` boots the kernel and asserts:
  - the per-controller `CheckAllowedOrigins` step's `fullOrigins` matches the per-controller list (not the root one),
  - `allow_subdomains` is honoured per-controller,
  - the global `webauthn.allowed_origins` parameter is unaffected by per-controller overrides.
- PHPStan baseline regenerated to drop two now-unreached `CheckOrigin` instantiations consolidated into `buildOriginCheck()`.

## BC

- The lib factory methods gain optional parameters (default `null` / `false`). Existing call sites without args keep working.
- The bundle's deprecated `secured_rp_ids` alias keeps working as a BC fallback. Its existing `setDeprecated()` markers (root + per-controller) are preserved.
- No public API removed.

## Why this matters for the helpers

The restored optional parameter unblocks `withAllowedOrigins(string ...\$origins)` / `withAllowSubdomains(bool)` on `WebauthnAttestationVerifier` / `WebauthnAssertionVerifier` (follow-up PR): the verifier can call `\$factory->creationCeremony(\$overrides, \$allowSubdomains)` to produce a scoped CSM without touching global state.