### PR TITLE
feat(config): deprecate the DI service ID YAML nodes

### DIFF
--- a/src/symfony/src/DependencyInjection/Configuration.php
+++ b/src/symfony/src/DependencyInjection/Configuration.php
@@ -55,6 +55,11 @@ final readonly class Configuration implements ConfigurationInterface
 
         $rootNode->children()
             ->scalarNode('fake_credential_generator')
+            ->setDeprecated(
+                'web-auth/webauthn-symfony-bundle',
+                '5.4.0',
+                'The "%node%" YAML node is deprecated and will be removed in 6.0. Alias "Webauthn\\FakeCredentialGenerator" in your "services.yaml" instead.'
+            )
             ->defaultValue(SimpleFakeCredentialGenerator::class)
             ->cannotBeEmpty()
             ->info(
@@ -62,32 +67,67 @@ final readonly class Configuration implements ConfigurationInterface
             )
             ->end()
             ->scalarNode('clock')
+            ->setDeprecated(
+                'web-auth/webauthn-symfony-bundle',
+                '5.4.0',
+                'The "%node%" YAML node is deprecated and will be removed in 6.0. Alias "Psr\\Clock\\ClockInterface" in your "services.yaml" instead (or rely on Symfony\'s default autowired clock).'
+            )
             ->defaultValue('webauthn.clock.default')
             ->info('PSR-20 Clock service.')
             ->end()
             ->scalarNode('options_storage')
+            ->setDeprecated(
+                'web-auth/webauthn-symfony-bundle',
+                '5.4.0',
+                'The "%node%" YAML node is deprecated and will be removed in 6.0. Alias "Webauthn\\Bundle\\Security\\Storage\\OptionsStorage" in your "services.yaml" instead.'
+            )
             ->defaultValue(SessionStorage::class)
             ->info('Service responsible of the options/user entity storage during the ceremony')
             ->end()
             ->scalarNode('event_dispatcher')
+            ->setDeprecated(
+                'web-auth/webauthn-symfony-bundle',
+                '5.4.0',
+                'The "%node%" YAML node is deprecated and will be removed in 6.0. Alias "webauthn.event_dispatcher" in your "services.yaml" instead (or rely on the default autowired Psr\\EventDispatcher\\EventDispatcherInterface).'
+            )
             ->defaultValue(EventDispatcherInterface::class)
             ->info('PSR-14 Event Dispatcher service.')
             ->end()
             ->scalarNode('http_client')
+            ->setDeprecated(
+                'web-auth/webauthn-symfony-bundle',
+                '5.4.0',
+                'The "%node%" YAML node is deprecated and will be removed in 6.0. Alias "webauthn.http_client" in your "services.yaml" instead (or rely on the default autowired Symfony\\Contracts\\HttpClient\\HttpClientInterface).'
+            )
             ->cannotBeEmpty()
             ->defaultValue('webauthn.http_client.default')
             ->info('A Symfony HTTP client.')
             ->end()
             ->scalarNode('logger')
+            ->setDeprecated(
+                'web-auth/webauthn-symfony-bundle',
+                '5.4.0',
+                'The "%node%" YAML node is deprecated and will be removed in 6.0. Alias "webauthn.logger" in your "services.yaml" instead (or rely on the default autowired Psr\\Log\\LoggerInterface).'
+            )
             ->defaultValue('webauthn.logger.default')
             ->info('A PSR-3 logger to receive logs during the processes')
             ->end()
             ->scalarNode('credential_repository')
+            ->setDeprecated(
+                'web-auth/webauthn-symfony-bundle',
+                '5.4.0',
+                'The "%node%" YAML node is deprecated and will be removed in 6.0. Alias "Webauthn\\Bundle\\Repository\\CredentialRecordRepositoryInterface" in your "services.yaml" instead.'
+            )
             ->cannotBeEmpty()
             ->defaultValue(DummyPublicKeyCredentialSourceRepository::class)
             ->info('This repository is responsible of the credential storage')
             ->end()
             ->scalarNode('user_repository')
