### PR TITLE
feat(metadata): per-verifier withMetadata / withoutMetadata helper setters

### DIFF
--- a/src/symfony/src/Service/WebauthnAttestationVerifier.php
+++ b/src/symfony/src/Service/WebauthnAttestationVerifier.php
@@ -17,6 +17,9 @@ use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
 use Webauthn\Bundle\Security\Storage\OptionsStorage;
 use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
 use Webauthn\CredentialRecord;
+use Webauthn\MetadataService\CertificateChain\CertificateChainValidator;
+use Webauthn\MetadataService\MetadataStatementRepository;
+use Webauthn\MetadataService\StatusReportRepository;
 use Webauthn\PublicKeyCredential;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialOptions;
@@ -36,14 +39,26 @@ use Webauthn\PublicKeyCredentialUserEntity;
  * the verifier automatically uses the conditional creation ceremony manager
  * (which relaxes the User Verification check, per the spec).
  *
- * Per-verifier origin overrides are supported through
- * {@see self::withAllowedOrigins()} / {@see self::withAllowSubdomains()}: when
- * set, a fresh validator is built on top of a scoped ceremony step manager so
- * the global `webauthn.allowed_origins` configuration is unaffected.
+ * Per-verifier overrides supported through fluent setters (build a fresh
+ * {@see CeremonyStepManager} on top of a clone of the autowired factory, so the
+ * factory's global state stays unchanged):
+ *
+ *   - {@see self::withAllowedOrigins()} / {@see self::withAllowSubdomains()}
+ *     to scope the accepted origins for this verification only;
+ *   - {@see self::withMetadata()} to plug Metadata Statement / Status Report /
+ *     Certificate Chain validation services for this verification only.
  */
 final class WebauthnAttestationVerifier extends AbstractWebauthnVerifier
 {
     private bool $saveCredential = true;
+
+    private ?MetadataStatementRepository $metadataStatementRepository = null;
+
+    private ?StatusReportRepository $statusReportRepository = null;
+
+    private ?CertificateChainValidator $certificateChainValidator = null;
+
+    private bool $metadataDisabled = false;
 
     public function __construct(
         SerializerInterface $serializer,
@@ -61,6 +76,47 @@ final class WebauthnAttestationVerifier extends AbstractWebauthnVerifier
     {
         $clone = clone $this;
         $clone->saveCredential = $save;
+
+        return $clone;
+    }
+
+    /**
+     * Override the Metadata Statement support for this verification only. Used
+     * either to swap the globally-configured services (different MDS / Status /
+     * Cert chain validator on a specific endpoint) or to plug metadata
+     * validation on a single endpoint when the global `webauthn.metadata`
+     * config is disabled.
+     *
+     * The autowired {@see CeremonyStepManagerFactory} is cloned and reconfigured
+     * for the call so the singleton's global state stays untouched.
+     */
+    public function withMetadata(
+        MetadataStatementRepository $metadataStatementRepository,
+        StatusReportRepository $statusReportRepository,
+        CertificateChainValidator $certificateChainValidator,
+    ): static {
+        $clone = clone $this;
+        $clone->metadataStatementRepository = $metadataStatementRepository;
+        $clone->statusReportRepository = $statusReportRepository;
+        $clone->certificateChainValidator = $certificateChainValidator;
+        $clone->metadataDisabled = false;
+
+        return $clone;
+    }
+
+    /**
+     * Disable Metadata Statement validation for this verification only. Useful
+     * when the bundle's global `webauthn.metadata` configuration is enabled but
+     * a specific endpoint should NOT enforce metadata checks (e.g. a registration
+     * route open to authenticators that have no published Metadata Statement).
+     */
+    public function withoutMetadata(): static
+    {
+        $clone = clone $this;
+        $clone->metadataStatementRepository = null;
+        $clone->statusReportRepository = null;
+        $clone->certificateChainValidator = null;
+        $clone->metadataDisabled = true;
 
         return $clone;
     }
@@ -107,25 +163,40 @@ final class WebauthnAttestationVerifier extends AbstractWebauthnVerifier
 
     private function resolveValidator(bool $isConditional): AuthenticatorAttestationResponseValidator
     {
-        if ($this->allowedOriginsOverride === null) {
+        if (! $this->hasOverrides()) {
             return $isConditional ? $this->conditionalValidator : $this->validator;
         }
 
-        $csm = $isConditional
-            ? $this->ceremonyStepManagerFactory->conditionalCreateCeremony(
-                $this->allowedOriginsOverride,
-                $this->allowSubdomainsOverride,
-            )
-            : $this->ceremonyStepManagerFactory->creationCeremony(
-                $this->allowedOriginsOverride,
-                $this->allowSubdomainsOverride,
+        $factory = clone $this->ceremonyStepManagerFactory;
+        if ($this->metadataDisabled) {
+            $factory->disableMetadataStatementSupport();
+        } elseif ($this->metadataStatementRepository !== null
+            && $this->statusReportRepository !== null
+            && $this->certificateChainValidator !== null
+        ) {
+            $factory->enableMetadataStatementSupport(
+                $this->metadataStatementRepository,
+                $this->statusReportRepository,
+                $this->certificateChainValidator,
             );
+        }
+
+        $csm = $isConditional
+            ? $factory->conditionalCreateCeremony($this->allowedOriginsOverride, $this->allowSubdomainsOverride)
+            : $factory->creationCeremony($this->allowedOriginsOverride, $this->allowSubdomainsOverride);
 
         $scoped = new AuthenticatorAttestationResponseValidator($csm);
         $scoped->setLogger($this->logger);
         $scoped->setEventDispatcher($this->eventDispatcher);
 
         return $scoped;
+    }
+
+    private function hasOverrides(): bool
+    {
+        return $this->allowedOriginsOverride !== null
+            || $this->metadataStatementRepository !== null
+            || $this->metadataDisabled;
     }
 
     private function persist(CredentialRecord $credentialRecord): void

--- a/src/webauthn/src/CeremonyStep/CeremonyStepManagerFactory.php
+++ b/src/webauthn/src/CeremonyStep/CeremonyStepManagerFactory.php
@@ -114,6 +114,18 @@ final class CeremonyStepManagerFactory
         $this->certificateChainValidator = $certificateChainValidator;
     }
 
+    /**
+     * Reset Metadata Statement support back to disabled. Useful when cloning a
+     * globally-configured factory to scope a single ceremony out of the
+     * metadata pipeline.
+     */
+    public function disableMetadataStatementSupport(): void
+    {
+        $this->metadataStatementRepository = null;
+        $this->statusReportRepository = null;
+        $this->certificateChainValidator = null;
+    }
+
     public function enableCertificateChainValidator(CertificateChainValidator $certificateChainValidator): void
     {
         $this->certificateChainValidator = $certificateChainValidator;

--- a/tests/symfony/unit/Service/WebauthnResponseVerifierTest.php
+++ b/tests/symfony/unit/Service/WebauthnResponseVerifierTest.php
@@ -33,6 +33,9 @@ use Webauthn\CollectedClientData;
 use Webauthn\CredentialRecord;
 use Webauthn\Denormalizer\WebauthnSerializerFactory;
 use Webauthn\Exception\AuthenticatorResponseVerificationException;
+use Webauthn\MetadataService\CertificateChain\CertificateChainValidator;
+use Webauthn\MetadataService\MetadataStatementRepository;
+use Webauthn\MetadataService\StatusReportRepository;
 use Webauthn\PublicKeyCredential;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialDescriptor;
@@ -348,6 +351,68 @@ final class WebauthnResponseVerifierTest extends TestCase
         )
             ->forAssertion('example.com')
             ->withAllowedOrigins('https://app.example.com')
+            ->verify($this->jsonRequest());
+    }
+
+    #[Test]
+    public function withMetadataBuildsAFreshValidatorAndBypassesTheInjectedOne(): void
+    {
+        $rawId = 'cred-id';
+        $standardValidator = $this->createMock(AuthenticatorAttestationResponseValidator::class);
+        $standardValidator->expects(static::never())
+            ->method('check');
+
+        // When withMetadata() is set the verifier asks the (cloned) factory to
+        // produce a fresh CSM with CheckMetadataStatement enabled, then runs a
+        // fresh validator on top. That fresh validator rejects our synthetic
+        // credential (challenge mismatch); the failure surfaces as
+        // WebauthnAuthenticationFailureException.
+        $this->expectException(WebauthnAuthenticationFailureException::class);
+
+        $this->verifier(
+            serializer: $this->serializerReturning($this->fakeAttestationCredential($rawId)),
+            storage: $this->storageWith($this->creationOptions()),
+            attestationValidator: $standardValidator,
+            factory: new CeremonyStepManagerFactory(),
+        )
+            ->forAttestation('example.com')
+            ->withMetadata(
+                static::createStub(MetadataStatementRepository::class),
+                static::createStub(StatusReportRepository::class),
+                static::createStub(CertificateChainValidator::class),
+            )
+            ->verify($this->jsonRequest());
+    }
+
+    #[Test]
+    public function withoutMetadataBuildsAFreshValidatorWithMetadataSupportDisabled(): void
+    {
+        $rawId = 'cred-id';
+        $standardValidator = $this->createMock(AuthenticatorAttestationResponseValidator::class);
+        $standardValidator->expects(static::never())
+            ->method('check');
+
+        // The factory is pre-configured with metadata support enabled globally
+        // (mirrors what `webauthn.metadata` YAML does at boot); withoutMetadata()
+        // must opt this verification out by calling
+        // `disableMetadataStatementSupport()` on the cloned factory.
+        $factory = new CeremonyStepManagerFactory();
+        $factory->enableMetadataStatementSupport(
+            static::createStub(MetadataStatementRepository::class),
+            static::createStub(StatusReportRepository::class),
+            static::createStub(CertificateChainValidator::class),
+        );
+
+        $this->expectException(WebauthnAuthenticationFailureException::class);
+
+        $this->verifier(
+            serializer: $this->serializerReturning($this->fakeAttestationCredential($rawId)),
+            storage: $this->storageWith($this->creationOptions()),
+            attestationValidator: $standardValidator,
+            factory: $factory,
+        )
+            ->forAttestation('example.com')
+            ->withoutMetadata()
             ->verify($this->jsonRequest());
     }
 


### PR DESCRIPTION
## Summary

Adds per-verifier metadata-statement overrides on `WebauthnAttestationVerifier`, layered on top of the bundle's global `webauthn.metadata` YAML configuration (which stays alive — no deprecation here).

## Behaviour

The bundle's `CeremonyStepManagerFactoryCompilerPass` keeps wiring metadata support globally when `webauthn.metadata.enabled: true`, exactly like before. The new setters override that default for one verification only:

* **`withMetadata($mds, $status, $cert)`** swaps the globally-configured services for this verification (e.g. a more permissive MDS on an admin-only endpoint, or plug metadata validation on a single endpoint when the bundle's global toggle is off).
* **`withoutMetadata()`** opts a single verification out of metadata validation entirely (useful when global metadata is enabled but a specific registration route accepts authenticators that have no published Metadata Statement).

```php
// Override per endpoint
$result = $this->verifier
    ->forAttestation('example.com')
    ->withMetadata($mds, $status, $cert)
    ->verify($request);

// Opt out per endpoint
$result = $this->verifier
    ->forAttestation('example.com')
    ->withoutMetadata()
    ->verify($request);
```

Both setters clone the autowired `CeremonyStepManagerFactory` and reconfigure the clone before asking for a fresh `CeremonyStepManager`, so the singleton's global state stays untouched. Same pattern as `withAllowedOrigins()` / `withAllowSubdomains()` (PR #880).

## Lib

Adds `CeremonyStepManagerFactory::disableMetadataStatementSupport()`, the symmetric reset of `enableMetadataStatementSupport()`. Used by the verifier to implement `withoutMetadata()` against a globally-enabled clone.

## Tests

Two new tests in `WebauthnResponseVerifierTest`:

* `withMetadataBuildsAFreshValidatorAndBypassesTheInjectedOne` — confirms the override path
* `withoutMetadataBuildsAFreshValidatorWithMetadataSupportDisabled` — confirms the disable path against a globally-enabled factory

531/531 tests green. Rector / ECS / PHPStan clean.

## Why no YAML deprecation

The `webauthn.metadata` YAML section is a small DI-binding-heavy block that drives global state by design. Deprecating it would force users to wire three service interfaces by hand without a meaningful gain (no per-route YAML existed for metadata). Keep the global config, layer per-verifier overrides on top.

## BC

Strictly additive: two new methods on the verifier, one new method on the factory. No public API removed.