### PR TITLE
feat(helpers): per-call overrides for the bundle's DI service IDs

### DIFF
--- a/src/symfony/src/Service/AbstractWebauthnOptionsBuilder.php
+++ b/src/symfony/src/Service/AbstractWebauthnOptionsBuilder.php
@@ -55,11 +55,37 @@ abstract class AbstractWebauthnOptionsBuilder
     protected ?ClientOverridePolicy $clientOverridePolicy = null;
 
     public function __construct(
-        protected readonly OptionsStorage $storage,
+        protected OptionsStorage $storage,
         protected readonly SerializerInterface $serializer,
         protected readonly ValidatorInterface $validator,
-        protected readonly CredentialRecordRepositoryInterface $credentialRepository,
+        protected CredentialRecordRepositoryInterface $credentialRepository,
     ) {
+    }
+
+    /**
+     * Override the bundle's `OptionsStorage` for this single options build.
+     * Useful for multi-tenant setups where some routes write challenges to a
+     * different cache than the global default.
+     */
+    public function withOptionsStorage(OptionsStorage $storage): static
+    {
+        $clone = clone $this;
+        $clone->storage = $storage;
+
+        return $clone;
+    }
+
+    /**
+     * Override the bundle's `CredentialRecordRepositoryInterface` for this
+     * single options build (e.g. multi-tenant lookup of a user's existing
+     * credentials from a tenant-scoped store).
+     */
+    public function withCredentialRepository(CredentialRecordRepositoryInterface $repository): static
+    {
+        $clone = clone $this;
+        $clone->credentialRepository = $repository;
+
+        return $clone;
     }
 
     public function withAttestation(?string $attestation): static

--- a/src/symfony/src/Service/AbstractWebauthnVerifier.php
+++ b/src/symfony/src/Service/AbstractWebauthnVerifier.php
@@ -14,6 +14,7 @@ use Throwable;
 use Webauthn\AuthenticatorResponse;
 use Webauthn\Bundle\Security\Authentication\Exception\WebauthnAuthenticationFailureException;
 use Webauthn\Bundle\Security\Storage\OptionsStorage;
+use Webauthn\CeremonyStep\TopOriginValidator;
 use Webauthn\CredentialRecord;
 use Webauthn\Event\CanDispatchEvents;
 use Webauthn\Event\NullEventDispatcher;
@@ -51,13 +52,17 @@ abstract class AbstractWebauthnVerifier implements CanLogData, CanDispatchEvents
 
     protected bool $allowSubdomainsOverride = false;
 
