### PR TITLE
feat(helpers): per-verifier origin override + anti-enumeration faker

### DIFF
--- a/src/symfony/src/Service/AbstractWebauthnOptionsBuilder.php
+++ b/src/symfony/src/Service/AbstractWebauthnOptionsBuilder.php
@@ -122,7 +122,7 @@ abstract class AbstractWebauthnOptionsBuilder
     public function build(Request $request): JsonResponse
     {
         $userEntity = $this->resolveUserEntity($request);
-        $optionsRequest = $this->clientOverridePolicy !== null ? $this->parseClientRequest($request) : null;
+        $optionsRequest = $this->shouldParseClientRequest() ? $this->parseClientRequest($request) : null;
         $options = $this->assembleOptions($request, $userEntity, $optionsRequest);
 
         $this->storage->store(Item::create($options, $userEntity));
@@ -133,6 +133,18 @@ abstract class AbstractWebauthnOptionsBuilder
             ]),
             json: true,
         );
+    }
+
+    /**
+     * Hook used by {@see self::build()} to decide whether the request body is
+     * worth parsing into the ceremony-specific DTO. Returns `true` when a
+     * client override policy is attached; subclasses can override to opt in
+     * for additional reasons (e.g. anti-enumeration via a fake credential
+     * generator on the request side).
+     */
+    protected function shouldParseClientRequest(): bool
+    {
+        return $this->clientOverridePolicy !== null;
     }
 
     abstract protected function resolveUserEntity(Request $request): ?PublicKeyCredentialUserEntity;

--- a/src/symfony/src/Service/AbstractWebauthnVerifier.php
+++ b/src/symfony/src/Service/AbstractWebauthnVerifier.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\Service;
 
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -12,6 +15,9 @@ use Webauthn\AuthenticatorResponse;
 use Webauthn\Bundle\Security\Authentication\Exception\WebauthnAuthenticationFailureException;
 use Webauthn\Bundle\Security\Storage\OptionsStorage;
 use Webauthn\CredentialRecord;
+use Webauthn\Event\CanDispatchEvents;
+use Webauthn\Event\NullEventDispatcher;
+use Webauthn\MetadataService\CanLogData;
 use Webauthn\PublicKeyCredential;
 use Webauthn\PublicKeyCredentialOptions;
 use Webauthn\PublicKeyCredentialUserEntity;
@@ -30,13 +36,65 @@ use Webauthn\PublicKeyCredentialUserEntity;
  * {@see WebauthnAuthenticationFailureException} so the controller can build a
  * contextual response (e.g. a Signal API payload to drop a stale credential
  * from the platform UI).
+ *
+ * Implements {@see CanLogData} and {@see CanDispatchEvents} so the bundle's
+ * autoconfiguration tags propagate the configured logger and event dispatcher
+ * here. Both are forwarded to any one-off validator the verifier may
+ * instantiate when {@see self::withAllowedOrigins()} is set.
  */
-abstract class AbstractWebauthnVerifier
+abstract class AbstractWebauthnVerifier implements CanLogData, CanDispatchEvents
 {
+    /**
+     * @var list<string>|null
+     */
+    protected ?array $allowedOriginsOverride = null;
+
+    protected bool $allowSubdomainsOverride = false;
+
+    protected LoggerInterface $logger;
+
+    protected EventDispatcherInterface $eventDispatcher;
+
     public function __construct(
         protected readonly SerializerInterface $serializer,
         protected readonly OptionsStorage $storage,
     ) {
+        $this->logger = new NullLogger();
+        $this->eventDispatcher = new NullEventDispatcher();
+    }
+
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+    }
+
+    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher): void
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * Override the set of accepted origins for this single verification.
+     * Equivalent to the global `webauthn.allowed_origins` configuration but
+     * scoped to the current verifier instance: the underlying
+     * {@see \Webauthn\CeremonyStep\CeremonyStepManagerFactory} is asked to
+     * produce a fresh {@see \Webauthn\CeremonyStep\CeremonyStepManager} that
+     * uses these origins, without mutating the factory's global state.
+     */
+    public function withAllowedOrigins(string ...$origins): static
+    {
+        $clone = clone $this;
+        $clone->allowedOriginsOverride = array_values($origins);
+
+        return $clone;
+    }
+
+    public function withAllowSubdomains(bool $allow = true): static
+    {
+        $clone = clone $this;
+        $clone->allowSubdomainsOverride = $allow;
+
+        return $clone;
     }
 
     public function verify(Request $request): WebauthnVerificationResult

