### PR TITLE
fix(creation-options): default rp.name to rpId for browser compatibility

### DIFF
--- a/src/symfony/src/Service/WebauthnCreationOptionsBuilder.php
+++ b/src/symfony/src/Service/WebauthnCreationOptionsBuilder.php
@@ -43,6 +43,8 @@ final class WebauthnCreationOptionsBuilder extends AbstractWebauthnOptionsBuilde
 
     private bool $hideExistingCredentials = false;
 
+    private ?string $rpName = null;
+
     public function __construct(
         OptionsStorage $storage,
         SerializerInterface $serializer,
@@ -59,6 +61,22 @@ final class WebauthnCreationOptionsBuilder extends AbstractWebauthnOptionsBuilde
     {
         $clone = clone $this;
         $clone->authenticatorSelection = $authenticatorSelection;
+
+        return $clone;
+    }
+
+    /**
+     * Override the human-palatable Relying Party name advertised to the user
+     * agent during the creation ceremony. Defaults to the `rpId` passed to
+     * {@see WebauthnOptionsResponse::forCreation()}: per W3C IDL
+     * `PublicKeyCredentialEntity.name` is required, and SimpleWebAuthn's
+     * browser bindings refuse to register when it is missing, even though
+     * recent Chrome / Firefox builds tolerate the absence.
+     */
+    public function withRpName(string $rpName): static
+    {
+        $clone = clone $this;
+        $clone->rpName = $rpName;
 
         return $clone;
     }
@@ -143,7 +161,7 @@ final class WebauthnCreationOptionsBuilder extends AbstractWebauthnOptionsBuilde
         }
 
         return PublicKeyCredentialCreationOptions::create(
-            rp: PublicKeyCredentialRpEntity::create(id: $this->rpId),
+            rp: PublicKeyCredentialRpEntity::create($this->rpName ?? $this->rpId, $this->rpId),
             user: $userEntity,
             challenge: random_bytes($this->challengeLength),
             pubKeyCredParams: $this->pubKeyCredParams,


### PR DESCRIPTION
## Summary

Per W3C IDL, `PublicKeyCredentialEntity.name` is **required**:

```webidl
dictionary PublicKeyCredentialEntity {
    required DOMString name;
};
```

The 5.4 helper had `PublicKeyCredentialRpEntity::create(id: $this->rpId)` which serialised to `{"rp": {"id": "localhost"}}` (no name). Recent Chrome / Firefox builds tolerate the absence and fall back to the eTLD+1, but **SimpleWebAuthn's browser bindings refuse** to call `navigator.credentials.create()` when the type-checked input has no `rp.name`, and the registration ceremony silently fails: the user clicks Register, the options endpoint returns 200, then nothing happens.

Reproduced on the [`symfony-webauthn-demo`](https://github.com/web-auth/symfony-webauthn-demo) `upgrade` branch with `@web-auth/webauthn-stimulus@5.3.2` (which depends on `@simplewebauthn/browser@13.x`). The form posts the options request, the JSON comes back without `rp.name`, and the click handler exits silently inside `_processRegistration`.

## Fix

* Default `rp.name` to the `rpId` so the JSON always carries a non-empty name. The user agent uses it as a display label; the rpId is a sensible default since it is already a human-readable hostname.
* Add `withRpName(string $rpName)` for callers that want a different human-palatable label.

## BC

The 5.4 helper API is unreleased, additive setter, no signature change. Existing code keeps working with the implicit default.