+    protected ?TopOriginValidator $topOriginValidatorOverride = null;
+
+    protected bool $topOriginValidatorIsOverridden = false;
+
     protected LoggerInterface $logger;
 
     protected EventDispatcherInterface $eventDispatcher;
 
     public function __construct(
         protected readonly SerializerInterface $serializer,
-        protected readonly OptionsStorage $storage,
+        protected OptionsStorage $storage,
     ) {
         $this->logger = new NullLogger();
         $this->eventDispatcher = new NullEventDispatcher();
@@ -93,6 +98,35 @@ abstract class AbstractWebauthnVerifier implements CanLogData, CanDispatchEvents
     {
         $clone = clone $this;
         $clone->allowSubdomainsOverride = $allow;
+
+        return $clone;
+    }
+
+    /**
+     * Override the top-origin validator used by `CheckTopOrigin` for this single
+     * verification. Pass `null` to explicitly disable cross-origin top-origin
+     * validation per call (e.g. when the global `top_origin_validator` config
+     * is set but a specific endpoint should not enforce it). Triggers the
+     * factory-clone path so the global state stays untouched.
+     */
+    public function withTopOriginValidator(?TopOriginValidator $topOriginValidator): static
+    {
+        $clone = clone $this;
+        $clone->topOriginValidatorOverride = $topOriginValidator;
+        $clone->topOriginValidatorIsOverridden = true;
+
+        return $clone;
+    }
+
+    /**
+     * Override the bundle's `OptionsStorage` for this single verification.
+     * Useful for multi-tenant setups where some routes read/write challenges
+     * to a different cache than the global default.
+     */
+    public function withOptionsStorage(OptionsStorage $storage): static
+    {
+        $clone = clone $this;
+        $clone->storage = $storage;
 
         return $clone;
     }

--- a/src/symfony/src/Service/WebauthnAssertionVerifier.php
+++ b/src/symfony/src/Service/WebauthnAssertionVerifier.php
@@ -14,6 +14,7 @@ use Webauthn\AuthenticatorResponse;
 use Webauthn\Bundle\Repository\CredentialRecordRepositoryInterface;
 use Webauthn\Bundle\Security\Storage\OptionsStorage;
 use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
+use Webauthn\Counter\CounterChecker;
 use Webauthn\CredentialRecord;
 use Webauthn\Exception\AuthenticatorResponseVerificationException;
 use Webauthn\PublicKeyCredential;
@@ -33,22 +34,59 @@ use Webauthn\PublicKeyCredentialUserEntity;
  * legacy {@see \Webauthn\Bundle\Controller\AssertionResponseController}: Doctrine
  * repositories flush automatically through the unit of work.
  *
- * Per-verifier origin overrides are supported through
- * {@see self::withAllowedOrigins()} / {@see self::withAllowSubdomains()}: when
- * set, a fresh validator is built on top of a scoped ceremony step manager so
- * the global `webauthn.allowed_origins` configuration is unaffected.
+ * Per-verifier overrides supported through fluent setters (build a fresh
+ * {@see \Webauthn\CeremonyStep\CeremonyStepManager} on top of a clone of the
+ * autowired factory, so the factory's global state stays unchanged):
+ *
+ *   - {@see self::withAllowedOrigins()} / {@see self::withAllowSubdomains()}
+ *   - {@see self::withTopOriginValidator()}
+ *   - {@see self::withCounterChecker()}
+ *
+ * Plus property-direct overrides:
+ *
+ *   - {@see self::withOptionsStorage()}
+ *   - {@see self::withCredentialRepository()}
  */
 final class WebauthnAssertionVerifier extends AbstractWebauthnVerifier
 {
+    private ?CounterChecker $counterCheckerOverride = null;
+
     public function __construct(
         SerializerInterface $serializer,
         OptionsStorage $storage,
         private readonly AuthenticatorAssertionResponseValidator $validator,
-        private readonly CredentialRecordRepositoryInterface $repository,
+        private CredentialRecordRepositoryInterface $repository,
         private readonly CeremonyStepManagerFactory $ceremonyStepManagerFactory,
         private readonly string $rpId,
     ) {
         parent::__construct($serializer, $storage);
+    }
+
+    /**
+     * Override the bundle's `CredentialRecordRepositoryInterface` for this single
+     * verification (e.g. multi-tenant setups where each route reads from its own
+     * credential store).
+     */
+    public function withCredentialRepository(CredentialRecordRepositoryInterface $repository): static
+    {
+        $clone = clone $this;
+        $clone->repository = $repository;
+
+        return $clone;
+    }
+
+    /**
+     * Override the bundle's signature counter checker for this single
+     * verification. Useful e.g. for a permissive admin endpoint that wants to
+     * accept counter rollbacks while the rest of the application enforces strict
+     * counter monotonicity.
+     */
+    public function withCounterChecker(CounterChecker $counterChecker): static
+    {
+        $clone = clone $this;
+        $clone->counterCheckerOverride = $counterChecker;
+
+        return $clone;
     }
 
     protected function ensureResponseMatches(AuthenticatorResponse $response): void
@@ -88,19 +126,33 @@ final class WebauthnAssertionVerifier extends AbstractWebauthnVerifier
 
     private function resolveValidator(): AuthenticatorAssertionResponseValidator
     {
-        if ($this->allowedOriginsOverride === null) {
+        if (! $this->hasOverrides()) {
             return $this->validator;
         }
 
-        $csm = $this->ceremonyStepManagerFactory->requestCeremony(
-            $this->allowedOriginsOverride,
-            $this->allowSubdomainsOverride,
-        );
+        $factory = clone $this->ceremonyStepManagerFactory;
+        if ($this->topOriginValidatorIsOverridden) {
+            $this->topOriginValidatorOverride === null
+                ? $factory->disableTopOriginValidator()
+                : $factory->enableTopOriginValidator($this->topOriginValidatorOverride);
+        }
+        if ($this->counterCheckerOverride !== null) {
+            $factory->setCounterChecker($this->counterCheckerOverride);
+        }
+
+        $csm = $factory->requestCeremony($this->allowedOriginsOverride, $this->allowSubdomainsOverride);
 
         $scoped = new AuthenticatorAssertionResponseValidator($csm);
         $scoped->setLogger($this->logger);
         $scoped->setEventDispatcher($this->eventDispatcher);
 
         return $scoped;
+    }
+
+    private function hasOverrides(): bool
+    {
+        return $this->allowedOriginsOverride !== null
+            || $this->topOriginValidatorIsOverridden
+            || $this->counterCheckerOverride !== null;
     }
 }

--- a/src/symfony/src/Service/WebauthnAttestationVerifier.php
+++ b/src/symfony/src/Service/WebauthnAttestationVerifier.php
@@ -65,7 +65,7 @@ final class WebauthnAttestationVerifier extends AbstractWebauthnVerifier
         OptionsStorage $storage,
         private readonly AuthenticatorAttestationResponseValidator $validator,
         private readonly AuthenticatorAttestationResponseValidator $conditionalValidator,
-        private readonly CredentialRecordRepositoryInterface $repository,
+        private CredentialRecordRepositoryInterface $repository,
         private readonly CeremonyStepManagerFactory $ceremonyStepManagerFactory,
         private readonly string $rpId,
     ) {
@@ -76,6 +76,19 @@ final class WebauthnAttestationVerifier extends AbstractWebauthnVerifier
     {
         $clone = clone $this;
         $clone->saveCredential = $save;
+
+        return $clone;
+    }
+
+    /**
+     * Override the bundle's `CredentialRecordRepositoryInterface` for this single
+     * verification (e.g. multi-tenant setups where each route writes to its own
+     * credential store).
+     */
+    public function withCredentialRepository(CredentialRecordRepositoryInterface $repository): static
+    {
+        $clone = clone $this;
+        $clone->repository = $repository;
 
         return $clone;
     }
@@ -180,6 +193,11 @@ final class WebauthnAttestationVerifier extends AbstractWebauthnVerifier
                 $this->certificateChainValidator,
             );
         }
+        if ($this->topOriginValidatorIsOverridden) {
+            $this->topOriginValidatorOverride === null
+                ? $factory->disableTopOriginValidator()
+                : $factory->enableTopOriginValidator($this->topOriginValidatorOverride);
+        }
 
         $csm = $isConditional
             ? $factory->conditionalCreateCeremony($this->allowedOriginsOverride, $this->allowSubdomainsOverride)
@@ -196,7 +214,8 @@ final class WebauthnAttestationVerifier extends AbstractWebauthnVerifier
     {
         return $this->allowedOriginsOverride !== null
             || $this->metadataStatementRepository !== null
-            || $this->metadataDisabled;
+            || $this->metadataDisabled
+            || $this->topOriginValidatorIsOverridden;
     }
 
     private function persist(CredentialRecord $credentialRecord): void

--- a/src/webauthn/src/CeremonyStep/CeremonyStepManagerFactory.php
+++ b/src/webauthn/src/CeremonyStep/CeremonyStepManagerFactory.php
@@ -137,6 +137,17 @@ final class CeremonyStepManagerFactory
     }
 
     /**
+     * Reset the top-origin validator back to disabled. Symmetric of
+     * {@see self::enableTopOriginValidator()}, useful when cloning a
+     * globally-configured factory to scope a single ceremony out of
+     * cross-origin top-origin validation.
+     */
+    public function disableTopOriginValidator(): void
+    {
+        $this->topOriginValidator = null;
+    }
+
+    /**
      * @param null|string[] $allowedOriginsOverride Per-call override of {@see self::setAllowedOrigins()}.
      *                                              Pass `null` to fall back to whatever was set on the factory.
      */