--- a/src/symfony/src/Service/WebauthnAssertionVerifier.php
+++ b/src/symfony/src/Service/WebauthnAssertionVerifier.php
@@ -13,6 +13,7 @@ use Webauthn\AuthenticatorAssertionResponseValidator;
 use Webauthn\AuthenticatorResponse;
 use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
 use Webauthn\Bundle\Security\Storage\OptionsStorage;
+use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
 use Webauthn\CredentialRecord;
 use Webauthn\Exception\AuthenticatorResponseVerificationException;
 use Webauthn\PublicKeyCredential;
@@ -31,6 +32,11 @@ use Webauthn\PublicKeyCredentialUserEntity;
  * of these updates is left to the repository implementation, mirroring the
  * legacy {@see \Webauthn\Bundle\Controller\AssertionResponseController}: Doctrine
  * repositories flush automatically through the unit of work.
+ *
+ * Per-verifier origin overrides are supported through
+ * {@see self::withAllowedOrigins()} / {@see self::withAllowSubdomains()}: when
+ * set, a fresh validator is built on top of a scoped ceremony step manager so
+ * the global `webauthn.allowed_origins` configuration is unaffected.
  */
 final class WebauthnAssertionVerifier extends AbstractWebauthnVerifier
 {
@@ -39,6 +45,7 @@ final class WebauthnAssertionVerifier extends AbstractWebauthnVerifier
         OptionsStorage $storage,
         private readonly AuthenticatorAssertionResponseValidator $validator,
         private readonly CredentialRecordRepositoryInterface $repository,
+        private readonly CeremonyStepManagerFactory $ceremonyStepManagerFactory,
         private readonly string $rpId,
     ) {
         parent::__construct($serializer, $storage);
@@ -75,12 +82,25 @@ final class WebauthnAssertionVerifier extends AbstractWebauthnVerifier
         $credentialRecord = $this->repository->findOneByCredentialId($publicKeyCredential->rawId)
             ?? throw AuthenticatorResponseVerificationException::create('The credential ID is invalid.');
 
-        return $this->validator->check(
-            $credentialRecord,
-            $response,
-            $options,
-            $request->getHost(),
-            $userEntity?->id,
+        return $this->resolveValidator()
+            ->check($credentialRecord, $response, $options, $request->getHost(), $userEntity?->id);
+    }
+
+    private function resolveValidator(): AuthenticatorAssertionResponseValidator
+    {
+        if ($this->allowedOriginsOverride === null) {
+            return $this->validator;
+        }
+
+        $csm = $this->ceremonyStepManagerFactory->requestCeremony(
+            $this->allowedOriginsOverride,
+            $this->allowSubdomainsOverride,
         );
+
+        $scoped = new AuthenticatorAssertionResponseValidator($csm);
+        $scoped->setLogger($this->logger);
+        $scoped->setEventDispatcher($this->eventDispatcher);
+
+        return $scoped;
     }
 }

--- a/src/symfony/src/Service/WebauthnAttestationVerifier.php
+++ b/src/symfony/src/Service/WebauthnAttestationVerifier.php
@@ -15,6 +15,7 @@ use Webauthn\Bundle\Exception\MissingFeatureException;
 use Webauthn\Bundle\Repository\CanSaveCredentialRecord;
 use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
 use Webauthn\Bundle\Security\Storage\OptionsStorage;
+use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
 use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredential;
 use Webauthn\PublicKeyCredentialCreationOptions;
@@ -34,6 +35,11 @@ use Webauthn\PublicKeyCredentialUserEntity;
  * If the stored creation options carry the W3C `mediation: conditional` flag,
  * the verifier automatically uses the conditional creation ceremony manager
  * (which relaxes the User Verification check, per the spec).
