### PR TITLE
feat(config): deprecate the YAML sections superseded by the helpers

### DIFF
--- a/src/symfony/src/DependencyInjection/Configuration.php
+++ b/src/symfony/src/DependencyInjection/Configuration.php
@@ -93,6 +93,11 @@ final readonly class Configuration implements ConfigurationInterface
             ->info('This repository is responsible of the user storage')
             ->end()
             ->arrayNode('allowed_origins')
+            ->setDeprecated(
+                'web-auth/webauthn-symfony-bundle',
+                '5.4.0',
+                'The "%node%" YAML node is deprecated and will be removed in 6.0. Call "WebauthnAttestationVerifier::withAllowedOrigins(...)" / "WebauthnAssertionVerifier::withAllowedOrigins(...)" on the helper instead. Multi-origin apps can spread a Symfony parameter into the call. Single-origin apps can omit the call entirely: the verifier falls back to the W3C-recommended same-origin check against the request host.'
+            )
             ->treatFalseLike([])
             ->treatTrueLike([])
             ->treatNullLike([])
@@ -101,6 +106,11 @@ final readonly class Configuration implements ConfigurationInterface
             ->end()
             ->end()
             ->booleanNode('allow_subdomains')
+            ->setDeprecated(
+                'web-auth/webauthn-symfony-bundle',
+                '5.4.0',
+                'The "%node%" YAML node is deprecated and will be removed in 6.0. Call "WebauthnAttestationVerifier::withAllowSubdomains()" / "WebauthnAssertionVerifier::withAllowSubdomains()" on the helper instead.'
+            )
             ->defaultFalse()
             ->end()
             ->arrayNode('secured_rp_ids')
@@ -143,6 +153,11 @@ final readonly class Configuration implements ConfigurationInterface
     {
         $rootNode->children()
             ->arrayNode('client_override_policy')
+            ->setDeprecated(
+                'web-auth/webauthn-symfony-bundle',
+                '5.4.0',
+                'The "%node%" YAML section is deprecated and will be removed in 6.0. Build a "Webauthn\\Bundle\\Policy\\ClientOverridePolicy" inline in your controller and attach it to the helper via "WebauthnCreationOptionsBuilder::withClientOverrides()" / "WebauthnRequestOptionsBuilder::withClientOverrides()".'
+            )
             ->addDefaultsIfNotSet()
             ->info('Configuration for allowing client request values to override profile configuration')
             ->children()
@@ -251,6 +266,11 @@ final readonly class Configuration implements ConfigurationInterface
         ];
         $rootNode->children()
             ->arrayNode('creation_profiles')
+            ->setDeprecated(
+                'web-auth/webauthn-symfony-bundle',
+                '5.4.0',
+                'The "%node%" YAML section is deprecated and will be removed in 6.0. Use the autowired "Webauthn\\Bundle\\Service\\WebauthnOptionsResponse::forCreation()" helper from a controller of your own; see the "Options Helpers" documentation.'
+            )
             ->treatFalseLike($defaultCreationProfiles)
             ->treatNullLike($defaultCreationProfiles)
             ->treatTrueLike($defaultCreationProfiles)
@@ -383,6 +403,11 @@ final readonly class Configuration implements ConfigurationInterface
 
         $rootNode->children()
             ->arrayNode('request_profiles')
+            ->setDeprecated(
+                'web-auth/webauthn-symfony-bundle',
+                '5.4.0',
+                'The "%node%" YAML section is deprecated and will be removed in 6.0. Use the autowired "Webauthn\\Bundle\\Service\\WebauthnOptionsResponse::forRequest()" helper from a controller of your own; see the "Options Helpers" documentation.'
+            )
             ->treatFalseLike($defaultRequestProfiles)
             ->treatTrueLike($defaultRequestProfiles)
             ->treatNullLike($defaultRequestProfiles)
@@ -422,6 +447,11 @@ final readonly class Configuration implements ConfigurationInterface
     {
         $rootNode->children()
             ->arrayNode('controllers')
+            ->setDeprecated(
+                'web-auth/webauthn-symfony-bundle',
+                '5.4.0',
+                'The "%node%" YAML section is deprecated and will be removed in 6.0. Write your own controllers using the autowired "Webauthn\\Bundle\\Service\\WebauthnOptionsResponse" and "Webauthn\\Bundle\\Service\\WebauthnResponseVerifier" helpers; see the "Options Helpers" and "Verification Helpers" documentation.'
+            )
             ->canBeEnabled()
             ->children()
             ->arrayNode('creation')


### PR DESCRIPTION
## Summary

With the helpers fully landed (PRs #876, #877, #879, #880), the bundle's profile- and controller-driven YAML configuration is fully redundant. This PR marks the corresponding YAML nodes as deprecated for 6.0 with no behaviour change. Users keep working configurations; they just get a clear migration message at boot.

## Deprecated nodes (removed in 6.0)

| YAML node | Helper replacement |
|---|---|
| `webauthn.creation_profiles` | `WebauthnOptionsResponse::forCreation()` |
| `webauthn.request_profiles` | `WebauthnOptionsResponse::forRequest()` |
| `webauthn.controllers` | user-written controllers + `WebauthnOptionsResponse` + `WebauthnResponseVerifier` |
| `webauthn.client_override_policy` | `ClientOverridePolicy` built inline + `->withClientOverrides()` on the helper |
| `webauthn.allowed_origins` | `WebauthnAttestationVerifier::withAllowedOrigins(...)` / `WebauthnAssertionVerifier::withAllowedOrigins(...)` |
| `webauthn.allow_subdomains` | `WebauthnAttestationVerifier::withAllowSubdomains(bool)` / `WebauthnAssertionVerifier::withAllowSubdomains(bool)` |

## Single- vs multi-origin migration

- **Single-origin apps**: drop `webauthn.allowed_origins` entirely. The verifier falls back to the W3C-recommended same-origin check (`CheckOrigin` against the request host). No setter call needed.
- **Multi-origin apps**: spread a Symfony parameter into the helper:
  ```yaml
  parameters:
      app.webauthn.origins:
          - 'https://app.example.com'
          - 'https://admin.example.com'
  ```
  ```php
  public function __construct(
      private readonly WebauthnResponseVerifier \$verifier,
      #[Autowire('%app.webauthn.origins%')]
      private readonly array \$origins,
  ) {}

  // ->withAllowedOrigins(...\$this->origins)
  ```

## Not deprecated yet

- `webauthn.passkey_endpoints` — its helper companion (`WebauthnPasskeyEndpointsResponse`) is on a separate branch waiting to land. Will be deprecated in the same PR as the helper, so users always have somewhere to migrate to.
- `webauthn.metadata` — small, contained, no helper-vs-config duality. Stays.
- Repository / storage / clock / logger service ID nodes — these are DI bindings, not "behaviour" config, and stay useful.

## Tests

529/529 green (1 unrelated pre-existing warning in `BrowserBoundSignatureVerifierTest::knownChromeKeyShapeIsAccepted`). The test kernel uses several of the deprecated sections; PHPUnit's `ignoreIndirectDeprecations="true"` keeps them from breaking CI, exactly as for the existing `secured_rp_ids` deprecation.

## BC

Strictly additive: only deprecation messages added, no behaviour change.