### PR TITLE
refactor(helpers): withExtensions(array) instead of AuthenticationExtensions

### DIFF
--- a/src/symfony/src/Service/AbstractWebauthnOptionsBuilder.php
+++ b/src/symfony/src/Service/AbstractWebauthnOptionsBuilder.php
@@ -107,10 +107,13 @@ abstract class AbstractWebauthnOptionsBuilder
         return $clone;
     }
 
-    public function withExtensions(AuthenticationExtensions $extensions): static
+    /**
+     * @param list<AuthenticationExtension> $extensions
+     */
+    public function withExtensions(array $extensions): static
     {
         $clone = clone $this;
-        $clone->extensions = $extensions;
+        $clone->extensions = AuthenticationExtensions::create($extensions);
 
         return $clone;
     }


### PR DESCRIPTION
## Summary

Drops the `AuthenticationExtensions` wrapper at the call site of the helper builder. Callers pass a plain list of `AuthenticationExtension` value objects; the builder wraps them internally.

## Before / after

\`\`\`php
// Before
->withExtensions(AuthenticationExtensions::create([
    AuthenticationExtension::create('uvm', true),
]))

// After
->withExtensions([
    AuthenticationExtension::create('uvm', true),
])
\`\`\`

## Why

The wrapper added one nesting level for no benefit. Callers always built a fresh `AuthenticationExtensions` from a list anyway. Aligned with the "no spread, prefer array" convention (#886) and the typed `ClientOverrideRule` shape (#885).

## Tests

92/92 unit tests green. Rector / ECS / PHPStan clean.

## BC

The 5.4 helper API is unreleased — BC-safe.