+ *
+ * Per-verifier origin overrides are supported through
+ * {@see self::withAllowedOrigins()} / {@see self::withAllowSubdomains()}: when
+ * set, a fresh validator is built on top of a scoped ceremony step manager so
+ * the global `webauthn.allowed_origins` configuration is unaffected.
  */
 final class WebauthnAttestationVerifier extends AbstractWebauthnVerifier
 {
@@ -45,6 +51,7 @@ final class WebauthnAttestationVerifier extends AbstractWebauthnVerifier
         private readonly AuthenticatorAttestationResponseValidator $validator,
         private readonly AuthenticatorAttestationResponseValidator $conditionalValidator,
         private readonly CredentialRecordRepositoryInterface $repository,
+        private readonly CeremonyStepManagerFactory $ceremonyStepManagerFactory,
         private readonly string $rpId,
     ) {
         parent::__construct($serializer, $storage);
@@ -86,9 +93,8 @@ final class WebauthnAttestationVerifier extends AbstractWebauthnVerifier
         assert($response instanceof AuthenticatorAttestationResponse);
         assert($options instanceof PublicKeyCredentialCreationOptions);
 
-        $validator = $options->mediation === PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL
-            ? $this->conditionalValidator
-            : $this->validator;
+        $isConditional = $options->mediation === PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL;
+        $validator = $this->resolveValidator($isConditional);
 
         $credentialRecord = $validator->check($response, $options, $request->getHost());
 
@@ -97,6 +103,29 @@ final class WebauthnAttestationVerifier extends AbstractWebauthnVerifier
         }
 
         return $credentialRecord;
+    }
+
+    private function resolveValidator(bool $isConditional): AuthenticatorAttestationResponseValidator
+    {
+        if ($this->allowedOriginsOverride === null) {
+            return $isConditional ? $this->conditionalValidator : $this->validator;
+        }
+
+        $csm = $isConditional
+            ? $this->ceremonyStepManagerFactory->conditionalCreateCeremony(
+                $this->allowedOriginsOverride,
+                $this->allowSubdomainsOverride,
+            )
+            : $this->ceremonyStepManagerFactory->creationCeremony(
+                $this->allowedOriginsOverride,
+                $this->allowSubdomainsOverride,
+            );
+
+        $scoped = new AuthenticatorAttestationResponseValidator($csm);
+        $scoped->setLogger($this->logger);
+        $scoped->setEventDispatcher($this->eventDispatcher);
+
+        return $scoped;
     }
 
     private function persist(CredentialRecord $credentialRecord): void

--- a/src/symfony/src/Service/WebauthnOptionsResponse.php
+++ b/src/symfony/src/Service/WebauthnOptionsResponse.php
@@ -9,6 +9,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
 use Webauthn\Bundle\Security\Guesser\UserEntityGuesser;
 use Webauthn\Bundle\Security\Storage\OptionsStorage;
