### PR TITLE
fix(origins): accept non-URL facet IDs (e.g. android:apk-key-hash:...)

### DIFF
--- a/src/webauthn/src/CeremonyStep/CheckAllowedOrigins.php
+++ b/src/webauthn/src/CeremonyStep/CheckAllowedOrigins.php
@@ -30,6 +30,13 @@ final readonly class CheckAllowedOrigins implements CeremonyStep
     private array $fullOrigins;
 
     /**
+     * Non-URL facet identifiers (e.g. android:apk-key-hash:...) matched verbatim against clientDataJSON.origin.
+     *
+     * @var string[]
+     */
+    private array $rawOrigins;
+
+    /**
      * @param string[] $allowedOrigins
      * @param string[] $securedRelyingPartyId RP IDs that are allowed to use HTTP (e.g. localhost for development)
      */
@@ -39,11 +46,14 @@ final readonly class CheckAllowedOrigins implements CeremonyStep
         private array $securedRelyingPartyId = [],
     ) {
         $fullOrigins = [];
+        $rawOrigins = [];
         foreach ($allowedOrigins as $allowedOrigin) {
             $parsed = parse_url($allowedOrigin);
             $parsed !== false || throw new InvalidArgumentException(sprintf('Invalid origin: %s', $allowedOrigin));
             if (isset($parsed['scheme'], $parsed['host'])) {
                 $fullOrigins[] = self::buildOrigin($parsed['scheme'], $parsed['host'], $parsed['port'] ?? null);
+            } elseif (isset($parsed['scheme'])) {
+                $rawOrigins[] = $allowedOrigin;
             } else {
                 // Host-only entries are normalized to https:// since WebAuthn requires TLS
                 $host = $parsed['host'] ?? $allowedOrigin;
@@ -52,6 +62,7 @@ final readonly class CheckAllowedOrigins implements CeremonyStep
         }
 
         $this->fullOrigins = array_unique($fullOrigins);
+        $this->rawOrigins = array_unique($rawOrigins);
     }
 
     public function process(
@@ -72,13 +83,17 @@ final readonly class CheckAllowedOrigins implements CeremonyStep
         $authData = $authenticatorResponse instanceof AuthenticatorAssertionResponse ? $authenticatorResponse->authenticatorData : $authenticatorResponse->attestationObject->authData;
         $C = $authenticatorResponse->clientDataJSON;
 
+        if (in_array($C->origin, $this->rawOrigins, true)) {
+            return;
+        }
+
         $parsedOrigin = parse_url($C->origin);
         is_array($parsedOrigin) || throw AuthenticatorResponseVerificationException::create(
             'Invalid origin. Unable to parse the origin.'
         );
         $originHost = $parsedOrigin['host'] ?? $C->origin;
 
-        $hasAllowedOrigins = count($this->fullOrigins) !== 0;
+        $hasAllowedOrigins = count($this->fullOrigins) !== 0 || count($this->rawOrigins) !== 0;
 
         if ($hasAllowedOrigins) {
             // Full origin match (scheme + host + port)

--- a/tests/library/Functional/CheckAllowedOriginsTest.php
+++ b/tests/library/Functional/CheckAllowedOriginsTest.php
@@ -331,6 +331,104 @@ final class CheckAllowedOriginsTest extends AbstractTestCase
         );
     }
 
+    #[Test]
+    public function androidApkKeyHashOriginIsAccepted(): void
+    {
+        // Given
+        $apkKeyHash = 'android:apk-key-hash:Lir5oIjf2e6r3KhCJSqlqA64hWHa9JMA-9_8YYRxCdg';
+        $checkOrigins = new CheckAllowedOrigins([$apkKeyHash]);
+        $publicKeyCredentialSource = $this->getPublicKeyCredentialSource();
+        $publicKeyCredentialRequestOptions = $this->getPublicKeyCredentialRequestOptions();
+        $publicKeyCredential = $this->createPublicKeyCredentialWithOrigin($apkKeyHash);
+
+        // When
+        $checkOrigins->process(
+            $publicKeyCredentialSource,
+            $publicKeyCredential->response,
+            $publicKeyCredentialRequestOptions,
+            null,
+            'webauthn.spomky-labs.com',
+        );
+
+        // Then
+        static::assertTrue(true);
+    }
+
+    #[Test]
+    public function androidApkKeyHashOriginMixedWithHttpsAcceptsBoth(): void
+    {
+        // Given
+        $apkKeyHash = 'android:apk-key-hash:Lir5oIjf2e6r3KhCJSqlqA64hWHa9JMA-9_8YYRxCdg';
+        $checkOrigins = new CheckAllowedOrigins(['https://webauthn.spomky-labs.com', $apkKeyHash]);
+        $publicKeyCredentialSource = $this->getPublicKeyCredentialSource();
+        $publicKeyCredentialRequestOptions = $this->getPublicKeyCredentialRequestOptions();
+        $publicKeyCredential = $this->createPublicKeyCredentialWithOrigin($apkKeyHash);
+
+        // When
+        $checkOrigins->process(
+            $publicKeyCredentialSource,
+            $publicKeyCredential->response,
+            $publicKeyCredentialRequestOptions,
+            null,
+            'webauthn.spomky-labs.com',
+        );
+
+        // Then
+        static::assertTrue(true);
+    }
+
+    #[Test]
+    public function differentApkKeyHashOriginIsRejected(): void
+    {
+        // Then
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+        $this->expectExceptionMessage('Invalid origin');
+
+        // Given
+        $checkOrigins = new CheckAllowedOrigins([
+            'android:apk-key-hash:Lir5oIjf2e6r3KhCJSqlqA64hWHa9JMA-9_8YYRxCdg',
+        ]);
+        $publicKeyCredentialSource = $this->getPublicKeyCredentialSource();
+        $publicKeyCredentialRequestOptions = $this->getPublicKeyCredentialRequestOptions();
+        $publicKeyCredential = $this->createPublicKeyCredentialWithOrigin(
+            'android:apk-key-hash:dGhpc0lzQURpZmZlcmVudFNpZ25pbmdLZXlIYXNoVmFsdWU'
+        );
+
+        // When
+        $checkOrigins->process(
+            $publicKeyCredentialSource,
+            $publicKeyCredential->response,
+            $publicKeyCredentialRequestOptions,
+            null,
+            'webauthn.spomky-labs.com',
+        );
+    }
+
+    #[Test]
+    public function httpsOriginIsRejectedWhenOnlyApkKeyHashIsAllowed(): void
+    {
+        // Then
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+        $this->expectExceptionMessage('Invalid origin');
+
+        // Given
+        $checkOrigins = new CheckAllowedOrigins([
+            'android:apk-key-hash:Lir5oIjf2e6r3KhCJSqlqA64hWHa9JMA-9_8YYRxCdg',
+        ]);
+        $publicKeyCredentialSource = $this->getPublicKeyCredentialSource();
+        $publicKeyCredentialRequestOptions = $this->getPublicKeyCredentialRequestOptions();
+        $publicKeyCredential = $this->createPublicKeyCredentialWithOrigin('https://webauthn.spomky-labs.com');
+
+        // When
+        $checkOrigins->process(
+            $publicKeyCredentialSource,
+            $publicKeyCredential->response,
+            $publicKeyCredentialRequestOptions,
+            null,
+            'webauthn.spomky-labs.com',
+        );
+    }
+
     private function createPublicKeyCredentialWithOrigin(string $origin): PublicKeyCredential
     {
         $clientDataJson = json_encode([


### PR DESCRIPTION
## Summary
- Restore support for non-URL WebAuthn facet IDs like `android:apk-key-hash:<base64>` in `setAllowedOrigins(...)`, which regressed in 5.3 after #822.
- Detect entries that have a URI scheme but no host at construction time, store them in a dedicated `rawOrigins` bucket and match them verbatim against `clientDataJSON.origin`, instead of forcing them through `https://<host>` normalization.
- Cover the four relevant cases (matching APK key hash, mixed APK + HTTPS list, different APK key hash rejected, HTTPS origin rejected when only an APK key hash is allowed) in `CheckAllowedOriginsTest`.

Closes #888.