### PR TITLE
fix(creation-profiles): default rp.name to rp.id when empty (#893)

### DIFF
--- a/src/symfony/src/Service/PublicKeyCredentialCreationOptionsFactory.php
+++ b/src/symfony/src/Service/PublicKeyCredentialCreationOptionsFactory.php
@@ -125,11 +125,22 @@ final class PublicKeyCredentialCreationOptionsFactory implements CanDispatchEven
     }
 
     /**
+     * Per W3C IDL, `PublicKeyCredentialEntity.name` is required. When the deprecated
+     * `webauthn.creation_profiles.*.rp.name` node is omitted, the configuration default is an
+     * empty string and SimpleWebAuthn's browser bindings refuse to call
+     * `navigator.credentials.create()`. Falling back to the `id` (a human-readable hostname)
+     * keeps the JSON well-formed for callers that already dropped the deprecated node.
+     *
      * @param array{rp: array{name: string, id: ?string}} $profile
      */
     private function createRpEntity(array $profile): PublicKeyCredentialRpEntity
     {
-        return PublicKeyCredentialRpEntity::create($profile['rp']['name'], $profile['rp']['id']);
+        $name = $profile['rp']['name'];
+        if ($name === '') {
+            $name = (string) $profile['rp']['id'];
+        }
+
+        return PublicKeyCredentialRpEntity::create($name, $profile['rp']['id']);
     }
 
     /**

--- a/tests/symfony/unit/Issue893RegressionTest.php
+++ b/tests/symfony/unit/Issue893RegressionTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Bundle\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Webauthn\Bundle\Service\PublicKeyCredentialCreationOptionsFactory;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+/**
+ * Issue #893: dropping the deprecated `webauthn.creation_profiles.*.rp.name` node from the bundle
+ * configuration (as instructed by the 5.3.0 deprecation message) made the bundle emit
+ * `rp.name = ""`. SimpleWebAuthn's browser bindings refuse to call
+ * `navigator.credentials.create()` when `rp.name` is empty (per W3C IDL it is required),
+ * so adding authenticators to existing users silently failed. The factory now falls back to
+ * the configured `rp.id` whenever the name is empty.
+ *
+ * @see https://github.com/web-auth/webauthn-framework/issues/893
+ * @internal
+ */
+final class Issue893RegressionTest extends TestCase
+{
+    #[Test]
+    public function rpNameFallsBackToRpIdWhenNameIsEmpty(): void
+    {
+        $factory = new PublicKeyCredentialCreationOptionsFactory($this->profiles(rpName: '', rpId: 'example.com'));
+
+        $options = $factory->create('default', $this->userEntity());
+
+        static::assertSame('example.com', $options->rp->name);
+        static::assertSame('example.com', $options->rp->id);
+    }
+
+    #[Test]
+    public function rpNameIsPreservedWhenExplicitlyConfigured(): void
+    {
+        $factory = new PublicKeyCredentialCreationOptionsFactory(
+            $this->profiles(rpName: 'My Application', rpId: 'example.com')
+        );
+
+        $options = $factory->create('default', $this->userEntity());
+
+        static::assertSame('My Application', $options->rp->name);
+        static::assertSame('example.com', $options->rp->id);
+    }
+
+    #[Test]
+    public function rpNameFallbackProducesEmptyStringWhenRpIdIsAlsoNull(): void
+    {
+        $factory = new PublicKeyCredentialCreationOptionsFactory($this->profiles(rpName: '', rpId: null));
+
+        $options = $factory->create('default', $this->userEntity());
+
+        static::assertSame('', $options->rp->name);
+        static::assertNull($options->rp->id);
+    }
+
+    /**
+     * @return array<string, array{rp: array{name: string, id: ?string}, challenge_length: int, attestation_conveyance: ?string, authenticator_selection_criteria: array{authenticator_attachment: ?string, user_verification: ?string, resident_key: ?string}, public_key_credential_parameters: list<int>, extensions: array<string, mixed>, conditional_create: bool}>
+     */
+    private function profiles(string $rpName, ?string $rpId): array
+    {
+        return [
+            'default' => [
+                'rp' => [
+                    'name' => $rpName,
+                    'id' => $rpId,
+                ],
+                'challenge_length' => 32,
+                'attestation_conveyance' => null,
+                'authenticator_selection_criteria' => [
+                    'authenticator_attachment' => null,
+                    'user_verification' => 'preferred',
+                    'resident_key' => null,
+                ],
+                'public_key_credential_parameters' => [-7],
+                'extensions' => [],
+                'conditional_create' => false,
+            ],
+        ];
+    }
+
+    private function userEntity(): PublicKeyCredentialUserEntity
+    {
+        return PublicKeyCredentialUserEntity::create('alice', 'uid-alice', 'Alice');
+    }
+}


### PR DESCRIPTION
## Summary

Refs #893 (the framework side; the documentation legs are tracked in web-auth/doc#57, web-auth/doc#58 and web-auth/doc#59).

Per W3C IDL, `PublicKeyCredentialEntity.name` is **required**:

```webidl
dictionary PublicKeyCredentialEntity {
    required DOMString name;
};
```

The 5.3.0 release deprecated the `webauthn.creation_profiles.*.rp.name` configuration node. When users follow the deprecation message and remove the node, the configuration default falls back to `''`, so `PublicKeyCredentialCreationOptionsFactory::createRpEntity` produced `{"rp": {"name": "", "id": "..."}}`.

Recent Chrome / Firefox builds tolerate the empty name and fall back to the eTLD+1, but **SimpleWebAuthn's browser bindings** (`@simplewebauthn/browser@13.x`, pulled in by `@web-auth/webauthn-stimulus@5.3.x`) refuse to call `navigator.credentials.create()` when `rp.name` is empty: the registration silently fails after the options endpoint returns 200.

## Fix

When the configured `rp.name` is an empty string, fall back to the `rp.id`. The id is a human-readable hostname and is therefore a sensible default display label, and the JSON now always carries a non-empty name.

This mirrors the equivalent fix on the 5.4 helper API in #889.

## BC

Strictly additive on the runtime serialisation side: profiles that still configure a non-empty `rp.name` are unchanged, and the deprecated node keeps emitting the same deprecation warning at config-build time.