--- a/tests/symfony/unit/Service/WebauthnResponseVerifierTest.php
+++ b/tests/symfony/unit/Service/WebauthnResponseVerifierTest.php
@@ -29,7 +29,9 @@ use Webauthn\Bundle\Service\WebauthnAssertionVerifier;
 use Webauthn\Bundle\Service\WebauthnAttestationVerifier;
 use Webauthn\Bundle\Service\WebauthnResponseVerifier;
 use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
+use Webauthn\CeremonyStep\TopOriginValidator;
 use Webauthn\CollectedClientData;
+use Webauthn\Counter\CounterChecker;
 use Webauthn\CredentialRecord;
 use Webauthn\Denormalizer\WebauthnSerializerFactory;
 use Webauthn\Exception\AuthenticatorResponseVerificationException;
@@ -414,6 +416,104 @@ final class WebauthnResponseVerifierTest extends TestCase
             ->forAttestation('example.com')
             ->withoutMetadata()
             ->verify($this->jsonRequest());
+    }
+
+    #[Test]
+    public function withTopOriginValidatorBuildsAFreshAttestationValidator(): void
+    {
+        $standardValidator = $this->createMock(AuthenticatorAttestationResponseValidator::class);
+        $standardValidator->expects(static::never())
+            ->method('check');
+
+        $this->expectException(WebauthnAuthenticationFailureException::class);
+
+        $this->verifier(
+            serializer: $this->serializerReturning($this->fakeAttestationCredential('cred-id')),
+            storage: $this->storageWith($this->creationOptions()),
+            attestationValidator: $standardValidator,
+            factory: new CeremonyStepManagerFactory(),
+        )
+            ->forAttestation('example.com')
+            ->withTopOriginValidator(static::createStub(TopOriginValidator::class))
+            ->verify($this->jsonRequest());
+    }
+
+    #[Test]
+    public function withCounterCheckerBuildsAFreshAssertionValidator(): void
+    {
+        $stored = $this->record('cred-id');
+        $assertionValidator = $this->createMock(AuthenticatorAssertionResponseValidator::class);
+        $assertionValidator->expects(static::never())
+            ->method('check');
+
+        $this->expectException(WebauthnAuthenticationFailureException::class);
+
+        $this->verifier(
+            serializer: $this->serializerReturning($this->fakeAssertionCredential('cred-id')),
+            storage: $this->storageWith($this->requestOptions()),
+            repository: new InMemoryCredentialRepository([$stored]),
+            assertionValidator: $assertionValidator,
+            factory: new CeremonyStepManagerFactory(),
+        )
+            ->forAssertion('example.com')
+            ->withCounterChecker(static::createStub(CounterChecker::class))
+            ->verify($this->jsonRequest());
+    }
+
+    #[Test]
+    public function withOptionsStorageOverridesTheLookupForThisVerification(): void
+    {
+        $alternative = new InMemoryOptionsStorage();
+        $alternative->store(Item::create($this->creationOptions(), null));
+
+        $rawId = 'cred-id';
+        $standardValidator = $this->createMock(AuthenticatorAttestationResponseValidator::class);
+        $standardValidator->expects(static::once())
+            ->method('check')
+            ->willReturn($this->record($rawId));
+        $repository = new SaveableInMemoryCredentialRepository();
+
+        // The default storage is empty; without the override the verifier
+        // would fail the storage lookup and bubble up a BadRequest. With the
+        // override, the alternative storage hands back valid options and the
+        // verification proceeds normally.
+        $result = $this->verifier(
+            serializer: $this->serializerReturning($this->fakeAttestationCredential($rawId)),
+            storage: new InMemoryOptionsStorage(),
+            repository: $repository,
+            attestationValidator: $standardValidator,
+        )
+            ->forAttestation('example.com')
+            ->withOptionsStorage($alternative)
+            ->verify($this->jsonRequest());
+
+        static::assertSame($rawId, $result->credentialRecord->publicKeyCredentialId);
+    }
+
+    #[Test]
+    public function withCredentialRepositoryOverridesTheLookupForAssertion(): void
+    {
+        $rawId = 'cred-id';
+        $stored = $this->record($rawId);
+        $emptyRepo = new InMemoryCredentialRepository();
+        $alternativeRepo = new InMemoryCredentialRepository([$stored]);
+
+        $assertionValidator = $this->createMock(AuthenticatorAssertionResponseValidator::class);
+        $assertionValidator->expects(static::once())
+            ->method('check')
+            ->willReturn($stored);
+
+        $result = $this->verifier(
+            serializer: $this->serializerReturning($this->fakeAssertionCredential($rawId)),
+            storage: $this->storageWith($this->requestOptions()),
+            repository: $emptyRepo,
+            assertionValidator: $assertionValidator,
+        )
+            ->forAssertion('example.com')
+            ->withCredentialRepository($alternativeRepo)
+            ->verify($this->jsonRequest());
+
+        static::assertSame($stored, $result->credentialRecord);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Mirrors the metadata override pattern (#882): the YAML config keeps providing the global default, the helper exposes per-call setters that clone the underlying `CeremonyStepManagerFactory` (or override a property directly when the value is held by the helper itself) so the global state stays untouched. **No YAML deprecation in this PR** — the global config nodes stay alive.

## What changes

### Verifier setters (factory clone)

| Setter | Where | Use case |
|---|---|---|
| `withTopOriginValidator(?TopOriginValidator)` | both verifiers | Override or disable cross-origin top-origin validation per endpoint. Pass `null` to explicitly disable when the global config has it on. |
| `withCounterChecker(CounterChecker)` | assertion verifier only | Permissive admin endpoint accepting counter rollbacks while the rest enforces strict monotonicity. |

### Verifier + options builder setters (property override)

| Setter | Where | Use case |
|---|---|---|
| `withOptionsStorage(OptionsStorage)` | both verifiers + options builder | Multi-tenant routing of challenges to a tenant-scoped cache. |
| `withCredentialRepository(CredentialRecordRepositoryInterface)` | both verifiers + options builder | Multi-tenant lookup of a user's existing credentials from a tenant-scoped store. |

### Lib change

`CeremonyStepManagerFactory::disableTopOriginValidator()` resets the top-origin validator back to `null`, symmetric of `enableTopOriginValidator()`. Used by `withTopOriginValidator(null)` on the verifier.

## Why no YAML deprecation

Same reasoning as the metadata helper PR (#882): the YAML nodes (`fake_credential_generator`, `options_storage`, `credential_repository`, `user_repository`, `counter_checker`, `top_origin_validator`, `clock`, `event_dispatcher`, `http_client`, `logger`) are DI bindings that remain useful as the global default. The helper layers per-call overrides on top of them.

## Tests

Four new unit tests in `WebauthnResponseVerifierTest` cover the four new setters. **535/535** total tests green. Rector / ECS / PHPStan clean.

## BC

Strictly additive: new setters and one new factory method. No public API removed. The properties that gained per-call mutability (`OptionsStorage` on the abstract verifier and options builder, `CredentialRecordRepositoryInterface` on the same plus the concrete verifiers) lost the `readonly` modifier. They were never part of the documented surface.