+            ->setDeprecated(
+                'web-auth/webauthn-symfony-bundle',
+                '5.4.0',
+                'The "%node%" YAML node is deprecated and will be removed in 6.0. Alias "Webauthn\\Bundle\\Repository\\PublicKeyCredentialUserEntityRepositoryInterface" in your "services.yaml" instead.'
+            )
             ->cannotBeEmpty()
             ->defaultValue(DummyPublicKeyCredentialUserEntityRepository::class)
             ->info('This repository is responsible of the user storage')
@@ -127,6 +167,11 @@ final readonly class Configuration implements ConfigurationInterface
             ->end()
             ->end()
             ->scalarNode('counter_checker')
+            ->setDeprecated(
+                'web-auth/webauthn-symfony-bundle',
+                '5.4.0',
+                'The "%node%" YAML node is deprecated and will be removed in 6.0. Alias "Webauthn\\Counter\\CounterChecker" in your "services.yaml" instead.'
+            )
             ->defaultValue(ThrowExceptionIfInvalid::class)
             ->cannotBeEmpty()
             ->info(
@@ -134,6 +179,11 @@ final readonly class Configuration implements ConfigurationInterface
             )
             ->end()
             ->scalarNode('top_origin_validator')
+            ->setDeprecated(
+                'web-auth/webauthn-symfony-bundle',
+                '5.4.0',
+                'The "%node%" YAML node is deprecated and will be removed in 6.0. Alias "Webauthn\\CeremonyStep\\TopOriginValidator" in your "services.yaml" instead.'
+            )
             ->defaultNull()
             ->info('For cross origin (e.g. iframe), this service will be in charge of verifying the top origin.')
             ->end()


### PR DESCRIPTION
## Summary

Marks the ten root-level scalar YAML nodes that only act as DI aliases as deprecated, in line with the helpers-over-config direction (#881, #882). Each one has a direct standard Symfony equivalent: a service alias declared in the user's own `services.yaml`. The YAML nodes still work in 5.x; the deprecation message points to the interface or alias to bind in `services.yaml` for 6.0.

## Deprecated nodes (removed in 6.0)

| YAML node | Replacement (in your `services.yaml`) |
|---|---|
| `webauthn.fake_credential_generator` | `Webauthn\FakeCredentialGenerator: '@your-service'` |
| `webauthn.clock` | `Psr\Clock\ClockInterface: '@your-clock'` (or rely on Symfony's autowiring) |
| `webauthn.options_storage` | `Webauthn\Bundle\Security\Storage\OptionsStorage: '@your-storage'` |
| `webauthn.event_dispatcher` | `webauthn.event_dispatcher: '@your-dispatcher'` (or rely on the autowired EventDispatcherInterface) |
| `webauthn.http_client` | `webauthn.http_client: '@your-http-client'` (or rely on the autowired HttpClientInterface) |
| `webauthn.logger` | `webauthn.logger: '@your-logger'` (or rely on the autowired LoggerInterface) |
| `webauthn.credential_repository` | `Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface: '@your-repo'` |
| `webauthn.user_repository` | `Webauthn\Bundle\Repository\PublicKeyCredentialUserEntityRepositoryInterface: '@your-repo'` |
| `webauthn.counter_checker` | `Webauthn\Counter\CounterChecker: '@your-checker'` |
| `webauthn.top_origin_validator` | `Webauthn\CeremonyStep\TopOriginValidator: '@your-validator'` |

## Migration example

Most apps only override two or three of these. A typical 5.3 config:

\`\`\`yaml
webauthn:
    credential_repository: 'App\Repo\CredentialRepository'
    user_repository:       'App\Repo\UserRepository'
    options_storage:       'App\Storage\SessionStorage'
\`\`\`

becomes:

\`\`\`yaml
# config/services.yaml
services:
    Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface: '@App\Repo\CredentialRepository'
    Webauthn\Bundle\Repository\PublicKeyCredentialUserEntityRepositoryInterface: '@App\Repo\UserRepository'
    Webauthn\Bundle\Security\Storage\OptionsStorage: '@App\Storage\SessionStorage'
\`\`\`

## BC

Strictly additive: only deprecation messages added, no behaviour change. The bundle still consumes the YAML values at boot exactly as before. 531/531 tests green; the test kernel still uses three of the deprecated nodes and stays clean thanks to the `phpunit.xml.dist` `ignoreIndirectDeprecations="true"` setting.