+use Webauthn\FakeCredentialGenerator;
 use Webauthn\PublicKeyCredentialUserEntity;
 
 /**
@@ -47,6 +48,7 @@ final readonly class WebauthnOptionsResponse
         private SerializerInterface $serializer,
         private ValidatorInterface $validator,
         private CredentialRecordRepositoryInterface $credentialRepository,
+        private ?FakeCredentialGenerator $fakeCredentialGenerator = null,
     ) {
     }
 
@@ -72,6 +74,7 @@ final readonly class WebauthnOptionsResponse
             $this->validator,
             $this->credentialRepository,
             $rpId,
+            $this->fakeCredentialGenerator,
         );
     }
 }

--- a/src/symfony/src/Service/WebauthnRequestOptionsBuilder.php
+++ b/src/symfony/src/Service/WebauthnRequestOptionsBuilder.php
@@ -12,6 +12,7 @@ use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
 use Webauthn\Bundle\Security\Guesser\UserEntityGuesser;
 use Webauthn\Bundle\Security\Storage\OptionsStorage;
 use Webauthn\CredentialRecord;
+use Webauthn\FakeCredentialGenerator;
 use Webauthn\PublicKeyCredentialDescriptor;
 use Webauthn\PublicKeyCredentialOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
@@ -26,6 +27,13 @@ use Webauthn\PublicKeyCredentialUserEntity;
  * through {@see self::withUser()} when known. When a user entity is resolved,
  * `allowCredentials` is derived from the credential repository unless an
  * explicit list is provided through {@see self::withAllowCredentials()}.
+ *
+ * When user resolution fails but the JSON body carried a `username` (e.g. a
+ * login form posted `{"username":"alice"}`), the builder consults the autowired
+ * {@see FakeCredentialGenerator} to produce **fake** `allowCredentials`. This
+ * prevents username enumeration: the response shape is identical whether or
+ * not the username matches a real user. Disable with
+ * {@see self::withFakeCredentialGenerator()} (pass `null`).
  */
 final class WebauthnRequestOptionsBuilder extends AbstractWebauthnOptionsBuilder
 {
@@ -48,6 +56,7 @@ final class WebauthnRequestOptionsBuilder extends AbstractWebauthnOptionsBuilder
         ValidatorInterface $validator,
         CredentialRecordRepositoryInterface $credentialRepository,
         private readonly string $rpId,
+        private ?FakeCredentialGenerator $fakeCredentialGenerator = null,
     ) {
         parent::__construct($storage, $serializer, $validator, $credentialRepository);
     }
@@ -93,6 +102,19 @@ final class WebauthnRequestOptionsBuilder extends AbstractWebauthnOptionsBuilder
         return $clone;
     }
 
+    /**
+     * Swap the fake credential generator used for username-enumeration
+     * protection. Pass `null` to opt out (response will carry empty
+     * `allowCredentials` when the username does not resolve to a known user).
+     */
+    public function withFakeCredentialGenerator(?FakeCredentialGenerator $generator): static
+    {
+        $clone = clone $this;
+        $clone->fakeCredentialGenerator = $generator;
+
+        return $clone;
+    }
+
     protected function resolveUserEntity(Request $request): ?PublicKeyCredentialUserEntity
     {
         return self::resolveStaticOrGuessed($this->userOrGuesser, $request);
@@ -103,12 +125,17 @@ final class WebauthnRequestOptionsBuilder extends AbstractWebauthnOptionsBuilder
         return $this->parseDto($request, ServerPublicKeyCredentialRequestOptionsRequest::class);
     }
 
