### PR TITLE
feat(policy): typed ClientOverrideRule + fromRules() factory

### DIFF
--- a/src/symfony/src/Policy/ClientOverridePolicy.php
+++ b/src/symfony/src/Policy/ClientOverridePolicy.php
@@ -4,71 +4,129 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\Policy;
 
-use function in_array;
+use function is_array;
 
 /**
- * Manages client override policies for WebAuthn profile configurations.
+ * Decides whether a request body field can override the server-side default
+ * for a given WebAuthn options field, and validates that an override value is
+ * within the configured allow-list.
  *
- * Determines whether client request values can override profile defaults
- * and validates that override values are within allowed constraints.
+ * Two equivalent ways to build a policy:
+ *
+ *   - Typed factory {@see self::fromRules()} with {@see ClientOverrideRule}
+ *     value objects:
+ *
+ *         $policy = ClientOverridePolicy::fromRules(
+ *             userVerification: ClientOverrideRule::restrictTo(['preferred', 'required']),
+ *             extensions:       ClientOverrideRule::any(),
+ *         );
+ *
+ *   - Legacy nested-array form via {@see self::__construct()} (the shape used
+ *     by the bundle's deprecated `client_override_policy` YAML node):
+ *
+ *         $policy = new ClientOverridePolicy([
+ *             'user_verification' => [
+ *                 'enabled' => true,
+ *                 'allowed_values' => ['preferred', 'required'],
+ *             ],
+ *             'extensions' => ['enabled' => true],
+ *         ]);
+ *
+ * Both shapes are supported as first-class APIs; the constructor accepts
+ * either typed {@see ClientOverrideRule} entries or the legacy
+ * `{enabled, allowed_values?}` shape, on a per-field basis.
+ *
+ * Six fields are queryable through {@see self::canOverride()},
+ * {@see self::isValueAllowed()} and {@see self::getEffectiveValue()}:
+ *
+ *   - `user_verification`
+ *   - `authenticator_attachment`
+ *   - `resident_key`
+ *   - `attestation_conveyance`
+ *   - `extensions`
+ *   - `mediation`
  */
 final readonly class ClientOverridePolicy
 {
     /**
-     * @param array<string, array{enabled: bool, allowed_values?: string[]}> $policies
+     * @var array<string, ClientOverrideRule>
      */
-    public function __construct(
-        private array $policies = []
-    ) {
+    private array $rules;
+
+    /**
+     * @param array<string, ClientOverrideRule>|array<string, array{enabled: bool, allowed_values?: list<string>}> $policies
+     *        Each entry can be either a {@see ClientOverrideRule} value object
+     *        or a `{enabled: bool, allowed_values?: list<string>}` array. The
+     *        two shapes can be mixed within the same call.
+     */
+    public function __construct(array $policies = [])
+    {
+        $rules = [];
+        foreach ($policies as $field => $entry) {
+            if ($entry instanceof ClientOverrideRule) {
+                $rules[$field] = $entry;
+                continue;
+            }
+            if (is_array($entry) && ($entry['enabled'] ?? false) === true) {
+                $rules[$field] = new ClientOverrideRule($entry['allowed_values'] ?? null);
+            }
+        }
+
+        $this->rules = $rules;
     }
 
     /**
-     * Check if a field can be overridden by client request.
+     * Build a policy from typed {@see ClientOverrideRule} value objects, one
+     * per overridable field. Pass `null` (the default) for fields the client
+     * must NOT be able to override.
      */
+    public static function fromRules(
+        ?ClientOverrideRule $userVerification = null,
+        ?ClientOverrideRule $authenticatorAttachment = null,
+        ?ClientOverrideRule $residentKey = null,
+        ?ClientOverrideRule $attestationConveyance = null,
+        ?ClientOverrideRule $extensions = null,
+        ?ClientOverrideRule $mediation = null,
+    ): self {
+        $rules = array_filter([
+            'user_verification' => $userVerification,
+            'authenticator_attachment' => $authenticatorAttachment,
+            'resident_key' => $residentKey,
+            'attestation_conveyance' => $attestationConveyance,
+            'extensions' => $extensions,
+            'mediation' => $mediation,
+        ], static fn (?ClientOverrideRule $rule): bool => $rule !== null);
+
+        return new self($rules);
+    }
+
     public function canOverride(string $field): bool
     {
-        return $this->policies[$field]['enabled'] ?? false;
+        return isset($this->rules[$field]);
     }
 
-    /**
-     * Check if a specific value is allowed for override.
-     */
     public function isValueAllowed(string $field, mixed $value): bool
     {
-        if (! $this->canOverride($field)) {
-            return false;
-        }
+        $rule = $this->rules[$field] ?? null;
 
-        $allowedValues = $this->policies[$field]['allowed_values'] ?? null;
-
-        // If no allowed_values specified, all values are allowed
-        if ($allowedValues === null) {
-            return true;
-        }
-
-        return in_array($value, $allowedValues, true);
+        return $rule !== null && $rule->isValueAllowed($value);
     }
 
     /**
-     * Get the effective value for a field, considering override policy.
-     *
-     * @param mixed $requestValue Value from client request
-     * @param mixed $profileValue Value from profile configuration
-     * @return mixed The value to use
+     * Resolve the value to use for the given field: returns `$requestValue` if
+     * the field is overridable AND the value passes the allow-list, otherwise
+     * falls back to `$profileValue`.
      */
     public function getEffectiveValue(string $field, mixed $requestValue, mixed $profileValue): mixed
     {
-        // If no request value provided, always use profile
         if ($requestValue === null) {
             return $profileValue;
         }
 
-        // If override not allowed or value not permitted, use profile
         if (! $this->isValueAllowed($field, $requestValue)) {
             return $profileValue;
         }
 
-        // Use request value (override approved)
         return $requestValue;
     }
 }

--- a/src/symfony/src/Policy/ClientOverrideRule.php
+++ b/src/symfony/src/Policy/ClientOverrideRule.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Bundle\Policy;
+
+use function in_array;
+
+/**
+ * Per-field rule used by {@see ClientOverridePolicy}: marks a field as
+ * client-overridable and optionally restricts the values the client can submit.
+ *
+ * Presence of a rule on the policy means the field is overridable. Absence of a
+ * rule means the server alone decides the value.
+ *
+ *   new ClientOverrideRule()                                  // any value accepted
+ *   new ClientOverrideRule(['preferred', 'required'])         // restrict to a list
+ *   ClientOverrideRule::any()                                 // alias of ::__construct()
+ *   ClientOverrideRule::restrictTo(['preferred', 'required']) // alias of the restriction form
+ */
+final readonly class ClientOverrideRule
+{
+    /**
+     * @param null|list<string> $allowedValues Pass `null` to accept any value;
+     *                                         pass an explicit list to whitelist
+     *                                         the acceptable client values.
+     */
+    public function __construct(
+        public ?array $allowedValues = null,
+    ) {
+    }
+
+    public static function any(): self
+    {
+        return new self();
+    }
+
+    /**
+     * @param list<string> $allowedValues
+     */
+    public static function restrictTo(array $allowedValues): self
+    {
+        return new self($allowedValues);
+    }
+
+    public function isValueAllowed(mixed $value): bool
+    {
+        return $this->allowedValues === null || in_array($value, $this->allowedValues, true);
+    }
+}

--- a/tests/symfony/unit/Policy/ClientOverridePolicyTest.php
+++ b/tests/symfony/unit/Policy/ClientOverridePolicyTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Bundle\Unit\Policy;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Webauthn\Bundle\Policy\ClientOverridePolicy;
+use Webauthn\Bundle\Policy\ClientOverrideRule;
+
+/**
+ * @internal
+ */
+final class ClientOverridePolicyTest extends TestCase
+{
+    #[Test]
+    public function aFieldWithoutARuleIsNotOverridable(): void
+    {
+        $policy = ClientOverridePolicy::fromRules();
+
+        static::assertFalse($policy->canOverride('user_verification'));
+        static::assertFalse($policy->isValueAllowed('user_verification', 'preferred'));
+    }
+
+    #[Test]
+    public function fromRulesAcceptsAnyValueWhenTheRuleHasNoAllowList(): void
+    {
+        $policy = ClientOverridePolicy::fromRules(extensions: ClientOverrideRule::any());
+
+        static::assertTrue($policy->canOverride('extensions'));
+        static::assertTrue($policy->isValueAllowed('extensions', [
+            'credProps' => true,
+        ]));
+    }
+
+    #[Test]
+    public function fromRulesRestrictsValuesWhenAnAllowListIsProvided(): void
+    {
+        $policy = ClientOverridePolicy::fromRules(
+            userVerification: ClientOverrideRule::restrictTo(['preferred', 'required']),
+        );
+
+        static::assertTrue($policy->isValueAllowed('user_verification', 'preferred'));
+        static::assertTrue($policy->isValueAllowed('user_verification', 'required'));
+        static::assertFalse($policy->isValueAllowed('user_verification', 'discouraged'));
+    }
+
+    #[Test]
+    public function getEffectiveValueFallsBackToTheProfileWhenTheClientValueIsNull(): void
+    {
+        $policy = ClientOverridePolicy::fromRules(userVerification: ClientOverrideRule::any());
+
+        static::assertSame('preferred', $policy->getEffectiveValue('user_verification', null, 'preferred'));
+    }
+
+    #[Test]
+    public function getEffectiveValueFallsBackWhenTheClientSubmitsADisallowedValue(): void
+    {
+        $policy = ClientOverridePolicy::fromRules(
+            userVerification: ClientOverrideRule::restrictTo(['preferred', 'required']),
+        );
+
+        static::assertSame(
+            'preferred',
+            $policy->getEffectiveValue('user_verification', 'discouraged', 'preferred'),
+        );
+    }
+
+    #[Test]
+    public function getEffectiveValueAcceptsTheClientValueWhenItPassesTheAllowList(): void
+    {
+        $policy = ClientOverridePolicy::fromRules(
+            userVerification: ClientOverrideRule::restrictTo(['preferred', 'required']),
+        );
+
+        static::assertSame('required', $policy->getEffectiveValue('user_verification', 'required', 'preferred'));
+    }
+
+    #[Test]
+    public function legacyArrayShapeRemainsAFirstClassConstructorPath(): void
+    {
+        $policy = new ClientOverridePolicy([
+            'user_verification' => [
+                'enabled' => true,
+                'allowed_values' => ['preferred', 'required'],
+            ],
+            'extensions' => [
+                'enabled' => true,
+            ],
+        ]);
+
+        static::assertTrue($policy->canOverride('user_verification'));
+        static::assertTrue($policy->isValueAllowed('user_verification', 'required'));
+        static::assertFalse($policy->isValueAllowed('user_verification', 'discouraged'));
+
+        static::assertTrue($policy->canOverride('extensions'));
+        static::assertTrue($policy->isValueAllowed('extensions', 'anything'));
+    }
+
+    #[Test]
+    public function legacyArrayShapeSkipsFieldsWithEnabledFalse(): void
+    {
+        $policy = new ClientOverridePolicy([
+            'user_verification' => [
+                'enabled' => false,
+                'allowed_values' => ['preferred', 'required'],
+            ],
+        ]);
+
+        static::assertFalse($policy->canOverride('user_verification'));
+    }
+
+    #[Test]
+    public function constructorAcceptsAMixOfTypedAndLegacyEntries(): void
+    {
+        $policy = new ClientOverridePolicy([
+            'user_verification' => ClientOverrideRule::restrictTo(['preferred']),
+            'extensions' => [
+                'enabled' => true,
+            ],
+            'mediation' => [
+                'enabled' => false,
+            ],
+        ]);
+
+        static::assertTrue($policy->canOverride('user_verification'));
+        static::assertTrue($policy->canOverride('extensions'));
+        static::assertFalse($policy->canOverride('mediation'));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a typed alternative to the array-in-array constructor of `ClientOverridePolicy`, addressing the long-standing design concern about the awkward shape (`array<string, array{enabled: bool, allowed_values?: list<string>}>`).

Both ways to build a policy are first-class — applications choose between the typed factory and the nested-array constructor. **No deprecation** on the legacy form.

## Typed factory

```php
use Webauthn\Bundle\Policy\ClientOverridePolicy;
use Webauthn\Bundle\Policy\ClientOverrideRule;

$policy = ClientOverridePolicy::fromRules(
    userVerification: ClientOverrideRule::restrictTo(['preferred', 'required']),
    extensions:       ClientOverrideRule::any(),
);
```

## Legacy nested-array form (still supported)

```php
$policy = new ClientOverridePolicy([
    'user_verification' => ['enabled' => true, 'allowed_values' => ['preferred', 'required']],
    'extensions' => ['enabled' => true],
]);
```

## Mixed payloads

The constructor accepts either entry shape per field, so a payload can mix typed rules with legacy entries when needed (e.g. partial migration):

```php
new ClientOverridePolicy([
    'user_verification' => ClientOverrideRule::restrictTo(['preferred']),
    'extensions' => ['enabled' => true],
    'mediation' => ['enabled' => false],
]);
```

## ClientOverrideRule

Six fields are queryable through `canOverride()` / `isValueAllowed()` / `getEffectiveValue()`: `user_verification`, `authenticator_attachment`, `resident_key`, `attestation_conveyance`, `extensions`, `mediation`.

`ClientOverrideRule::__construct(?array $allowedValues = null)` plus convenience factories:

* `ClientOverrideRule::any()` — accepts any value
* `ClientOverrideRule::restrictTo(array $allowedValues)` — restricts to a list

(No spread/variadic in `restrictTo()`, per the project's API conventions on 5.4.)

## Tests

Nine new unit tests in `tests/symfony/unit/Policy/ClientOverridePolicyTest.php` cover both build paths (factory + array), the no-allow-list / restricted modes and the mixed-shape constructor. **544/544** total tests green. Rector / ECS / PHPStan clean.

## BC

Strictly additive: new `ClientOverrideRule` class, new `ClientOverridePolicy::fromRules()` factory, internal storage migrated to `ClientOverrideRule` instances. The constructor signature is unchanged at the type level (still `array $policies = []`); only its accepted entry shape was widened to also accept `ClientOverrideRule` instances. The query API (`canOverride()`, `isValueAllowed()`, `getEffectiveValue()`) is identical.