### PR TITLE
feat(stimulus): ship TypeScript type declarations (.d.ts)

### DIFF
--- a/src/stimulus/assets/README.md
+++ b/src/stimulus/assets/README.md
@@ -13,6 +13,7 @@ This package provides ready-to-use [Stimulus](https://stimulus.hotwired.dev/) co
 - 📱 **Platform authenticator detection** (Face ID, Touch ID, Windows Hello)
 - ⚡ **Event-driven architecture** for custom integrations
 - 🎨 **Framework agnostic** (works with any Stimulus-enabled app)
+- 🟦 **TypeScript ready** (ships ambient `.d.ts` declarations, generated from JSDoc)
 
 ## Installation
 
@@ -207,11 +208,7 @@ Then register the controllers in your Stimulus bootstrap (typically `assets/boot
 
 ```javascript
 import { Application } from '@hotwired/stimulus';
-import {
-    AuthenticationController,
-    RegistrationController,
-    WebauthnController,
-} from '@web-auth/webauthn-stimulus';
+import { AuthenticationController, RegistrationController, WebauthnController } from '@web-auth/webauthn-stimulus';
 
 const app = Application.start();
 app.register('web-auth--webauthn-stimulus--authentication', AuthenticationController);

--- a/src/stimulus/assets/package.json
+++ b/src/stimulus/assets/package.json
@@ -4,6 +4,7 @@
     "license": "MIT",
     "version": "0.0.0-development",
     "main": "src/index.js",
+    "types": "src/index.d.ts",
     "symfony": {
         "controllers": {
             "webauthn": {
@@ -42,7 +43,9 @@
         "@simplewebauthn/browser": "^13.2.0"
     },
     "scripts": {
-        "version": "echo \"Version will be set by CI/CD or manually\""
+        "version": "echo \"Version will be set by CI/CD or manually\"",
+        "build:types": "find src -name '*.d.ts' -delete && tsc",
+        "prepublishOnly": "npm run build:types"
     },
     "devDependencies": {
         "@hotwired/stimulus": "^3.0.0",
@@ -53,7 +56,8 @@
         "@testing-library/dom": "^10.0.0",
         "babel-jest": "^29.0.0",
         "jest": "^29.0.0",
-        "jest-environment-jsdom": "^29.0.0"
+        "jest-environment-jsdom": "^29.0.0",
+        "typescript": "^5.0.0"
     },
     "repository": {
         "type": "git",

--- a/src/stimulus/assets/src/authentication-controller.d.ts
+++ b/src/stimulus/assets/src/authentication-controller.d.ts
@@ -1,0 +1,89 @@
+/**
+ * @typedef {import('@simplewebauthn/browser').PublicKeyCredentialRequestOptionsJSON} PublicKeyCredentialRequestOptionsJSON
+ * @typedef {import('@simplewebauthn/browser').AuthenticationResponseJSON} AuthenticationResponseJSON
+ * @typedef {import('@simplewebauthn/browser').StartAuthenticationOpts} StartAuthenticationOpts
+ */
+/**
+ * Stimulus controller for WebAuthn authentication (sign-in).
+ *
+ * Usage:
+ * ```html
+ * <form data-controller="webauthn--authentication"
+ *       data-webauthn--authentication-options-url-value="/auth/options"
+ *       data-webauthn--authentication-result-url-value="/auth/verify"
+ *       data-webauthn--authentication-conditional-ui-value="true"
+ *       data-action="submit->webauthn--authentication#authenticate">
+ *   <input type="text" name="username" autocomplete="username webauthn" data-webauthn--authentication-target="username">
+ *   <input type="hidden" data-webauthn--authentication-target="result">
+ *   <button type="submit">Sign In</button>
+ * </form>
+ * ```
+ */
+export default class AuthenticationController extends BaseController {
+    static values: {
+        optionsUrl: {
+            type: StringConstructor;
+            default: string;
+        };
+        resultUrl: {
+            type: StringConstructor;
+            default: string;
+        };
+        submitViaForm: {
+            type: BooleanConstructor;
+            default: boolean;
+        };
+        successRedirectUri: StringConstructor;
+        conditionalUi: {
+            type: BooleanConstructor;
+            default: boolean;
+        };
+        verifyAutofillInput: {
+            type: BooleanConstructor;
+            default: boolean;
+        };
+        requestHeaders: {
+            type: ObjectConstructor;
+            default: {
+                'Content-Type': string;
+                Accept: string;
+            };
+        };
+    };
+    connect(): Promise<void>;
+    /**
+     * Authenticate the user via WebAuthn.
+     *
+     * @param {Event} event Form submit event.
+     * @returns {Promise<void>}
+     */
+    authenticate(event: Event): Promise<void>;
+    /**
+     * Start authentication with conditional UI (browser autofill).
+     *
+     * @private
+     * @returns {Promise<void>}
+     */
+    private _startAuthenticationWithConditionalUi;
+    /**
+     * Start authentication process.
+     *
+     * @private
+     * @param {Partial<StartAuthenticationOpts>} [options] Additional options for startAuthentication.
+     * @returns {Promise<void>}
+     */
+    private _startAuthentication;
+    /**
+     * Process authentication with WebAuthn.
+     *
+     * @private
+     * @param {PublicKeyCredentialRequestOptionsJSON} credentialRequestOptions WebAuthn credential request options.
+     * @param {Partial<StartAuthenticationOpts>} [startAuthenticationOptions] Options for startAuthentication call.
+     * @returns {Promise<void>}
+     */
+    private _processAuthentication;
+}
+export type PublicKeyCredentialRequestOptionsJSON = import("@simplewebauthn/browser").PublicKeyCredentialRequestOptionsJSON;
+export type AuthenticationResponseJSON = import("@simplewebauthn/browser").AuthenticationResponseJSON;
+export type StartAuthenticationOpts = import("@simplewebauthn/browser").StartAuthenticationOpts;
+import BaseController from './base-controller.js';

--- a/src/stimulus/assets/src/authentication-controller.js
+++ b/src/stimulus/assets/src/authentication-controller.js
@@ -11,9 +11,16 @@ import {
 import BaseController from './base-controller.js';
 
 /**
- * Stimulus controller for WebAuthn authentication (sign-in)
+ * @typedef {import('@simplewebauthn/browser').PublicKeyCredentialRequestOptionsJSON} PublicKeyCredentialRequestOptionsJSON
+ * @typedef {import('@simplewebauthn/browser').AuthenticationResponseJSON} AuthenticationResponseJSON
+ * @typedef {import('@simplewebauthn/browser').StartAuthenticationOpts} StartAuthenticationOpts
+ */
+
+/**
+ * Stimulus controller for WebAuthn authentication (sign-in).
  *
  * Usage:
+ * ```html
  * <form data-controller="webauthn--authentication"
  *       data-webauthn--authentication-options-url-value="/auth/options"
  *       data-webauthn--authentication-result-url-value="/auth/verify"
@@ -23,28 +30,9 @@ import BaseController from './base-controller.js';
  *   <input type="hidden" data-webauthn--authentication-target="result">
  *   <button type="submit">Sign In</button>
  * </form>
- *
- * @property {HTMLInputElement} usernameTarget - Username input element
- * @property {boolean} hasUsernameTarget - Whether username target exists
- * @property {HTMLSelectElement} userVerificationTarget - User verification input element
- * @property {boolean} hasUserVerificationTarget - Whether userVerification target exists
- * @property {HTMLInputElement} resultTarget - Result hidden input element
- * @property {boolean} hasResultTarget - Whether result target exists
- *
- * @property {string} optionsUrlValue - URL to fetch authentication options from
- * @property {boolean} hasOptionsUrlValue - Whether optionsUrl value is set
- * @property {string} resultUrlValue - URL to verify authentication result at
- * @property {boolean} hasResultUrlValue - Whether resultUrl value is set
- * @property {boolean} submitViaFormValue - Whether to submit credential via form instead of API
- * @property {boolean} hasSubmitViaFormValue - Whether submitViaForm value is set
- * @property {string} successRedirectUriValue - URI to redirect to on success
- * @property {boolean} hasSuccessRedirectUriValue - Whether successRedirectUri value is set
- * @property {boolean} conditionalUiValue - Whether to enable conditional UI (browser autofill)
- * @property {boolean} hasConditionalUiValue - Whether conditionalUi value is set
- * @property {boolean} verifyAutofillInputValue - Whether to verify autofill input element exists
- * @property {boolean} hasVerifyAutofillInputValue - Whether verifyAutofillInput value is set
+ * ```
  */
-export default class extends BaseController {
+export default class AuthenticationController extends BaseController {
     static targets = ['username', 'userVerification', 'result'];
 
     static values = {
@@ -81,8 +69,10 @@ export default class extends BaseController {
     }
 
     /**
-     * Authenticate user via WebAuthn
-     * @param {Event} event - Form submit event
+     * Authenticate the user via WebAuthn.
+     *
+     * @param {Event} event Form submit event.
+     * @returns {Promise<void>}
      */
     async authenticate(event) {
         event.preventDefault();
@@ -96,8 +86,10 @@ export default class extends BaseController {
     }
 
     /**
-     * Start authentication with conditional UI (browser autofill)
+     * Start authentication with conditional UI (browser autofill).
+     *
      * @private
+     * @returns {Promise<void>}
      */
     async _startAuthenticationWithConditionalUi() {
         const options = await this._fetchOptions(this.optionsUrlValue, {}, 'webauthn:authentication');
@@ -112,9 +104,11 @@ export default class extends BaseController {
     }
 
     /**
-     * Start authentication process
+     * Start authentication process.
+     *
      * @private
-     * @param {Object} options - Additional options for startAuthentication
+     * @param {Partial<StartAuthenticationOpts>} [options] Additional options for startAuthentication.
+     * @returns {Promise<void>}
      */
     async _startAuthentication(options = {}) {
         const formData = this._getFormData([
@@ -135,10 +129,12 @@ export default class extends BaseController {
     }
 
     /**
-     * Process authentication with WebAuthn
+     * Process authentication with WebAuthn.
+     *
      * @private
-     * @param {Object} credentialRequestOptions - WebAuthn credential request options
-     * @param {Object} startAuthenticationOptions - Options for startAuthentication call
+     * @param {PublicKeyCredentialRequestOptionsJSON} credentialRequestOptions WebAuthn credential request options.
+     * @param {Partial<StartAuthenticationOpts>} [startAuthenticationOptions] Options for startAuthentication call.
+     * @returns {Promise<void>}
      */
     async _processAuthentication(credentialRequestOptions, startAuthenticationOptions = {}) {
         try {

--- a/src/stimulus/assets/src/base-controller.d.ts
+++ b/src/stimulus/assets/src/base-controller.d.ts
@@ -1,0 +1,160 @@
+/**
+ * @typedef {import('@simplewebauthn/browser').PublicKeyCredentialCreationOptionsJSON} PublicKeyCredentialCreationOptionsJSON
+ * @typedef {import('@simplewebauthn/browser').PublicKeyCredentialRequestOptionsJSON} PublicKeyCredentialRequestOptionsJSON
+ * @typedef {import('@simplewebauthn/browser').RegistrationResponseJSON} RegistrationResponseJSON
+ * @typedef {import('@simplewebauthn/browser').AuthenticationResponseJSON} AuthenticationResponseJSON
+ */
+/**
+ * @typedef {Object} FieldTargetMapping
+ * @property {string} name Form data key to extract.
+ * @property {string} targetName Stimulus target name (without the `Target` suffix).
+ */
+/**
+ * @typedef {Object} PrfValuesJSON
+ * @property {string} first Base64url-encoded first value.
+ * @property {string} [second] Base64url-encoded second value (optional).
+ */
+/**
+ * @typedef {Object} PrfValuesBuffer
+ * @property {ArrayBuffer} first Decoded first value.
+ * @property {ArrayBuffer} [second] Decoded second value (optional).
+ */
+/**
+ * Base controller for WebAuthn operations.
+ *
+ * Contains shared logic for authentication and registration controllers.
+ *
+ * @abstract
+ */
+export default class BaseController extends Controller<Element> {
+    static values: {
+        requestHeaders: {
+            type: ObjectConstructor;
+            default: {
+                'Content-Type': string;
+                Accept: string;
+            };
+        };
+    };
+    constructor(context: import("@hotwired/stimulus").Context);
+    /**
+     * Fetch options from the server.
+     *
+     * @template {PublicKeyCredentialCreationOptionsJSON | PublicKeyCredentialRequestOptionsJSON} T
+     * @param {string} url The URL to fetch options from.
+     * @param {Record<string, unknown>} formData The form data to send as JSON body.
+     * @param {string} eventPrefix Prefix for dispatched events.
+     * @returns {Promise<T|false>} The options object or `false` on error.
+     */
+    _fetchOptions<T extends PublicKeyCredentialCreationOptionsJSON | PublicKeyCredentialRequestOptionsJSON>(url: string, formData: Record<string, unknown>, eventPrefix: string): Promise<T | false>;
+    /**
+     * Verify credential with the server.
+     *
+     * @template T
+     * @param {string} url The URL to verify credential at.
+     * @param {RegistrationResponseJSON | AuthenticationResponseJSON} credential The credential to verify.
+     * @param {string} eventPrefix Prefix for dispatched events.
+     * @returns {Promise<T|false>} The verification result or `false` on error.
+     */
+    _verifyCredential<T>(url: string, credential: RegistrationResponseJSON | AuthenticationResponseJSON, eventPrefix: string): Promise<T | false>;
+    /**
+     * Get form data and validate.
+     *
+     * @param {FieldTargetMapping[]} [fieldTargets] Field mappings.
+     * @returns {Record<string, unknown> | null} Form data, or `null` if the form is invalid.
+     */
+    _getFormData(fieldTargets?: FieldTargetMapping[]): Record<string, unknown> | null;
+    /**
+     * Remove empty values from an object recursively.
+     *
+     * @param {Record<string, unknown>} obj Object to clean.
+     * @returns {Record<string, unknown>} Cleaned object.
+     */
+    _removeEmpty(obj: Record<string, unknown>): Record<string, unknown>;
+    /**
+     * Process extensions input (e.g., PRF) before passing options to the authenticator.
+     *
+     * @template {PublicKeyCredentialCreationOptionsJSON | PublicKeyCredentialRequestOptionsJSON} T
+     * @param {T} options WebAuthn options.
+     * @returns {T} Processed options.
+     */
+    _processExtensionsInput<T extends PublicKeyCredentialCreationOptionsJSON | PublicKeyCredentialRequestOptionsJSON>(options: T): T;
+    /**
+     * Process PRF input by decoding base64url strings into ArrayBuffers.
+     *
+     * @param {Record<string, any>} prf PRF extension object.
+     * @returns {Record<string, any>} Processed PRF object.
+     */
+    _processPrfInput(prf: Record<string, any>): Record<string, any>;
+    /**
+     * Import PRF values from base64url strings to ArrayBuffer.
+     *
+     * @param {PrfValuesJSON} values PRF values with base64url strings.
+     * @returns {PrfValuesBuffer} PRF values with ArrayBuffers.
+     */
+    _importPrfValues(values: PrfValuesJSON): PrfValuesBuffer;
+    /**
+     * Process extensions output (e.g., PRF) after the authenticator answers.
+     *
+     * @template {RegistrationResponseJSON | AuthenticationResponseJSON} T
+     * @param {T} credential WebAuthn credential.
+     * @returns {T} Processed credential.
+     */
+    _processExtensionsOutput<T extends RegistrationResponseJSON | AuthenticationResponseJSON>(credential: T): T;
+    /**
+     * Process PRF output by encoding ArrayBuffers to base64url strings.
+     *
+     * @param {Record<string, any>} prf PRF extension result.
+     * @returns {Record<string, any>} Processed PRF result.
+     */
+    _processPrfOutput(prf: Record<string, any>): Record<string, any>;
+    /**
+     * Export PRF values from ArrayBuffer to base64url strings.
+     *
+     * @param {PrfValuesBuffer} values PRF values with ArrayBuffers.
+     * @returns {PrfValuesJSON} PRF values with base64url strings.
+     */
+    _exportPrfValues(values: PrfValuesBuffer): PrfValuesJSON;
+    /**
+     * Dispatch a bubbling custom event from the controller element.
+     *
+     * @param {string} name Event name.
+     * @param {Record<string, unknown>} payload Event detail payload.
+     */
+    _dispatchEvent(name: string, payload: Record<string, unknown>): void;
+}
+export type PublicKeyCredentialCreationOptionsJSON = import("@simplewebauthn/browser").PublicKeyCredentialCreationOptionsJSON;
+export type PublicKeyCredentialRequestOptionsJSON = import("@simplewebauthn/browser").PublicKeyCredentialRequestOptionsJSON;
+export type RegistrationResponseJSON = import("@simplewebauthn/browser").RegistrationResponseJSON;
+export type AuthenticationResponseJSON = import("@simplewebauthn/browser").AuthenticationResponseJSON;
+export type FieldTargetMapping = {
+    /**
+     * Form data key to extract.
+     */
+    name: string;
+    /**
+     * Stimulus target name (without the `Target` suffix).
+     */
+    targetName: string;
+};
+export type PrfValuesJSON = {
+    /**
+     * Base64url-encoded first value.
+     */
+    first: string;
+    /**
+     * Base64url-encoded second value (optional).
+     */
+    second?: string;
+};
+export type PrfValuesBuffer = {
+    /**
+     * Decoded first value.
+     */
+    first: ArrayBuffer;
+    /**
+     * Decoded second value (optional).
+     */
+    second?: ArrayBuffer;
+};
+import { Controller } from '@hotwired/stimulus';

--- a/src/stimulus/assets/src/base-controller.js
+++ b/src/stimulus/assets/src/base-controller.js
@@ -4,13 +4,38 @@ import { Controller } from '@hotwired/stimulus';
 import { base64URLStringToBuffer, bufferToBase64URLString } from '@simplewebauthn/browser';
 
 /**
- * Base controller for WebAuthn operations
- * Contains shared logic for authentication and registration controllers
- *
- * @property {Object} requestHeadersValue - HTTP headers for requests
- * @property {boolean} hasRequestHeadersValue - Whether requestHeaders value is set
+ * @typedef {import('@simplewebauthn/browser').PublicKeyCredentialCreationOptionsJSON} PublicKeyCredentialCreationOptionsJSON
+ * @typedef {import('@simplewebauthn/browser').PublicKeyCredentialRequestOptionsJSON} PublicKeyCredentialRequestOptionsJSON
+ * @typedef {import('@simplewebauthn/browser').RegistrationResponseJSON} RegistrationResponseJSON
+ * @typedef {import('@simplewebauthn/browser').AuthenticationResponseJSON} AuthenticationResponseJSON
  */
-export default class extends Controller {
+
+/**
+ * @typedef {Object} FieldTargetMapping
+ * @property {string} name Form data key to extract.
+ * @property {string} targetName Stimulus target name (without the `Target` suffix).
+ */
+
+/**
+ * @typedef {Object} PrfValuesJSON
+ * @property {string} first Base64url-encoded first value.
+ * @property {string} [second] Base64url-encoded second value (optional).
+ */
+
+/**
+ * @typedef {Object} PrfValuesBuffer
+ * @property {ArrayBuffer} first Decoded first value.
+ * @property {ArrayBuffer} [second] Decoded second value (optional).
+ */
+
+/**
+ * Base controller for WebAuthn operations.
+ *
+ * Contains shared logic for authentication and registration controllers.
+ *
+ * @abstract
+ */
+export default class BaseController extends Controller {
     static values = {
         requestHeaders: {
             type: Object,
@@ -22,11 +47,13 @@ export default class extends Controller {
     };
 
     /**
-     * Fetch options from the server
-     * @param {string} url - The URL to fetch options from
-     * @param {Object} formData - The form data to send
-     * @param {string} eventPrefix - Prefix for dispatched events
-     * @returns {Promise<Object|false>} The options object or false on error
+     * Fetch options from the server.
+     *
+     * @template {PublicKeyCredentialCreationOptionsJSON | PublicKeyCredentialRequestOptionsJSON} T
+     * @param {string} url The URL to fetch options from.
+     * @param {Record<string, unknown>} formData The form data to send as JSON body.
+     * @param {string} eventPrefix Prefix for dispatched events.
+     * @returns {Promise<T|false>} The options object or `false` on error.
      */
     async _fetchOptions(url, formData, eventPrefix) {
         this._dispatchEvent(`${eventPrefix}:options:request`, { data: formData });
@@ -54,11 +81,13 @@ export default class extends Controller {
     }
 
     /**
-     * Verify credential with the server
-     * @param {string} url - The URL to verify credential at
-     * @param {Object} credential - The credential to verify
-     * @param {string} eventPrefix - Prefix for dispatched events
-     * @returns {Promise<Object|false>} The verification result or false on error
+     * Verify credential with the server.
+     *
+     * @template T
+     * @param {string} url The URL to verify credential at.
+     * @param {RegistrationResponseJSON | AuthenticationResponseJSON} credential The credential to verify.
+     * @param {string} eventPrefix Prefix for dispatched events.
+     * @returns {Promise<T|false>} The verification result or `false` on error.
      */
     async _verifyCredential(url, credential, eventPrefix) {
         this._dispatchEvent(`${eventPrefix}:verify:request`, { credential });
@@ -86,9 +115,10 @@ export default class extends Controller {
     }
 
     /**
-     * Get form data and validate
-     * @param {Array<{name: string, targetName: string}>} fieldTargets - Field mappings
-     * @returns {Object|null} Form data or null if invalid
+     * Get form data and validate.
+     *
+     * @param {FieldTargetMapping[]} [fieldTargets] Field mappings.
+     * @returns {Record<string, unknown> | null} Form data, or `null` if the form is invalid.
      */
     _getFormData(fieldTargets = []) {
         if (!(this.element instanceof HTMLFormElement)) {
@@ -123,9 +153,10 @@ export default class extends Controller {
     }
 
     /**
-     * Remove empty values from object
-     * @param {Object} obj - Object to clean
-     * @returns {Object} Cleaned object
+     * Remove empty values from an object recursively.
+     *
+     * @param {Record<string, unknown>} obj Object to clean.
+     * @returns {Record<string, unknown>} Cleaned object.
      */
     _removeEmpty(obj) {
         return Object.entries(obj)
@@ -134,9 +165,11 @@ export default class extends Controller {
     }
 
     /**
-     * Process extensions input (e.g., PRF)
-     * @param {Object} options - WebAuthn options
-     * @returns {Object} Processed options
+     * Process extensions input (e.g., PRF) before passing options to the authenticator.
+     *
+     * @template {PublicKeyCredentialCreationOptionsJSON | PublicKeyCredentialRequestOptionsJSON} T
+     * @param {T} options WebAuthn options.
+     * @returns {T} Processed options.
      */
     _processExtensionsInput(options) {
         if (!options?.extensions) {
@@ -151,9 +184,10 @@ export default class extends Controller {
     }
 
     /**
-     * Process PRF input
-     * @param {Object} prf - PRF extension object
-     * @returns {Object} Processed PRF object
+     * Process PRF input by decoding base64url strings into ArrayBuffers.
+     *
+     * @param {Record<string, any>} prf PRF extension object.
+     * @returns {Record<string, any>} Processed PRF object.
      */
     _processPrfInput(prf) {
         if (prf.eval) {
@@ -170,9 +204,10 @@ export default class extends Controller {
     }
 
     /**
-     * Import PRF values from base64url strings to ArrayBuffer
-     * @param {Object} values - PRF values with base64url strings
-     * @returns {Object} PRF values with ArrayBuffers
+     * Import PRF values from base64url strings to ArrayBuffer.
+     *
+     * @param {PrfValuesJSON} values PRF values with base64url strings.
+     * @returns {PrfValuesBuffer} PRF values with ArrayBuffers.
      */
     _importPrfValues(values) {
         const result = { ...values };
@@ -184,9 +219,11 @@ export default class extends Controller {
     }
 
     /**
-     * Process extensions output (e.g., PRF)
-     * @param {Object} credential - WebAuthn credential
-     * @returns {Object} Processed credential
+     * Process extensions output (e.g., PRF) after the authenticator answers.
+     *
+     * @template {RegistrationResponseJSON | AuthenticationResponseJSON} T
+     * @param {T} credential WebAuthn credential.
+     * @returns {T} Processed credential.
      */
     _processExtensionsOutput(credential) {
         if (!credential?.clientExtensionResults) {
@@ -201,9 +238,10 @@ export default class extends Controller {
     }
 
     /**
-     * Process PRF output
-     * @param {Object} prf - PRF extension result
-     * @returns {Object} Processed PRF result
+     * Process PRF output by encoding ArrayBuffers to base64url strings.
+     *
+     * @param {Record<string, any>} prf PRF extension result.
+     * @returns {Record<string, any>} Processed PRF result.
      */
     _processPrfOutput(prf) {
         if (!prf.results) {
@@ -215,9 +253,10 @@ export default class extends Controller {
     }
 
     /**
-     * Export PRF values from ArrayBuffer to base64url strings
-     * @param {Object} values - PRF values with ArrayBuffers
-     * @returns {Object} PRF values with base64url strings
+     * Export PRF values from ArrayBuffer to base64url strings.
+     *
+     * @param {PrfValuesBuffer} values PRF values with ArrayBuffers.
+     * @returns {PrfValuesJSON} PRF values with base64url strings.
      */
     _exportPrfValues(values) {
         const result = { ...values };
@@ -229,9 +268,10 @@ export default class extends Controller {
     }
 
     /**
-     * Dispatch custom event
-     * @param {string} name - Event name
-     * @param {Object} payload - Event detail payload
+     * Dispatch a bubbling custom event from the controller element.
+     *
+     * @param {string} name Event name.
+     * @param {Record<string, unknown>} payload Event detail payload.
      */
     _dispatchEvent(name, payload) {
         this.element.dispatchEvent(new CustomEvent(name, { detail: payload, bubbles: true }));

--- a/src/stimulus/assets/src/controller.d.ts
+++ b/src/stimulus/assets/src/controller.d.ts
@@ -1,0 +1,196 @@
+/**
+ * @typedef {import('@simplewebauthn/browser').PublicKeyCredentialCreationOptionsJSON} PublicKeyCredentialCreationOptionsJSON
+ * @typedef {import('@simplewebauthn/browser').PublicKeyCredentialRequestOptionsJSON} PublicKeyCredentialRequestOptionsJSON
+ * @typedef {import('@simplewebauthn/browser').RegistrationResponseJSON} RegistrationResponseJSON
+ * @typedef {import('@simplewebauthn/browser').AuthenticationResponseJSON} AuthenticationResponseJSON
+ */
+/**
+ * Legacy combined WebAuthn Stimulus controller.
+ *
+ * Handles both registration (`signup`) and authentication (`signin`) on the same element.
+ * New integrations should prefer the dedicated {@link AuthenticationController} and
+ * {@link RegistrationController} controllers.
+ *
+ * @deprecated since 5.3.0, kept for backward compatibility. Will be removed in 6.0.
+ */
+export default class WebauthnController extends Controller<Element> {
+    static values: {
+        requestResultUrl: {
+            type: StringConstructor;
+            default: string;
+        };
+        requestOptionsUrl: {
+            type: StringConstructor;
+            default: string;
+        };
+        requestResultField: {
+            type: StringConstructor;
+            default: any;
+        };
+        requestSuccessRedirectUri: StringConstructor;
+        creationResultUrl: {
+            type: StringConstructor;
+            default: string;
+        };
+        creationOptionsUrl: {
+            type: StringConstructor;
+            default: string;
+        };
+        creationResultField: {
+            type: StringConstructor;
+            default: any;
+        };
+        creationSuccessRedirectUri: StringConstructor;
+        usernameField: {
+            type: StringConstructor;
+            default: string;
+        };
+        displayNameField: {
+            type: StringConstructor;
+            default: string;
+        };
+        attestationField: {
+            type: StringConstructor;
+            default: string;
+        };
+        userVerificationField: {
+            type: StringConstructor;
+            default: string;
+        };
+        residentKeyField: {
+            type: StringConstructor;
+            default: string;
+        };
+        authenticatorAttachmentField: {
+            type: StringConstructor;
+            default: string;
+        };
+        useBrowserAutofill: {
+            type: BooleanConstructor;
+            default: boolean;
+        };
+        requestHeaders: {
+            type: ObjectConstructor;
+            default: {
+                'Content-Type': string;
+                Accept: string;
+                mode: string;
+                credentials: string;
+            };
+        };
+    };
+    constructor(context: import("@hotwired/stimulus").Context);
+    connect: () => Promise<void>;
+    /**
+     * Authenticate the user (assertion ceremony).
+     *
+     * @param {Event} event Form submit event.
+     * @returns {Promise<void>}
+     */
+    signin(event: Event): Promise<void>;
+    /**
+     * @private
+     * @param {PublicKeyCredentialRequestOptionsJSON} optionsResponseJson
+     * @param {boolean} useBrowserAutofill
+     * @returns {Promise<void>}
+     */
+    private _processSignin;
+    /**
+     * Register a new credential (attestation ceremony).
+     *
+     * @param {Event} event Form submit event.
+     * @returns {Promise<void>}
+     */
+    signup(event: Event): Promise<void>;
+    /**
+     * @private
+     * @param {string} name
+     * @param {Record<string, unknown>} payload
+     */
+    private _dispatchEvent;
+    /**
+     * @private
+     * @returns {Record<string, unknown> | undefined}
+     */
+    private _getData;
+    /**
+     * @private
+     * @param {Record<string, unknown> | null} formData
+     * @returns {Promise<PublicKeyCredentialRequestOptionsJSON | false>}
+     */
+    private _getPublicKeyCredentialRequestOptions;
+    /**
+     * @private
+     * @param {Record<string, unknown> | null} formData
+     * @returns {Promise<PublicKeyCredentialCreationOptionsJSON | false>}
+     */
+    private _getPublicKeyCredentialCreationOptions;
+    /**
+     * @private
+     * @template T
+     * @param {string} url
+     * @param {Record<string, unknown> | null} formData
+     * @returns {Promise<T | false>}
+     */
+    private _getOptions;
+    /**
+     * @private
+     * @param {RegistrationResponseJSON} authenticatorResponse
+     */
+    private _getAttestationResponse;
+    /**
+     * @private
+     * @param {AuthenticationResponseJSON} authenticatorResponse
+     */
+    private _getAssertionResponse;
+    /**
+     * @private
+     * @param {string} url
+     * @param {string} eventPrefix
+     * @param {RegistrationResponseJSON | AuthenticationResponseJSON} authenticatorResponse
+     */
+    private _getResult;
+    /**
+     * @private
+     * @template {PublicKeyCredentialCreationOptionsJSON | PublicKeyCredentialRequestOptionsJSON} T
+     * @param {T} options
+     * @returns {T}
+     */
+    private _processExtensionsInput;
+    /**
+     * @private
+     * @param {Record<string, any>} prf
+     * @returns {Record<string, any>}
+     */
+    private _processPrfInput;
+    /**
+     * @private
+     * @param {{ first: string, second?: string }} values
+     * @returns {{ first: ArrayBuffer, second?: ArrayBuffer }}
+     */
+    private _importPrfValues;
+    /**
+     * @private
+     * @template {RegistrationResponseJSON | AuthenticationResponseJSON} T
+     * @param {T} options
+     * @returns {T}
+     */
+    private _processExtensionsOutput;
+    /**
+     * @private
+     * @param {Record<string, any>} prf
+     * @returns {Record<string, any>}
+     */
+    private _processPrfOutput;
+    /**
+     * @private
+     * @param {{ first: ArrayBuffer, second?: ArrayBuffer }} values
+     * @returns {{ first: string, second?: string }}
+     */
+    private _exportPrfValues;
+}
+export type PublicKeyCredentialCreationOptionsJSON = import("@simplewebauthn/browser").PublicKeyCredentialCreationOptionsJSON;
+export type PublicKeyCredentialRequestOptionsJSON = import("@simplewebauthn/browser").PublicKeyCredentialRequestOptionsJSON;
+export type RegistrationResponseJSON = import("@simplewebauthn/browser").RegistrationResponseJSON;
+export type AuthenticationResponseJSON = import("@simplewebauthn/browser").AuthenticationResponseJSON;
+import { Controller } from '@hotwired/stimulus';

--- a/src/stimulus/assets/src/controller.js
+++ b/src/stimulus/assets/src/controller.js
@@ -10,7 +10,23 @@ import {
     bufferToBase64URLString,
 } from '@simplewebauthn/browser';
 
-export default class extends Controller {
+/**
+ * @typedef {import('@simplewebauthn/browser').PublicKeyCredentialCreationOptionsJSON} PublicKeyCredentialCreationOptionsJSON
+ * @typedef {import('@simplewebauthn/browser').PublicKeyCredentialRequestOptionsJSON} PublicKeyCredentialRequestOptionsJSON
+ * @typedef {import('@simplewebauthn/browser').RegistrationResponseJSON} RegistrationResponseJSON
+ * @typedef {import('@simplewebauthn/browser').AuthenticationResponseJSON} AuthenticationResponseJSON
+ */
+
+/**
+ * Legacy combined WebAuthn Stimulus controller.
+ *
+ * Handles both registration (`signup`) and authentication (`signin`) on the same element.
+ * New integrations should prefer the dedicated {@link AuthenticationController} and
+ * {@link RegistrationController} controllers.
+ *
+ * @deprecated since 5.3.0, kept for backward compatibility. Will be removed in 6.0.
+ */
+export default class WebauthnController extends Controller {
     static values = {
         requestResultUrl: { type: String, default: '/request' },
         requestOptionsUrl: { type: String, default: '/request/options' },
@@ -62,6 +78,12 @@ export default class extends Controller {
         }
     };
 
+    /**
+     * Authenticate the user (assertion ceremony).
+     *
+     * @param {Event} event Form submit event.
+     * @returns {Promise<void>}
+     */
     async signin(event) {
         if (!browserSupportsWebAuthn()) {
             this._dispatchEvent('webauthn:unsupported', {});
@@ -75,6 +97,12 @@ export default class extends Controller {
         this._processSignin(optionsResponseJson, false);
     }
 
+    /**
+     * @private
+     * @param {PublicKeyCredentialRequestOptionsJSON} optionsResponseJson
+     * @param {boolean} useBrowserAutofill
+     * @returns {Promise<void>}
+     */
     async _processSignin(optionsResponseJson, useBrowserAutofill) {
         try {
             optionsResponseJson = this._processExtensionsInput(optionsResponseJson);
@@ -102,6 +130,12 @@ export default class extends Controller {
         }
     }
 
+    /**
+     * Register a new credential (attestation ceremony).
+     *
+     * @param {Event} event Form submit event.
+     * @returns {Promise<void>}
+     */
     async signup(event) {
         try {
             if (!browserSupportsWebAuthn()) {
@@ -136,10 +170,19 @@ export default class extends Controller {
         }
     }
 
+    /**
+     * @private
+     * @param {string} name
+     * @param {Record<string, unknown>} payload
+     */
     _dispatchEvent(name, payload) {
         this.element.dispatchEvent(new CustomEvent(name, { detail: payload, bubbles: true }));
     }
 
+    /**
+     * @private
+     * @returns {Record<string, unknown> | undefined}
+     */
     _getData() {
         let data = new FormData();
         try {
@@ -168,14 +211,31 @@ export default class extends Controller {
         });
     }
 
+    /**
+     * @private
+     * @param {Record<string, unknown> | null} formData
+     * @returns {Promise<PublicKeyCredentialRequestOptionsJSON | false>}
+     */
     async _getPublicKeyCredentialRequestOptions(formData) {
         return this._getOptions(this.requestOptionsUrlValue, formData);
     }
 
+    /**
+     * @private
+     * @param {Record<string, unknown> | null} formData
+     * @returns {Promise<PublicKeyCredentialCreationOptionsJSON | false>}
+     */
     async _getPublicKeyCredentialCreationOptions(formData) {
         return this._getOptions(this.creationOptionsUrlValue, formData);
     }
 
+    /**
+     * @private
+     * @template T
+     * @param {string} url
+     * @param {Record<string, unknown> | null} formData
+     * @returns {Promise<T | false>}
+     */
     async _getOptions(url, formData) {
         const data = formData || this._getData();
         if (!data) {
@@ -199,14 +259,28 @@ export default class extends Controller {
         return options;
     }
 
+    /**
+     * @private
+     * @param {RegistrationResponseJSON} authenticatorResponse
+     */
     async _getAttestationResponse(authenticatorResponse) {
         return this._getResult(this.creationResultUrlValue, 'webauthn:attestation:', authenticatorResponse);
     }
 
+    /**
+     * @private
+     * @param {AuthenticationResponseJSON} authenticatorResponse
+     */
     async _getAssertionResponse(authenticatorResponse) {
         return this._getResult(this.requestResultUrlValue, 'webauthn:assertion:', authenticatorResponse);
     }
 
+    /**
+     * @private
+     * @param {string} url
+     * @param {string} eventPrefix
+     * @param {RegistrationResponseJSON | AuthenticationResponseJSON} authenticatorResponse
+     */
     async _getResult(url, eventPrefix, authenticatorResponse) {
         const attestationResponse = await fetch(url, {
             headers: { ...this.requestHeadersValue },
@@ -223,6 +297,12 @@ export default class extends Controller {
         return attestationResponseJSON;
     }
 
+    /**
+     * @private
+     * @template {PublicKeyCredentialCreationOptionsJSON | PublicKeyCredentialRequestOptionsJSON} T
+     * @param {T} options
+     * @returns {T}
+     */
     _processExtensionsInput(options) {
         if (!options || !options.extensions) {
             return options;
@@ -235,6 +315,11 @@ export default class extends Controller {
         return options;
     }
 
+    /**
+     * @private
+     * @param {Record<string, any>} prf
+     * @returns {Record<string, any>}
+     */
     _processPrfInput(prf) {
         if (prf.eval) {
             prf.eval = this._importPrfValues(eval);
@@ -249,6 +334,11 @@ export default class extends Controller {
         return prf;
     }
 
+    /**
+     * @private
+     * @param {{ first: string, second?: string }} values
+     * @returns {{ first: ArrayBuffer, second?: ArrayBuffer }}
+     */
     _importPrfValues(values) {
         values.first = base64URLStringToBuffer(values.first);
         if (values.second) {
@@ -258,6 +348,12 @@ export default class extends Controller {
         return values;
     }
 
+    /**
+     * @private
+     * @template {RegistrationResponseJSON | AuthenticationResponseJSON} T
+     * @param {T} options
+     * @returns {T}
+     */
     _processExtensionsOutput(options) {
         if (!options || !options.extensions) {
             return options;
@@ -270,6 +366,11 @@ export default class extends Controller {
         return options;
     }
 
+    /**
+     * @private
+     * @param {Record<string, any>} prf
+     * @returns {Record<string, any>}
+     */
     _processPrfOutput(prf) {
         if (!prf.result) {
             return prf;
@@ -280,6 +381,11 @@ export default class extends Controller {
         return prf;
     }
 
+    /**
+     * @private
+     * @param {{ first: ArrayBuffer, second?: ArrayBuffer }} values
+     * @returns {{ first: string, second?: string }}
+     */
     _exportPrfValues(values) {
         values.first = bufferToBase64URLString(values.first);
         if (values.second) {

--- a/src/stimulus/assets/src/index.d.ts
+++ b/src/stimulus/assets/src/index.d.ts
@@ -1,0 +1,4 @@
+export { default as AuthenticationController } from "./authentication-controller.js";
+export { default as RegistrationController } from "./registration-controller.js";
+export { default as WebauthnController } from "./controller.js";
+export { default as BaseController } from "./base-controller.js";

--- a/src/stimulus/assets/src/registration-controller.d.ts
+++ b/src/stimulus/assets/src/registration-controller.d.ts
@@ -1,0 +1,77 @@
+/**
+ * @typedef {import('@simplewebauthn/browser').PublicKeyCredentialCreationOptionsJSON} PublicKeyCredentialCreationOptionsJSON
+ * @typedef {import('@simplewebauthn/browser').RegistrationResponseJSON} RegistrationResponseJSON
+ */
+/**
+ * Stimulus controller for WebAuthn registration (credential creation).
+ *
+ * Usage:
+ * ```html
+ * <form data-controller="webauthn--registration"
+ *       data-webauthn--registration-options-url-value="/register/options"
+ *       data-webauthn--registration-result-url-value="/register/verify"
+ *       data-action="submit->webauthn--registration#register">
+ *   <input type="text" name="username" data-webauthn--registration-target="username">
+ *   <select name="attestation" data-webauthn--registration-target="attestation">
+ *     <option value="none">None</option>
+ *     <option value="direct">Direct</option>
+ *   </select>
+ *   <input type="hidden" data-webauthn--registration-target="result">
+ *   <button type="submit">Register</button>
+ * </form>
+ * ```
+ */
+export default class RegistrationController extends BaseController {
+    static values: {
+        optionsUrl: {
+            type: StringConstructor;
+            default: string;
+        };
+        resultUrl: {
+            type: StringConstructor;
+            default: string;
+        };
+        submitViaForm: {
+            type: BooleanConstructor;
+            default: boolean;
+        };
+        successRedirectUri: StringConstructor;
+        autoRegister: {
+            type: BooleanConstructor;
+            default: boolean;
+        };
+        requestHeaders: {
+            type: ObjectConstructor;
+            default: {
+                'Content-Type': string;
+                Accept: string;
+            };
+        };
+    };
+    connect(): Promise<void>;
+    /**
+     * Register a new WebAuthn credential.
+     *
+     * @param {Event} event Form submit event.
+     * @returns {Promise<void>}
+     */
+    register(event: Event): Promise<void>;
+    /**
+     * Start registration process.
+     *
+     * @private
+     * @returns {Promise<void>}
+     */
+    private _startRegistration;
+    /**
+     * Process registration with WebAuthn.
+     *
+     * @private
+     * @param {PublicKeyCredentialCreationOptionsJSON} options WebAuthn credential creation options.
+     * @returns {Promise<void>}
+     */
+    private _processRegistration;
+}
+export type PublicKeyCredentialCreationOptionsJSON = import("@simplewebauthn/browser").PublicKeyCredentialCreationOptionsJSON;
+export type RegistrationResponseJSON = import("@simplewebauthn/browser").RegistrationResponseJSON;
+import BaseController from './base-controller.js';

--- a/src/stimulus/assets/src/registration-controller.js
+++ b/src/stimulus/assets/src/registration-controller.js
@@ -10,9 +10,15 @@ import {
 import BaseController from './base-controller.js';
 
 /**
- * Stimulus controller for WebAuthn registration (credential creation)
+ * @typedef {import('@simplewebauthn/browser').PublicKeyCredentialCreationOptionsJSON} PublicKeyCredentialCreationOptionsJSON
+ * @typedef {import('@simplewebauthn/browser').RegistrationResponseJSON} RegistrationResponseJSON
+ */
+
+/**
+ * Stimulus controller for WebAuthn registration (credential creation).
  *
  * Usage:
+ * ```html
  * <form data-controller="webauthn--registration"
  *       data-webauthn--registration-options-url-value="/register/options"
  *       data-webauthn--registration-result-url-value="/register/verify"
@@ -25,32 +31,9 @@ import BaseController from './base-controller.js';
  *   <input type="hidden" data-webauthn--registration-target="result">
  *   <button type="submit">Register</button>
  * </form>
- *
- * @property {HTMLInputElement} usernameTarget - Username input element
- * @property {boolean} hasUsernameTarget - Whether username target exists
- * @property {HTMLSelectElement} attestationTarget - Attestation select element
- * @property {boolean} hasAttestationTarget - Whether attestation target exists
- * @property {HTMLSelectElement} residentKeyTarget - Resident key select element
- * @property {boolean} hasResidentKeyTarget - Whether residentKey target exists
- * @property {HTMLSelectElement} userVerificationTarget - User verification select element
- * @property {boolean} hasUserVerificationTarget - Whether userVerification target exists
- * @property {HTMLSelectElement} authenticatorAttachmentTarget - Authenticator attachment select element
- * @property {boolean} hasAuthenticatorAttachmentTarget - Whether authenticatorAttachment target exists
- * @property {HTMLInputElement} resultTarget - Result hidden input element
- * @property {boolean} hasResultTarget - Whether result target exists
- *
- * @property {string} optionsUrlValue - URL to fetch registration options from
- * @property {boolean} hasOptionsUrlValue - Whether optionsUrl value is set
- * @property {string} resultUrlValue - URL to verify registration result at
- * @property {boolean} hasResultUrlValue - Whether resultUrl value is set
- * @property {boolean} submitViaFormValue - Whether to submit credential via form instead of API
- * @property {boolean} hasSubmitViaFormValue - Whether submitViaForm value is set
- * @property {string} successRedirectUriValue - URI to redirect to on success
- * @property {boolean} hasSuccessRedirectUriValue - Whether successRedirectUri value is set
- * @property {boolean} autoRegisterValue - Whether to use auto-register (conditional create)
- * @property {boolean} hasAutoRegisterValue - Whether autoRegister value is set
+ * ```
  */
-export default class extends BaseController {
+export default class RegistrationController extends BaseController {
     static targets = [
         'username',
         'attestation',
@@ -84,8 +67,10 @@ export default class extends BaseController {
     }
 
     /**
-     * Register a new WebAuthn credential
-     * @param {Event} event - Form submit event
+     * Register a new WebAuthn credential.
+     *
+     * @param {Event} event Form submit event.
+     * @returns {Promise<void>}
      */
     async register(event) {
         event.preventDefault();
@@ -99,8 +84,10 @@ export default class extends BaseController {
     }
 
     /**
-     * Start registration process
+     * Start registration process.
+     *
      * @private
+     * @returns {Promise<void>}
      */
     async _startRegistration() {
         const formData = this._getFormData([
@@ -124,9 +111,11 @@ export default class extends BaseController {
     }
 
     /**
-     * Process registration with WebAuthn
+     * Process registration with WebAuthn.
+     *
      * @private
-     * @param {Object} options - WebAuthn credential creation options
+     * @param {PublicKeyCredentialCreationOptionsJSON} options WebAuthn credential creation options.
+     * @returns {Promise<void>}
      */
     async _processRegistration(options) {
         try {

--- a/src/stimulus/assets/tsconfig.json
+++ b/src/stimulus/assets/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "lib": ["ES2020", "DOM"],
+        "allowJs": true,
+        "checkJs": false,
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "strict": false,
+        "skipLibCheck": true,
+        "esModuleInterop": true,
+        "resolveJsonModule": true,
+        "isolatedModules": true
+    },
+    "include": ["src/**/*.js"],
+    "exclude": ["node_modules", "src/**/*.d.ts"]
+}


### PR DESCRIPTION
## Summary

Closes #890.

The `@web-auth/webauthn-stimulus` npm package now ships ambient TypeScript declarations, so consumers get autocomplete and type checking out of the box without any extra dependency.

The `.d.ts` files are generated from the existing JSDoc via `tsc --declaration --allowJs --emitDeclarationOnly`, which keeps the types in sync with the JavaScript source. They are also regenerated on `npm publish` via a `prepublishOnly` hook.

## Changes

- add `tsconfig.json`, a `build:types` script and a `prepublishOnly` hook in `src/stimulus/assets`, plus a `typescript ^5.0.0` devDependency
- name the previously anonymous controller classes so the emitted `.d.ts` expose `BaseController`, `AuthenticationController`, `RegistrationController` and `WebauthnController` instead of `_default`
- refine JSDoc on the public surface with the `@simplewebauthn/browser` types (`PublicKeyCredentialCreationOptionsJSON`, `RegistrationResponseJSON`, `StartAuthenticationOpts`, etc.)
- expose `types: "src/index.d.ts"` on the published package
- mention TypeScript readiness in the package README (drive-by absorbing a pre-existing prettier warning on the same file)