+    protected function shouldParseClientRequest(): bool
+    {
+        return parent::shouldParseClientRequest() || $this->fakeCredentialGenerator !== null;
+    }
+
     protected function assembleOptions(
         Request $request,
         ?PublicKeyCredentialUserEntity $userEntity,
         ?object $optionsRequest,
     ): PublicKeyCredentialOptions {
-        $allowCredentials = $this->resolveAllowCredentials($userEntity);
+        $allowCredentials = $this->resolveAllowCredentials($request, $userEntity, $optionsRequest);
 
         $userVerification = $this->userVerification;
         $extensions = $this->extensions;
@@ -144,19 +171,31 @@ final class WebauthnRequestOptionsBuilder extends AbstractWebauthnOptionsBuilder
     /**
      * @return list<PublicKeyCredentialDescriptor>
      */
-    private function resolveAllowCredentials(?PublicKeyCredentialUserEntity $userEntity): array
-    {
+    private function resolveAllowCredentials(
+        Request $request,
+        ?PublicKeyCredentialUserEntity $userEntity,
+        ?object $optionsRequest,
+    ): array {
         if ($this->allowCredentials !== null) {
             return $this->allowCredentials;
         }
 
-        if (! $this->deriveAllowCredentialsFromUser || $userEntity === null) {
-            return [];
+        if ($userEntity !== null && $this->deriveAllowCredentialsFromUser) {
+            return array_map(
+                static fn (CredentialRecord $record): PublicKeyCredentialDescriptor => $record->getPublicKeyCredentialDescriptor(),
+                $this->credentialRepository->findAllForUserEntity($userEntity),
+            );
         }
 
-        return array_map(
-            static fn (CredentialRecord $record): PublicKeyCredentialDescriptor => $record->getPublicKeyCredentialDescriptor(),
-            $this->credentialRepository->findAllForUserEntity($userEntity),
-        );
+        if ($userEntity === null
+            && $this->fakeCredentialGenerator !== null
+            && $optionsRequest instanceof ServerPublicKeyCredentialRequestOptionsRequest
+            && $optionsRequest->username !== null
+            && $optionsRequest->username !== ''
+        ) {
+            return array_values($this->fakeCredentialGenerator->generate($request, $optionsRequest->username));
+        }
+
+        return [];
     }
 }

--- a/src/symfony/src/Service/WebauthnResponseVerifier.php
+++ b/src/symfony/src/Service/WebauthnResponseVerifier.php
@@ -4,11 +4,18 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\Service;
 
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\Serializer\SerializerInterface;
 use Webauthn\AuthenticatorAssertionResponseValidator;
 use Webauthn\AuthenticatorAttestationResponseValidator;
 use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
 use Webauthn\Bundle\Security\Storage\OptionsStorage;
+use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
+use Webauthn\Event\CanDispatchEvents;
+use Webauthn\Event\NullEventDispatcher;
+use Webauthn\MetadataService\CanLogData;
 
 /**
  * Single, autowired entry point that produces a fluent
@@ -34,39 +41,73 @@ use Webauthn\Bundle\Security\Storage\OptionsStorage;
  *         ->forAssertion('example.com')
  *         ->verify($request);
  *     // $result->credentialRecord has its counter / backup state updated
+ *
+ *     // Per-controller origin override (mirrors the legacy
+ *     // controllers[].allowed_origins YAML option)
+ *     $result = $this->verifier
+ *         ->forAttestation('example.com')
+ *         ->withAllowedOrigins('https://app.example.com')
+ *         ->verify($request);
  */
-final readonly class WebauthnResponseVerifier
+final class WebauthnResponseVerifier implements CanLogData, CanDispatchEvents
 {
+    private LoggerInterface $logger;
+
+    private EventDispatcherInterface $eventDispatcher;
+
     public function __construct(
-        private SerializerInterface $serializer,
-        private OptionsStorage $storage,
-        private CredentialRecordRepositoryInterface $repository,
-        private AuthenticatorAttestationResponseValidator $attestationValidator,
-        private AuthenticatorAttestationResponseValidator $conditionalAttestationValidator,
-        private AuthenticatorAssertionResponseValidator $assertionValidator,
+        private readonly SerializerInterface $serializer,
+        private readonly OptionsStorage $storage,
+        private readonly CredentialRecordRepositoryInterface $repository,
+        private readonly AuthenticatorAttestationResponseValidator $attestationValidator,
+        private readonly AuthenticatorAttestationResponseValidator $conditionalAttestationValidator,
+        private readonly AuthenticatorAssertionResponseValidator $assertionValidator,
+        private readonly CeremonyStepManagerFactory $ceremonyStepManagerFactory,
     ) {
+        $this->logger = new NullLogger();
+        $this->eventDispatcher = new NullEventDispatcher();
+    }
+
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+    }
+
+    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher): void
+    {
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     public function forAttestation(string $rpId): WebauthnAttestationVerifier
     {
-        return new WebauthnAttestationVerifier(
+        $verifier = new WebauthnAttestationVerifier(
             $this->serializer,
             $this->storage,
             $this->attestationValidator,
             $this->conditionalAttestationValidator,
             $this->repository,
+            $this->ceremonyStepManagerFactory,
             $rpId,
         );
+        $verifier->setLogger($this->logger);
+        $verifier->setEventDispatcher($this->eventDispatcher);
+
+        return $verifier;
     }
 
     public function forAssertion(string $rpId): WebauthnAssertionVerifier
     {
-        return new WebauthnAssertionVerifier(
+        $verifier = new WebauthnAssertionVerifier(
             $this->serializer,
             $this->storage,
             $this->assertionValidator,
             $this->repository,
+            $this->ceremonyStepManagerFactory,
             $rpId,
         );
+        $verifier->setLogger($this->logger);
+        $verifier->setEventDispatcher($this->eventDispatcher);
+
+        return $verifier;
     }
 }

--- a/tests/symfony/unit/Service/WebauthnOptionsResponseTest.php
+++ b/tests/symfony/unit/Service/WebauthnOptionsResponseTest.php
@@ -7,6 +7,7 @@ namespace Webauthn\Tests\Bundle\Unit\Service;
 use const JSON_THROW_ON_ERROR;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Uid\Uuid;
@@ -21,6 +22,7 @@ use Webauthn\Bundle\Security\Storage\OptionsStorage;
 use Webauthn\Bundle\Service\WebauthnOptionsResponse;
 use Webauthn\CredentialRecord;
 use Webauthn\Denormalizer\WebauthnSerializerFactory;
+use Webauthn\FakeCredentialGenerator;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialDescriptor;
 use Webauthn\PublicKeyCredentialRequestOptions;
@@ -250,15 +252,85 @@ final class WebauthnOptionsResponseTest extends TestCase
         static::assertNotSame($base, $derived);
     }
 
+    #[Test]
+    public function forRequestUsesTheFakeCredentialGeneratorWhenAUsernameDoesNotResolveToAUser(): void
+    {
+        $storage = new InMemoryOptionsStorage();
+        $fakeDescriptor = PublicKeyCredentialDescriptor::create('public-key', 'fake-cred');
+        $generator = new class($fakeDescriptor) implements FakeCredentialGenerator {
+            public function __construct(
+                private readonly PublicKeyCredentialDescriptor $descriptor,
+            ) {
+            }
+
+            public function generate(Request $request, string $username): array
+            {
+                return [$this->descriptor];
+            }
+        };
+
+        $this->helper(storage: $storage, fakeCredentialGenerator: $generator)
+            ->forRequest('example.com')
+            ->build($this->jsonRequest(json_encode([
+                'username' => 'unknown-user',
+            ], JSON_THROW_ON_ERROR)));
+
+        $options = $storage->last()
+            ->getPublicKeyCredentialOptions();
+        static::assertCount(1, $options->allowCredentials);
+        static::assertSame('fake-cred', $options->allowCredentials[0]->id);
+    }
+
+    #[Test]
+    public function forRequestProducesEmptyAllowCredentialsWhenTheBodyIsUserlessEvenIfAFakerIsActive(): void
+    {
+        $storage = new InMemoryOptionsStorage();
+        $generator = new class() implements FakeCredentialGenerator {
+            public function generate(Request $request, string $username): array
+            {
+                throw new RuntimeException('The fake generator MUST NOT be invoked when no username is posted.');
+            }
+        };
+
+        $this->helper(storage: $storage, fakeCredentialGenerator: $generator)
+            ->forRequest('example.com')
+            ->build($this->jsonRequest('{}'));
+
+        static::assertSame([], $storage->last()->getPublicKeyCredentialOptions()->allowCredentials);
+    }
+
+    #[Test]
+    public function withFakeCredentialGeneratorNullOptsOutOfTheAntiEnumerationProtection(): void
+    {
+        $storage = new InMemoryOptionsStorage();
+        $generator = new class() implements FakeCredentialGenerator {
+            public function generate(Request $request, string $username): array
+            {
+                throw new RuntimeException('The fake generator MUST NOT be invoked once opted out.');
+            }
+        };
+
+        $this->helper(storage: $storage, fakeCredentialGenerator: $generator)
+            ->forRequest('example.com')
+            ->withFakeCredentialGenerator(null)
+            ->build($this->jsonRequest(json_encode([
+                'username' => 'unknown-user',
+            ], JSON_THROW_ON_ERROR)));
+
+        static::assertSame([], $storage->last()->getPublicKeyCredentialOptions()->allowCredentials);
+    }
+
     private function helper(
         ?OptionsStorage $storage = null,
         ?CredentialRecordRepositoryInterface $repository = null,
+        ?FakeCredentialGenerator $fakeCredentialGenerator = null,
     ): WebauthnOptionsResponse {
         return new WebauthnOptionsResponse(
             $storage ?? new InMemoryOptionsStorage(),
             $this->serializer(),
             Validation::createValidator(),
             $repository ?? new InMemoryCredentialRepository(),
+            $fakeCredentialGenerator,
         );
     }
 

--- a/tests/symfony/unit/Service/WebauthnResponseVerifierTest.php
+++ b/tests/symfony/unit/Service/WebauthnResponseVerifierTest.php
@@ -28,6 +28,7 @@ use Webauthn\Bundle\Security\Storage\OptionsStorage;
 use Webauthn\Bundle\Service\WebauthnAssertionVerifier;
 use Webauthn\Bundle\Service\WebauthnAttestationVerifier;
 use Webauthn\Bundle\Service\WebauthnResponseVerifier;
+use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
 use Webauthn\CollectedClientData;
 use Webauthn\CredentialRecord;
 use Webauthn\Denormalizer\WebauthnSerializerFactory;
@@ -302,6 +303,55 @@ final class WebauthnResponseVerifierTest extends TestCase
     }
 
     #[Test]
+    public function withAllowedOriginsBuildsAFreshValidatorAndBypassesTheInjectedOne(): void
+    {
+        $rawId = 'cred-id';
+        $standardValidator = $this->createMock(AuthenticatorAttestationResponseValidator::class);
+        $standardValidator->expects(static::never())
+            ->method('check');
+
+        // Real factory: when withAllowedOrigins() is set the verifier asks it
+        // to produce a fresh CSM, then instantiates a fresh validator on top.
+        // That fresh validator runs against the synthetic credential built in
+        // the test fixture and rejects it (challenge mismatch / etc.), which
+        // gets wrapped in WebauthnAuthenticationFailureException.
+        $this->expectException(WebauthnAuthenticationFailureException::class);
+
+        $this->verifier(
+            serializer: $this->serializerReturning($this->fakeAttestationCredential($rawId)),
+            storage: $this->storageWith($this->creationOptions()),
+            attestationValidator: $standardValidator,
+            factory: new CeremonyStepManagerFactory(),
+        )
+            ->forAttestation('example.com')
+            ->withAllowedOrigins('https://app.example.com')
+            ->verify($this->jsonRequest());
+    }
+
+    #[Test]
+    public function withAllowedOriginsOnAssertionBypassesTheInjectedValidator(): void
+    {
+        $rawId = 'cred-id';
+        $stored = $this->record($rawId);
+        $assertionValidator = $this->createMock(AuthenticatorAssertionResponseValidator::class);
+        $assertionValidator->expects(static::never())
+            ->method('check');
+
+        $this->expectException(WebauthnAuthenticationFailureException::class);
+
+        $this->verifier(
+            serializer: $this->serializerReturning($this->fakeAssertionCredential($rawId)),
+            storage: $this->storageWith($this->requestOptions()),
+            repository: new InMemoryCredentialRepository([$stored]),
+            assertionValidator: $assertionValidator,
+            factory: new CeremonyStepManagerFactory(),
+        )
+            ->forAssertion('example.com')
+            ->withAllowedOrigins('https://app.example.com')
+            ->verify($this->jsonRequest());
+    }
+
+    #[Test]
     public function forAttestationReturnsAttestationVerifier(): void
     {
         static::assertInstanceOf(
@@ -324,6 +374,7 @@ final class WebauthnResponseVerifierTest extends TestCase
         ?AuthenticatorAttestationResponseValidator $attestationValidator = null,
         ?AuthenticatorAttestationResponseValidator $conditionalAttestationValidator = null,
         ?AuthenticatorAssertionResponseValidator $assertionValidator = null,
+        ?CeremonyStepManagerFactory $factory = null,
     ): WebauthnResponseVerifier {
         return new WebauthnResponseVerifier(
             $serializer ?? $this->realSerializer(),
@@ -332,6 +383,7 @@ final class WebauthnResponseVerifierTest extends TestCase
             $attestationValidator ?? static::createStub(AuthenticatorAttestationResponseValidator::class),
             $conditionalAttestationValidator ?? static::createStub(AuthenticatorAttestationResponseValidator::class),
             $assertionValidator ?? static::createStub(AuthenticatorAssertionResponseValidator::class),
+            $factory ?? new CeremonyStepManagerFactory(),
         );
     }
 


### PR DESCRIPTION
## Summary

Extends the helper API so a user-written controller can reproduce **every** behaviour the legacy `controllers[].*` YAML config exposed, including per-controller origin overrides and the fake-credentials anti-enumeration guard. Builds on top of #879 (which restored the factory-method parameters that make this possible without mutating the singleton factory).

## What changes

### Verifiers (`WebauthnAttestationVerifier`, `WebauthnAssertionVerifier`)

```php
\$result = \$this->verifier
    ->forAttestation('example.com')
    ->withAllowedOrigins('https://app.example.com', 'https://admin.example.com')
    ->withAllowSubdomains(true)
    ->verify(\$request);
```

- `withAllowedOrigins(string ...\$origins)` and `withAllowSubdomains(bool \$allow = true)` are immutable setters on the abstract base. When set, the verifier asks `CeremonyStepManagerFactory` to produce a fresh `CeremonyStepManager` + a fresh `AuthenticatorXxxResponseValidator` on top, so the singleton factory's state is unaffected.
- The verifier now implements `CanLogData` + `CanDispatchEvents` so the bundle's autoconfigure tags wire the configured logger and event dispatcher. Both are propagated to any one-off validator built when the override is set.

### Request options builder (`WebauthnRequestOptionsBuilder`)

```php
\$response = \$this->options
    ->forRequest('example.com')
    ->build(\$request);
// If body has {"username": "alice"} and alice is not a known user,
// fake allowCredentials are emitted instead of an empty list.
```

- `withFakeCredentialGenerator(?FakeCredentialGenerator)` swaps or opts out (`null`) of the username-enumeration protection.
- Default = the autowired generator (`SimpleFakeCredentialGenerator` / whatever the bundle's `fake_credential_generator` config points to).
- Body parsing decision moves to a protected `shouldParseClientRequest()` hook so the request builder can opt in for body parsing whenever a faker is active (in addition to the existing `clientOverridePolicy` gate).

`WebauthnOptionsResponse` gets a new `?FakeCredentialGenerator` constructor argument and wires it through to `forRequest()`'s builder. Backwards-compatible (the new arg is nullable with a `null` default).

## YAML mapping (now feature-parity)

| `controllers[].*` field | Helper equivalent | Status |
|---|---|---|
| `hide_existing_credentials` | `WebauthnCreationOptionsBuilder::withHideExistingCredentials(true)` | ✓ shipped |
| `options_path` / `result_path` | `#[Route]` on user controllers | ✓ |
| `user_entity_guesser` | 2nd arg of `forCreation(\$rpId, \$guesser)` | ✓ shipped |
| `allowed_origins` | `WebauthnAttestationVerifier::withAllowedOrigins(...)` (resp. assertion) | **this PR** |
| `allow_subdomains` | `WebauthnAttestationVerifier::withAllowSubdomains(bool)` (resp. assertion) | **this PR** |
| (anti-enumeration default) | `WebauthnRequestOptionsBuilder` uses the autowired faker by default; `withFakeCredentialGenerator(null)` opts out | **this PR** |

## Tests

- `WebauthnResponseVerifierTest`: 2 new tests (`withAllowedOrigins` on attestation and assertion) confirming the injected validator is bypassed in favour of a fresh one when the override is set.
- `WebauthnOptionsResponseTest`: 3 new tests (faker invoked when username does not resolve, faker not invoked when no username, `withFakeCredentialGenerator(null)` opts out).

77 unit + 529 total tests green. ECS / Rector / PHPStan clean.

## BC

- Lib: no public API change (the factory parameters were already restored in #879).
- Bundle: `WebauthnOptionsResponse` constructor gains a 5th nullable arg with `null` default; `WebauthnAttestationVerifier` / `WebauthnAssertionVerifier` constructors gain a `CeremonyStepManagerFactory` arg. Both are autowired services so the change is transparent to users that injected `WebauthnOptionsResponse` / `WebauthnResponseVerifier` (the public-facing entry points). Direct instantiation of the verifiers requires the factory now, but those classes are not part of the documented surface.
- Helper API: only additive (new `with*()` setters).

## Companion doc PR

To follow.