### PR TITLE
docs(examples): add basic, usernameless, passkey-upgrade and signal-api pure-PHP demos (#649)

### DIFF
--- a/docs/examples/basic-demo/.gitignore
+++ b/docs/examples/basic-demo/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+/var/*.json
+composer.lock

--- a/docs/examples/basic-demo/README.md
+++ b/docs/examples/basic-demo/README.md
@@ -1,0 +1,128 @@
+# Basic Demo, `web-auth/webauthn-lib`
+
+A minimal end-to-end pure-PHP example of a username-based passkey login,
+using only `web-auth/webauthn-lib` (no Symfony bundle, no Doctrine). The
+demo runs on the PHP built-in web server and persists everything to JSON
+files under `var/`. It exists to answer the most common question raised on
+[issue #649](https://github.com/web-auth/webauthn-framework/issues/649):
+
+> What do I actually have to wire up, and what do I have to store?
+
+## Four pages, three flows
+
+| Page | What it does |
+|---|---|
+| [`/`](same-origin/public/index.html) | Landing page, shows whether you are signed in and links to the other pages. |
+| [`/register.html`](same-origin/public/register.html) | Creates a brand-new account secured by a passkey. The page calls `navigator.credentials.create()`, the server validates the attestation with `AuthenticatorAttestationResponseValidator` and persists a `CredentialRecord` bound to the user handle. |
+| [`/login.html`](same-origin/public/login.html) | Authenticates an existing account. The page calls `navigator.credentials.get()` with a server-issued `allowCredentials` list, the server validates the assertion with `AuthenticatorAssertionResponseValidator`, updates the counter and opens a PHP session. |
+| [`/account.html`](same-origin/public/account.html) | Protected page. Lists registered passkeys (label, AAGUID, counter, backup state, last used), lets you add another passkey on the current account (`excludeCredentials` pre-filled), rename a passkey or delete one. The last passkey of an account cannot be deleted. |
+
+## What this demo demonstrates
+
+- **The four endpoints** every relying party needs:
+  `POST /api/register/options`, `POST /api/register/verify`,
+  `POST /api/login/options`, `POST /api/login/verify`.
+- **What to store** after a successful registration: the framework's
+  `CredentialRecord` serialized to JSON, plus the user handle binding and
+  any application metadata (label, timestamps). See
+  [`src/CredentialStore.php`](src/CredentialStore.php) for the canonical
+  shape.
+- **What to update** after a successful assertion: the same
+  `CredentialRecord`, because the validator mutates the counter and the
+  backup flags in place. Persisting the updated record is what makes the
+  W3C clone-detection rule work over time.
+- **How to enrol additional passkeys** on an existing account, with
+  `excludeCredentials` pre-filled so the user agent refuses to register
+  the same authenticator twice.
+- **The "last passkey" rule**: a relying party without an account-recovery
+  fallback (password, magic link, ...) MUST refuse to delete the last
+  passkey of an account, otherwise losing it locks the user out for good.
+
+```
++------------------+     POST /api/register/options       +----------------------+
+|  register.html   | ----------------------------------->  |  router.php (RP)     |
+|  (browser)       | <---------- creation options -------  |  - serializer       |
+|                  |                                       |  - validators        |
+|                  |     POST /api/register/verify         |  - UserStore         |
+|                  | ----------------------------------->  |  - CredentialStore   |
++------------------+                                       +----------------------+
+
++------------------+     POST /api/login/options          +----------------------+
+|  login.html      | ----------------------------------->  |  allowCredentials    |
+|  (browser)       | <-------- request options ---------   |  pre-filled per user |
+|                  |     POST /api/login/verify            |                      |
+|                  | ----------------------------------->  |  updates counter +   |
+|                  |                                       |  opens PHP session   |
++------------------+                                       +----------------------+
+```
+
+## Run it
+
+```bash
+cd docs/examples/basic-demo
+./same-origin/run.sh
+```
+
+The script `composer install`s on first run and boots the demo on
+<http://localhost:8000>. The shipped `composer.json` symlinks
+`web-auth/webauthn-framework` from this checkout (`../../..`). To run
+against a published `^5.4` release once one exists, swap the path-repo
+block for the standard packagist `web-auth/webauthn-lib` requirement.
+
+Open <http://localhost:8000> in a browser with passkey support:
+
+- A platform authenticator (Touch ID, Windows Hello, Android device
+  unlock) or a roaming hardware key.
+- A secure context. `localhost` qualifies; otherwise serve over HTTPS.
+
+Walk through the pages in order:
+
+1. <http://localhost:8000/register.html>, register a passkey on a fresh
+   account, you are redirected to `/account.html` automatically.
+2. (Optional) hit *Sign out* on `/account.html`, then
+   <http://localhost:8000/login.html> to authenticate again with the same
+   passkey.
+3. <http://localhost:8000/account.html>, click *Add another passkey* to
+   enrol a second device on the same account, then try renaming and
+   deleting passkeys.
+
+## What lives in `var/`
+
+State is persisted to two JSON files so the demo survives across HTTP
+requests with `php -S`:
+
+- `var/users.json`: `username -> { userHandle, displayName, createdAt }`.
+- `var/credentials.json`: `credentialId -> { userHandle, credentialId,
+  source, label, addedAt, lastUsedAt }`. The `source` field holds the
+  whole `CredentialRecord` JSON, which is the only blob the framework
+  needs to verify the next assertion.
+
+Delete the two JSON files to reset the demo.
+
+## What this demo deliberately leaves out
+
+- A real database. Production code MUST plug
+  `Webauthn\CredentialRecordRepositoryInterface` and (optionally)
+  `Webauthn\CanSaveCredentialRecord` against a real persistence layer.
+  The Symfony bundle ships a Doctrine implementation
+  (`DoctrineCredentialSourceRepository`) that doubles as a reference.
+- **Account recovery.** Lose every registered passkey and the account is
+  unreachable. A production design needs a fallback: a second passkey
+  enrolled upfront, a password backup, an email magic link, ...
+- Email verification, password backup, CSRF protection, rate limiting,
+  attestation chain verification (the demo accepts the `none` format
+  only).
+- Multi-RP / cross-origin setups; see the `spc-demo` for cross-origin
+  patterns.
+
+## Where to look in the code
+
+| What | File |
+|---|---|
+| Service wiring (serializer, validators, allowed origins) | [`src/bootstrap.php`](src/bootstrap.php) |
+| User table (username -> userHandle mapping) | [`src/UserStore.php`](src/UserStore.php) |
+| Credential persistence (the part that answers "what do I store?") | [`src/CredentialStore.php`](src/CredentialStore.php) |
+| All HTTP endpoints | [`same-origin/router.php`](same-origin/router.php) |
+| Browser side, attestation | [`same-origin/public/register.html`](same-origin/public/register.html) |
+| Browser side, assertion | [`same-origin/public/login.html`](same-origin/public/login.html) |
+| Browser side, account management | [`same-origin/public/account.html`](same-origin/public/account.html) |

--- a/docs/examples/basic-demo/composer.json
+++ b/docs/examples/basic-demo/composer.json
@@ -1,0 +1,30 @@
+{
+    "name": "web-auth/basic-demo",
+    "description": "End-to-end pure-PHP demo of a username-based passkey login (register + sign in + manage credentials) using web-auth/webauthn-lib",
+    "type": "project",
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../..",
+            "options": {
+                "symlink": true,
+                "versions": {
+                    "web-auth/webauthn-framework": "5.4.x-dev"
+                }
+            }
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "ext-json": "*",
+        "ext-openssl": "*",
+        "web-auth/webauthn-framework": "5.4.x-dev",
+        "symfony/clock": "^6.4 || ^7.0",
+        "symfony/serializer": "^6.4 || ^7.0",
+        "symfony/property-access": "^6.4 || ^7.0",
+        "symfony/property-info": "^6.4 || ^7.0",
+        "symfony/uid": "^6.4 || ^7.0"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/docs/examples/basic-demo/same-origin/public/account.html
+++ b/docs/examples/basic-demo/same-origin/public/account.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Basic Demo, My account</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 860px; margin: 40px auto; padding: 20px; color: #1f2937; line-height: 1.55; }
+        h1 { font-size: 1.5rem; }
+        h2 { font-size: 1.1rem; margin-top: 2rem; }
+        nav a { color: #2563eb; margin-right: 1rem; }
+        button { background: #2563eb; color: #fff; border: none; cursor: pointer; padding: 0.45rem 0.85rem; border-radius: 6px; font-size: 0.95rem; margin-right: 0.4rem; }
+        button.ghost { background: transparent; color: #2563eb; border: 1px solid #2563eb; }
+        button.danger { background: #b91c1c; }
+        button:disabled { background: #94a3b8; cursor: not-allowed; }
+        table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+        th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid #e5e7eb; font-size: 0.92rem; vertical-align: top; }
+        th { background: #f9fafb; }
+        td.label input { padding: 0.3rem 0.5rem; font-size: 0.9rem; border-radius: 4px; border: 1px solid #d1d5db; width: 100%; box-sizing: border-box; }
+        td.actions { white-space: nowrap; }
+        code { background: #f3f4f6; padding: 1px 6px; border-radius: 4px; font-size: 0.85rem; }
+        pre { background: #f3f4f6; padding: 12px; border-radius: 6px; overflow-x: auto; max-height: 200px; white-space: pre-wrap; word-break: break-all; }
+        .ok { color: #047857; }
+        .err { color: #b91c1c; }
+        .hidden { display: none; }
+    </style>
+</head>
+<body>
+<nav>
+    <a href="/">&larr; Home</a>
+    <a href="/register.html">Register a different account</a>
+</nav>
+
+<h1>My account</h1>
+
+<div id="unauthenticated" class="hidden">
+    <p class="err">You are not signed in.</p>
+    <p><a href="/login.html"><button>Sign in</button></a></p>
+</div>
+
+<div id="authenticated" class="hidden">
+    <p>Signed in as <strong id="username"></strong> (<span id="displayName"></span>).</p>
+    <p>
+        <button id="add-passkey">Add another passkey</button>
+        <button id="logout" class="ghost">Sign out</button>
+    </p>
+
+    <h2>Registered passkeys</h2>
+    <p>Each row maps to a stored <code>CredentialRecord</code>. The label is purely server-side metadata.</p>
+    <table id="passkeys">
+        <thead>
+        <tr>
+            <th>Label</th>
+            <th>Credential ID</th>
+            <th>AAGUID</th>
+            <th>Counter</th>
+            <th>Backup</th>
+            <th>Last used</th>
+            <th>Actions</th>
+        </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</div>
+
+<h2>Activity log</h2>
+<pre id="output">Loading account...</pre>
+
+<script type="module">
+    const output = document.getElementById('output');
+    const log = (msg, cls = '') => {
+        const line = document.createElement('div');
+        if (cls) line.className = cls;
+        line.textContent = msg;
+        output.appendChild(line);
+    };
+
+    const b64u = {
+        encode: (buf) => {
+            const bytes = new Uint8Array(buf);
+            let str = '';
+            for (let i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i]);
+            return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+        },
+        decode: (s) => {
+            s = s.replace(/-/g, '+').replace(/_/g, '/');
+            const pad = (4 - (s.length % 4)) % 4;
+            s += '='.repeat(pad);
+            const bin = atob(s);
+            const out = new Uint8Array(bin.length);
+            for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+            return out;
+        },
+    };
+
+    const toCreateOptions = (json) => {
+        const o = { ...json };
+        o.challenge = b64u.decode(json.challenge);
+        o.user = { ...json.user, id: b64u.decode(json.user.id) };
+        if (json.excludeCredentials) {
+            o.excludeCredentials = json.excludeCredentials.map((c) => ({
+                ...c,
+                id: b64u.decode(c.id),
+            }));
+        }
+        return o;
+    };
+
+    const credentialToJson = (cred, label) => ({
+        id: cred.id,
+        rawId: b64u.encode(cred.rawId),
+        type: cred.type,
+        response: {
+            clientDataJSON: b64u.encode(cred.response.clientDataJSON),
+            attestationObject: b64u.encode(cred.response.attestationObject),
+        },
+        clientExtensionResults: { demoLabel: label },
+    });
+
+    const formatDate = (ts) => ts ? new Date(ts * 1000).toLocaleString() : 'never';
+    const formatBackup = (eligible, status) => {
+        if (eligible === null || eligible === undefined) return 'unknown';
+        return `${eligible ? 'eligible' : 'not eligible'} / ${status ? 'backed up' : 'local only'}`;
+    };
+
+    const renderPasskeys = (credentials) => {
+        const tbody = document.querySelector('#passkeys tbody');
+        tbody.innerHTML = '';
+        const lastOne = credentials.length === 1;
+        credentials.forEach((c) => {
+            const tr = document.createElement('tr');
+            const credIdShort = c.credentialId.length > 22
+                ? c.credentialId.slice(0, 12) + '...' + c.credentialId.slice(-6)
+                : c.credentialId;
+            tr.innerHTML = `
+                <td class="label"><input type="text" value="${c.label.replace(/"/g, '&quot;')}" data-cred="${c.credentialId}"></td>
+                <td><code title="${c.credentialId}">${credIdShort}</code></td>
+                <td><code>${c.aaguid}</code></td>
+                <td>${c.counter}</td>
+                <td>${formatBackup(c.backupEligible, c.backupStatus)}</td>
+                <td>${formatDate(c.lastUsedAt)}</td>
+                <td class="actions">
+                    <button class="ghost" data-action="rename" data-cred="${c.credentialId}">Rename</button>
+                    <button class="danger" data-action="delete" data-cred="${c.credentialId}" ${lastOne ? 'disabled title="The last passkey of an account cannot be deleted in this demo."' : ''}>Delete</button>
+                </td>
+            `;
+            tbody.appendChild(tr);
+        });
+    };
+
+    const loadMe = async () => {
+        const r = await fetch('/api/me');
+        if (r.status === 401) {
+            document.getElementById('unauthenticated').classList.remove('hidden');
+            log('Not signed in.', 'err');
+            return null;
+        }
+        const me = await r.json();
+        document.getElementById('authenticated').classList.remove('hidden');
+        document.getElementById('username').textContent = me.username;
+        document.getElementById('displayName').textContent = me.displayName ?? '';
+        renderPasskeys(me.credentials);
+        log(`Loaded ${me.credentials.length} passkey(s) for ${me.username}.`, 'ok');
+        return me;
+    };
+
+    document.getElementById('logout').addEventListener('click', async () => {
+        await fetch('/api/logout', { method: 'POST' });
+        window.location.href = '/';
+    });
+
+    document.getElementById('add-passkey').addEventListener('click', async (e) => {
+        const btn = e.currentTarget;
+        btn.disabled = true;
+        try {
+            const label = window.prompt('Label for the new passkey (e.g. "my YubiKey"):') ?? '';
+            log('Asking server for add-passkey options...');
+            const optResp = await fetch('/api/account/passkey/add/options', { method: 'POST' });
+            if (!optResp.ok) throw new Error(`options HTTP ${optResp.status}: ${await optResp.text()}`);
+            const optsJson = await optResp.json();
+            log('Options received. Calling navigator.credentials.create()...', 'ok');
+
+            const credential = await navigator.credentials.create({ publicKey: toCreateOptions(optsJson) });
+            log('Credential created. POST /api/account/passkey/add/verify ...', 'ok');
+
+            const verifyResp = await fetch('/api/account/passkey/add/verify', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(credentialToJson(credential, label)),
+            });
+            if (!verifyResp.ok) throw new Error(`verify HTTP ${verifyResp.status}: ${await verifyResp.text()}`);
+            log('New passkey stored. Refreshing list...', 'ok');
+            await loadMe();
+        } catch (err) {
+            log(`Error: ${err.message}`, 'err');
+        } finally {
+            btn.disabled = false;
+        }
+    });
+
+    document.querySelector('#passkeys').addEventListener('click', async (e) => {
+        const btn = e.target.closest('button[data-action]');
+        if (!btn) return;
+        const credentialId = btn.dataset.cred;
+        const action = btn.dataset.action;
+        try {
+            if (action === 'rename') {
+                const input = document.querySelector(`input[data-cred="${CSS.escape(credentialId)}"]`);
+                const label = input?.value ?? '';
+                if (label.trim() === '') return;
+                const r = await fetch('/api/account/passkey/rename', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ credentialId, label }),
+                });
+                if (!r.ok) throw new Error(`rename HTTP ${r.status}: ${await r.text()}`);
+                log(`Renamed to "${label}".`, 'ok');
+            } else if (action === 'delete') {
+                if (!window.confirm('Delete this passkey?')) return;
+                const r = await fetch('/api/account/passkey/delete', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ credentialId }),
+                });
+                if (!r.ok) throw new Error(`delete HTTP ${r.status}: ${await r.text()}`);
+                log('Passkey deleted. Refreshing list...', 'ok');
+                await loadMe();
+            }
+        } catch (err) {
+            log(`Error: ${err.message}`, 'err');
+        }
+    });
+
+    output.textContent = '';
+    await loadMe();
+</script>
+</body>
+</html>

--- a/docs/examples/basic-demo/same-origin/public/index.html
+++ b/docs/examples/basic-demo/same-origin/public/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Basic WebAuthn Demo</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 720px; margin: 40px auto; padding: 20px; color: #1f2937; line-height: 1.55; }
+        h1 { font-size: 1.5rem; }
+        h2 { font-size: 1.1rem; margin-top: 2rem; }
+        a { color: #2563eb; }
+        .card { background: #f3f4f6; border-radius: 8px; padding: 16px 20px; margin: 1.2rem 0; }
+        .card h3 { margin-top: 0; font-size: 1rem; }
+        nav { margin-bottom: 2rem; }
+        nav a { margin-right: 1rem; }
+        code { background: #f3f4f6; padding: 1px 6px; border-radius: 4px; font-size: 0.9rem; }
+        .status { font-size: 0.95rem; padding: 10px 14px; border-radius: 6px; margin: 1rem 0; }
+        .status.logged-in { background: #d1fae5; color: #065f46; }
+        .status.logged-out { background: #fee2e2; color: #991b1b; }
+        button { background: #2563eb; color: #fff; border: none; cursor: pointer; padding: 0.45rem 0.85rem; border-radius: 6px; font-size: 0.95rem; }
+        button.ghost { background: transparent; color: #2563eb; border: 1px solid #2563eb; }
+    </style>
+</head>
+<body>
+
+<h1>Basic WebAuthn Demo</h1>
+<p>
+    Minimal end-to-end example of a username-based passkey login in pure PHP,
+    using <a href="https://github.com/web-auth/webauthn-framework"><code>web-auth/webauthn-lib</code></a>.
+    The whole demo runs on the built-in PHP web server, no database required.
+</p>
+
+<div id="status" class="status logged-out">Loading session state...</div>
+
+<div class="card">
+    <h3>1. Register a passkey</h3>
+    <p>Create a brand-new account secured by a passkey.</p>
+    <p><a href="/register.html"><button>Register a new account</button></a></p>
+</div>
+
+<div class="card">
+    <h3>2. Sign in</h3>
+    <p>Authenticate as an existing account using one of its registered passkeys.</p>
+    <p><a href="/login.html"><button>Sign in with a passkey</button></a></p>
+</div>
+
+<div class="card">
+    <h3>3. Manage passkeys</h3>
+    <p>Once signed in: list registered credentials, add another passkey (e.g. a second device), rename or delete.</p>
+    <p><a href="/account.html"><button class="ghost">Open my account</button></a></p>
+</div>
+
+<h2>What this demo demonstrates</h2>
+<ul>
+    <li>The four endpoints of a WebAuthn relying party: <code>/api/register/options</code>, <code>/api/register/verify</code>, <code>/api/login/options</code>, <code>/api/login/verify</code>.</li>
+    <li>What to actually store after a successful registration (the <code>CredentialRecord</code> blob plus a user binding).</li>
+    <li>How to update the stored record after every successful sign-in (counter, backup flags).</li>
+    <li>How to enrol additional passkeys on an existing account.</li>
+    <li>Why the relying party MUST refuse to delete the last passkey of an account.</li>
+</ul>
+
+<h2>What this demo deliberately leaves out</h2>
+<ul>
+    <li>A real database. Credentials live in a JSON file under <code>var/</code>.</li>
+    <li>Account recovery. Lose every registered passkey, lose the account.</li>
+    <li>Account email verification, password fallback, rate limiting, CSRF protection, ...</li>
+    <li>Production-grade attestation. The demo accepts the <code>none</code> attestation format only.</li>
+</ul>
+
+<script type="module">
+    const status = document.getElementById('status');
+
+    try {
+        const r = await fetch('/api/me');
+        const me = await r.json();
+        if (me.authenticated) {
+            status.className = 'status logged-in';
+            status.textContent = `Signed in as ${me.username} (${me.credentials.length} passkey(s) registered).`;
+        } else {
+            status.className = 'status logged-out';
+            status.textContent = 'Not signed in.';
+        }
+    } catch (e) {
+        status.className = 'status logged-out';
+        status.textContent = 'Session check failed: ' + e.message;
+    }
+</script>
+
+</body>
+</html>

--- a/docs/examples/basic-demo/same-origin/public/login.html
+++ b/docs/examples/basic-demo/same-origin/public/login.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Basic Demo, Sign in</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 720px; margin: 40px auto; padding: 20px; color: #1f2937; line-height: 1.55; }
+        h1 { font-size: 1.5rem; }
+        label { display: block; margin: 0.6rem 0 0.25rem; font-weight: 500; }
+        input, button { padding: 0.55rem 0.75rem; font-size: 1rem; border-radius: 6px; border: 1px solid #d1d5db; box-sizing: border-box; }
+        input { width: 100%; }
+        button { background: #2563eb; color: #fff; border: none; cursor: pointer; }
+        button:disabled { background: #94a3b8; cursor: not-allowed; }
+        pre { background: #f3f4f6; padding: 12px; border-radius: 6px; overflow-x: auto; max-height: 360px; white-space: pre-wrap; word-break: break-all; }
+        .ok { color: #047857; }
+        .err { color: #b91c1c; }
+        nav a { color: #2563eb; margin-right: 1rem; }
+    </style>
+</head>
+<body>
+<nav><a href="/">&larr; Home</a><a href="/register.html">Register a new account</a></nav>
+
+<h1>2. Sign in with a registered passkey</h1>
+
+<p>
+    The page asks the server for <code>PublicKeyCredentialRequestOptions</code>
+    scoped to the username (pre-filled <code>allowCredentials</code>), calls
+    <code>navigator.credentials.get()</code> and posts the assertion back for
+    validation. On success the server updates the credential counter and opens
+    a PHP session.
+</p>
+
+<form id="login-form">
+    <label for="username">Username (email)</label>
+    <input id="username" name="username" type="email" required value="jane.doe@example.com" autocomplete="username">
+
+    <p><button type="submit" id="submit">Sign in</button></p>
+</form>
+
+<h2>Output</h2>
+<pre id="output">Submit the form to start an assertion ceremony.</pre>
+
+<script type="module">
+    const form = document.getElementById('login-form');
+    const submit = document.getElementById('submit');
+    const output = document.getElementById('output');
+
+    const log = (msg, cls = '') => {
+        const line = document.createElement('div');
+        if (cls) line.className = cls;
+        line.textContent = msg;
+        output.appendChild(line);
+    };
+
+    const b64u = {
+        encode: (buf) => {
+            const bytes = new Uint8Array(buf);
+            let str = '';
+            for (let i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i]);
+            return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+        },
+        decode: (s) => {
+            s = s.replace(/-/g, '+').replace(/_/g, '/');
+            const pad = (4 - (s.length % 4)) % 4;
+            s += '='.repeat(pad);
+            const bin = atob(s);
+            const out = new Uint8Array(bin.length);
+            for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+            return out;
+        },
+    };
+
+    const toGetOptions = (json) => {
+        const o = { ...json };
+        o.challenge = b64u.decode(json.challenge);
+        if (json.allowCredentials) {
+            o.allowCredentials = json.allowCredentials.map((c) => ({
+                ...c,
+                id: b64u.decode(c.id),
+            }));
+        }
+        return o;
+    };
+
+    const assertionToJson = (cred) => ({
+        id: cred.id,
+        rawId: b64u.encode(cred.rawId),
+        type: cred.type,
+        response: {
+            clientDataJSON: b64u.encode(cred.response.clientDataJSON),
+            authenticatorData: b64u.encode(cred.response.authenticatorData),
+            signature: b64u.encode(cred.response.signature),
+            userHandle: cred.response.userHandle ? b64u.encode(cred.response.userHandle) : null,
+        },
+    });
+
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        submit.disabled = true;
+        output.textContent = '';
+
+        try {
+            const username = form.username.value;
+
+            log('Asking server for assertion options...');
+            const optResp = await fetch('/api/login/options', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username }),
+            });
+            if (!optResp.ok) throw new Error(`options HTTP ${optResp.status}: ${await optResp.text()}`);
+            const optsJson = await optResp.json();
+            log(`Options received (${optsJson.allowCredentials?.length ?? 0} credential(s) allowed).`, 'ok');
+
+            log('Calling navigator.credentials.get()...');
+            const credential = await navigator.credentials.get({ publicKey: toGetOptions(optsJson) });
+            log('Assertion produced by the authenticator.', 'ok');
+
+            log('POST /api/login/verify ...');
+            const verifyResp = await fetch('/api/login/verify', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(assertionToJson(credential)),
+            });
+            if (!verifyResp.ok) throw new Error(`verify HTTP ${verifyResp.status}: ${await verifyResp.text()}`);
+            const verified = await verifyResp.json();
+            log(`Signed in as ${verified.username}.`, 'ok');
+            log('Redirecting to /account.html in 1.5s...');
+            setTimeout(() => { window.location.href = '/account.html'; }, 1500);
+        } catch (err) {
+            log(`Error: ${err.message}`, 'err');
+        } finally {
+            submit.disabled = false;
+        }
+    });
+</script>
+</body>
+</html>

--- a/docs/examples/basic-demo/same-origin/public/register.html
+++ b/docs/examples/basic-demo/same-origin/public/register.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Basic Demo, Register</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 720px; margin: 40px auto; padding: 20px; color: #1f2937; line-height: 1.55; }
+        h1 { font-size: 1.5rem; }
+        label { display: block; margin: 0.6rem 0 0.25rem; font-weight: 500; }
+        input, button { padding: 0.55rem 0.75rem; font-size: 1rem; border-radius: 6px; border: 1px solid #d1d5db; box-sizing: border-box; }
+        input { width: 100%; }
+        button { background: #2563eb; color: #fff; border: none; cursor: pointer; }
+        button:disabled { background: #94a3b8; cursor: not-allowed; }
+        pre { background: #f3f4f6; padding: 12px; border-radius: 6px; overflow-x: auto; max-height: 360px; white-space: pre-wrap; word-break: break-all; }
+        .ok { color: #047857; }
+        .err { color: #b91c1c; }
+        nav a { color: #2563eb; margin-right: 1rem; }
+    </style>
+</head>
+<body>
+<nav><a href="/">&larr; Home</a><a href="/login.html">Sign in &rarr;</a></nav>
+
+<h1>1. Register a passkey for a new account</h1>
+
+<p>
+    The page asks the server for <code>PublicKeyCredentialCreationOptions</code>,
+    calls <code>navigator.credentials.create()</code> with them, and posts the
+    resulting credential back for server-side validation. On success the
+    server persists a <code>CredentialRecord</code> bound to the user handle.
+</p>
+
+<form id="register-form">
+    <label for="username">Username (email)</label>
+    <input id="username" name="username" type="email" required value="jane.doe@example.com">
+
+    <label for="displayName">Display name</label>
+    <input id="displayName" name="displayName" type="text" value="Jane Doe">
+
+    <label for="label">Passkey label (shown on /account.html)</label>
+    <input id="label" name="label" type="text" placeholder="e.g. My iPhone">
+
+    <p><button type="submit" id="submit">Register</button></p>
+</form>
+
+<h2>Output</h2>
+<pre id="output">Submit the form to start a registration ceremony.</pre>
+
+<script type="module">
+    const form = document.getElementById('register-form');
+    const submit = document.getElementById('submit');
+    const output = document.getElementById('output');
+
+    const log = (msg, cls = '') => {
+        const line = document.createElement('div');
+        if (cls) line.className = cls;
+        line.textContent = msg;
+        output.appendChild(line);
+    };
+
+    const b64u = {
+        encode: (buf) => {
+            const bytes = new Uint8Array(buf);
+            let str = '';
+            for (let i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i]);
+            return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+        },
+        decode: (s) => {
+            s = s.replace(/-/g, '+').replace(/_/g, '/');
+            const pad = (4 - (s.length % 4)) % 4;
+            s += '='.repeat(pad);
+            const bin = atob(s);
+            const out = new Uint8Array(bin.length);
+            for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+            return out;
+        },
+    };
+
+    const toCreateOptions = (json) => {
+        const o = { ...json };
+        o.challenge = b64u.decode(json.challenge);
+        o.user = { ...json.user, id: b64u.decode(json.user.id) };
+        if (json.excludeCredentials) {
+            o.excludeCredentials = json.excludeCredentials.map((c) => ({
+                ...c,
+                id: b64u.decode(c.id),
+            }));
+        }
+        return o;
+    };
+
+    const credentialToJson = (cred, label) => ({
+        id: cred.id,
+        rawId: b64u.encode(cred.rawId),
+        type: cred.type,
+        response: {
+            clientDataJSON: b64u.encode(cred.response.clientDataJSON),
+            attestationObject: b64u.encode(cred.response.attestationObject),
+        },
+        clientExtensionResults: { demoLabel: label },
+    });
+
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        submit.disabled = true;
+        output.textContent = '';
+
+        try {
+            const username = form.username.value;
+            const displayName = form.displayName.value;
+            const label = form.label.value;
+
+            log('Asking server for creation options...');
+            const optResp = await fetch('/api/register/options', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username, displayName }),
+            });
+            if (!optResp.ok) throw new Error(`options HTTP ${optResp.status}: ${await optResp.text()}`);
+            const optsJson = await optResp.json();
+            log('Options received from /api/register/options.', 'ok');
+
+            log('Calling navigator.credentials.create()...');
+            const credential = await navigator.credentials.create({ publicKey: toCreateOptions(optsJson) });
+            log('Credential created by the authenticator.', 'ok');
+
+            log('POST /api/register/verify ...');
+            const verifyResp = await fetch('/api/register/verify', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(credentialToJson(credential, label)),
+            });
+            if (!verifyResp.ok) throw new Error(`verify HTTP ${verifyResp.status}: ${await verifyResp.text()}`);
+            const verified = await verifyResp.json();
+            log(`Stored. credentialId=${verified.credentialId}`, 'ok');
+            log('You are now signed in. Redirecting to /account.html in 1.5s...');
+            setTimeout(() => { window.location.href = '/account.html'; }, 1500);
+        } catch (err) {
+            log(`Error: ${err.message}`, 'err');
+        } finally {
+            submit.disabled = false;
+        }
+    });
+</script>
+</body>
+</html>

--- a/docs/examples/basic-demo/same-origin/router.php
+++ b/docs/examples/basic-demo/same-origin/router.php
@@ -1,0 +1,484 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Front controller for `php -S`.
+ *
+ * Routes the `/api/*` endpoints to PHP handlers; for every other request it
+ * returns false so the built-in server falls back to serving the matching
+ * static file from `public/`. Bare `/` is rewritten to `/index.html` because
+ * the built-in server does not auto-index.
+ *
+ * Run with: php -S localhost:8000 -t public router.php
+ */
+
+use App\BasicDemo\Container;
+use ParagonIE\ConstantTime\Base64;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\AuthenticatorSelectionCriteria;
+use Webauthn\PublicKeyCredential;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialParameters;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\PublicKeyCredentialRpEntity;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+require_once __DIR__ . '/../src/bootstrap.php';
+
+session_start();
+$container = new Container();
+$path = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?: '/';
+
+if ($path === '/') {
+    $_SERVER['REQUEST_URI'] = '/index.html';
+
+    return false;
+}
+
+if (! str_starts_with($path, '/api/')) {
+    return false;
+}
+
+header('Content-Type: application/json');
+
+try {
+    match ($path) {
+        '/api/me' => me($container),
+        '/api/logout' => logout(),
+        '/api/register/options' => registerOptions($container),
+        '/api/register/verify' => registerVerify($container),
+        '/api/login/options' => loginOptions($container),
+        '/api/login/verify' => loginVerify($container),
+        '/api/account/passkey/add/options' => addPasskeyOptions($container),
+        '/api/account/passkey/add/verify' => addPasskeyVerify($container),
+        '/api/account/passkey/rename' => renamePasskey($container),
+        '/api/account/passkey/delete' => deletePasskey($container),
+        default => notFound(),
+    };
+} catch (\Throwable $e) {
+    http_response_code(400);
+    echo json_encode([
+        'error' => $e->getMessage(),
+        'class' => $e::class,
+    ], \JSON_THROW_ON_ERROR);
+}
+
+function notFound(): void
+{
+    http_response_code(404);
+    echo json_encode([
+        'error' => 'Not found',
+    ], \JSON_THROW_ON_ERROR);
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function readJson(): array
+{
+    $body = file_get_contents('php://input') ?: '{}';
+    $json = json_decode($body, true, flags: \JSON_THROW_ON_ERROR);
+
+    return is_array($json) ? $json : [];
+}
+
+function jsonOut(mixed $payload): void
+{
+    echo json_encode($payload, \JSON_THROW_ON_ERROR);
+}
+
+/**
+ * Serialize a WebAuthn options object the way the browser expects:
+ * SKIP_NULL_VALUES strips unused optional fields so the JSON stays compatible
+ * with the W3C client API.
+ */
+function serializeOptions(Container $container, object $options): string
+{
+    return $container->serializer->serialize($options, 'json', [
+        'json_encode_options' => \JSON_THROW_ON_ERROR,
+        \Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+    ]);
+}
+
+function requireLogin(): string
+{
+    $userHandleB64 = $_SESSION['userHandle'] ?? null;
+    if (! is_string($userHandleB64) || $userHandleB64 === '') {
+        http_response_code(401);
+        echo json_encode([
+            'error' => 'Not authenticated',
+        ], \JSON_THROW_ON_ERROR);
+        exit;
+    }
+
+    return (string) base64_decode($userHandleB64, true);
+}
+
+function me(Container $container): void
+{
+    $userHandleB64 = $_SESSION['userHandle'] ?? null;
+    if (! is_string($userHandleB64) || $userHandleB64 === '') {
+        http_response_code(401);
+        jsonOut([
+            'authenticated' => false,
+        ]);
+
+        return;
+    }
+    $userHandle = (string) base64_decode($userHandleB64, true);
+    $username = $container->userStore->findUsernameByHandle($userHandle);
+    jsonOut([
+        'authenticated' => true,
+        'username' => $username,
+        'displayName' => $username === null ? null : $container->userStore->findDisplayName($username),
+        'credentials' => $container->credentialStore->listForUser($userHandle),
+    ]);
+}
+
+function logout(): void
+{
+    $_SESSION = [];
+    if (ini_get('session.use_cookies')) {
+        $params = session_get_cookie_params();
+        setcookie(
+            session_name(),
+            '',
+            time() - 42_000,
+            $params['path'],
+            $params['domain'],
+            $params['secure'],
+            $params['httponly']
+        );
+    }
+    session_destroy();
+    jsonOut([
+        'loggedOut' => true,
+    ]);
+}
+
+/**
+ * Step 1 of registration: server generates the creation options.
+ *
+ * The browser receives the challenge, the relying party identity, the supported
+ * algorithms and the list of credentials the same user already owns
+ * (excludeCredentials) so the authenticator can refuse to enroll twice.
+ */
+function registerOptions(Container $container): void
+{
+    $body = readJson();
+    $username = trim((string) ($body['username'] ?? ''));
+    $displayName = trim((string) ($body['displayName'] ?? '')) ?: $username;
+    if ($username === '') {
+        throw new \RuntimeException('username is required.');
+    }
+
+    $userHandle = $container->userStore->findOrCreate($username, $displayName);
+    $_SESSION['register_username'] = $username;
+    $_SESSION['register_userHandle'] = base64_encode($userHandle);
+
+    $challenge = random_bytes(32);
+    $_SESSION['register_challenge'] = base64_encode($challenge);
+
+    $options = PublicKeyCredentialCreationOptions::create(
+        PublicKeyCredentialRpEntity::create($container->relyingPartyName, $container->relyingPartyId),
+        PublicKeyCredentialUserEntity::create($username, $userHandle, $displayName),
+        $challenge,
+        [
+            PublicKeyCredentialParameters::create('public-key', -7),
+            PublicKeyCredentialParameters::create('public-key', -257),
+        ],
+        AuthenticatorSelectionCriteria::create(
+            null,
+            AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_PREFERRED,
+            AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_PREFERRED,
+        ),
+        PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
+        $container->credentialStore->excludeCredentialsFor($userHandle),
+    );
+    $options->timeout = 60_000;
+
+    echo serializeOptions($container, $options);
+}
+
+/**
+ * Step 2 of registration: server validates the attestation response.
+ *
+ * The validator runs the full W3C ceremony (CheckOrigin, CheckChallenge,
+ * CheckRelyingPartyIdHash, signature verification, ...) and returns a
+ * CredentialRecord. That record is the single object the relying party
+ * persists; it carries everything the assertion step will need later.
+ */
+function registerVerify(Container $container): void
+{
+    $body = file_get_contents('php://input') ?: '{}';
+    $credential = $container->serializer->deserialize($body, PublicKeyCredential::class, 'json');
+    \assert($credential instanceof PublicKeyCredential);
+
+    $response = $credential->response;
+    if (! $response instanceof AuthenticatorAttestationResponse) {
+        throw new \RuntimeException('Expected an AuthenticatorAttestationResponse.');
+    }
+
+    $challengeB64 = $_SESSION['register_challenge'] ?? null;
+    $username = (string) ($_SESSION['register_username'] ?? '');
+    $userHandleB64 = $_SESSION['register_userHandle'] ?? null;
+    if (! is_string($challengeB64) || $username === '' || ! is_string($userHandleB64)) {
+        throw new \RuntimeException('Missing registration session. Start over from /register.html.');
+    }
+    $challenge = (string) base64_decode($challengeB64, true);
+    $userHandle = (string) base64_decode($userHandleB64, true);
+
+    $options = PublicKeyCredentialCreationOptions::create(
+        PublicKeyCredentialRpEntity::create($container->relyingPartyName, $container->relyingPartyId),
+        PublicKeyCredentialUserEntity::create($username, $userHandle, $username),
+        $challenge,
+        [
+            PublicKeyCredentialParameters::create('public-key', -7),
+            PublicKeyCredentialParameters::create('public-key', -257),
+        ],
+    );
+
+    $record = $container->attestationValidator->check($response, $options, $container->relyingPartyId);
+    $label = trim((string) ($credential->clientExtensionResults['demoLabel'] ?? ''));
+    if ($label === '') {
+        $label = sprintf('Passkey added on %s', date('Y-m-d H:i'));
+    }
+    $container->credentialStore->save($userHandle, $record, $label);
+
+    unset($_SESSION['register_challenge'], $_SESSION['register_username'], $_SESSION['register_userHandle']);
+    $_SESSION['username'] = $username;
+    $_SESSION['userHandle'] = $userHandleB64;
+
+    jsonOut([
+        'verified' => true,
+        'credentialId' => Base64::encode($record->publicKeyCredentialId),
+    ]);
+}
+
+/**
+ * Step 1 of login: server generates the request options and pre-fills
+ * allowCredentials with the descriptors registered for the requested
+ * username, so the browser only prompts for an authenticator that can sign.
+ */
+function loginOptions(Container $container): void
+{
+    $body = readJson();
+    $username = trim((string) ($body['username'] ?? ''));
+    if ($username === '') {
+        throw new \RuntimeException('username is required.');
+    }
+
+    $userHandle = $container->userStore->findUserHandle($username);
+    if ($userHandle === null) {
+        throw new \RuntimeException('Unknown user.');
+    }
+
+    $allowCredentials = $container->credentialStore->allowCredentialsFor($userHandle);
+    if ($allowCredentials === []) {
+        throw new \RuntimeException('No passkey registered for this account.');
+    }
+
+    $challenge = random_bytes(32);
+    $_SESSION['login_challenge'] = base64_encode($challenge);
+    $_SESSION['login_username'] = $username;
+
+    $options = PublicKeyCredentialRequestOptions::create(
+        $challenge,
+        $container->relyingPartyId,
+        $allowCredentials,
+        PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_PREFERRED,
+    );
+    $options->timeout = 60_000;
+
+    echo serializeOptions($container, $options);
+}
+
+/**
+ * Step 2 of login: server validates the assertion response.
+ *
+ * The validator updates the counter and backup flags on the CredentialRecord
+ * in place; we re-serialize it so the next sign-in sees the latest counter
+ * and the W3C clone-detection rule keeps working.
+ */
+function loginVerify(Container $container): void
+{
+    $body = file_get_contents('php://input') ?: '{}';
+    $credential = $container->serializer->deserialize($body, PublicKeyCredential::class, 'json');
+    \assert($credential instanceof PublicKeyCredential);
+
+    $response = $credential->response;
+    if (! $response instanceof AuthenticatorAssertionResponse) {
+        throw new \RuntimeException('Expected an AuthenticatorAssertionResponse.');
+    }
+
+    $challengeB64 = $_SESSION['login_challenge'] ?? null;
+    $username = (string) ($_SESSION['login_username'] ?? '');
+    if (! is_string($challengeB64) || $username === '') {
+        throw new \RuntimeException('Missing login session. Start over from /login.html.');
+    }
+    $challenge = (string) base64_decode($challengeB64, true);
+
+    $userHandle = $container->userStore->findUserHandle($username);
+    if ($userHandle === null) {
+        throw new \RuntimeException('Unknown user.');
+    }
+
+    $record = $container->credentialStore->findByCredentialId($credential->rawId);
+    if ($record === null) {
+        throw new \RuntimeException('Unknown credential for this account.');
+    }
+
+    $options = PublicKeyCredentialRequestOptions::create(
+        $challenge,
+        $container->relyingPartyId,
+        $container->credentialStore->allowCredentialsFor($userHandle),
+        PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_PREFERRED,
+    );
+
+    $updated = $container->assertionValidator->check(
+        $record,
+        $response,
+        $options,
+        $container->relyingPartyId,
+        $userHandle,
+    );
+    $container->credentialStore->updateAfterAssertion($updated);
+
+    unset($_SESSION['login_challenge'], $_SESSION['login_username']);
+    $_SESSION['username'] = $username;
+    $_SESSION['userHandle'] = base64_encode($userHandle);
+
+    jsonOut([
+        'verified' => true,
+        'username' => $username,
+    ]);
+}
+
+/**
+ * Adds a second (or third, ...) passkey to a logged-in account. Mirrors the
+ * registration flow but skips the user-table entry and pre-fills
+ * excludeCredentials with everything the user already owns.
+ */
+function addPasskeyOptions(Container $container): void
+{
+    $userHandle = requireLogin();
+    $username = $container->userStore->findUsernameByHandle($userHandle);
+    if ($username === null) {
+        throw new \RuntimeException('Session out of sync. Sign in again.');
+    }
+
+    $challenge = random_bytes(32);
+    $_SESSION['add_passkey_challenge'] = base64_encode($challenge);
+
+    $options = PublicKeyCredentialCreationOptions::create(
+        PublicKeyCredentialRpEntity::create($container->relyingPartyName, $container->relyingPartyId),
+        PublicKeyCredentialUserEntity::create($username, $userHandle, (string) $container->userStore->findDisplayName($username)),
+        $challenge,
+        [
+            PublicKeyCredentialParameters::create('public-key', -7),
+            PublicKeyCredentialParameters::create('public-key', -257),
+        ],
+        AuthenticatorSelectionCriteria::create(
+            null,
+            AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_PREFERRED,
+            AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_PREFERRED,
+        ),
+        PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
+        $container->credentialStore->excludeCredentialsFor($userHandle),
+    );
+    $options->timeout = 60_000;
+
+    echo serializeOptions($container, $options);
+}
+
+function addPasskeyVerify(Container $container): void
+{
+    $userHandle = requireLogin();
+    $username = $container->userStore->findUsernameByHandle($userHandle);
+    if ($username === null) {
+        throw new \RuntimeException('Session out of sync. Sign in again.');
+    }
+
+    $body = file_get_contents('php://input') ?: '{}';
+    $credential = $container->serializer->deserialize($body, PublicKeyCredential::class, 'json');
+    \assert($credential instanceof PublicKeyCredential);
+
+    $response = $credential->response;
+    if (! $response instanceof AuthenticatorAttestationResponse) {
+        throw new \RuntimeException('Expected an AuthenticatorAttestationResponse.');
+    }
+
+    $challengeB64 = $_SESSION['add_passkey_challenge'] ?? null;
+    if (! is_string($challengeB64)) {
+        throw new \RuntimeException('Missing add-passkey session.');
+    }
+    $challenge = (string) base64_decode($challengeB64, true);
+
+    $options = PublicKeyCredentialCreationOptions::create(
+        PublicKeyCredentialRpEntity::create($container->relyingPartyName, $container->relyingPartyId),
+        PublicKeyCredentialUserEntity::create($username, $userHandle, $username),
+        $challenge,
+        [
+            PublicKeyCredentialParameters::create('public-key', -7),
+            PublicKeyCredentialParameters::create('public-key', -257),
+        ],
+    );
+
+    $record = $container->attestationValidator->check($response, $options, $container->relyingPartyId);
+    $label = trim((string) ($credential->clientExtensionResults['demoLabel'] ?? ''));
+    if ($label === '') {
+        $label = sprintf('Passkey added on %s', date('Y-m-d H:i'));
+    }
+    $container->credentialStore->save($userHandle, $record, $label);
+    unset($_SESSION['add_passkey_challenge']);
+
+    jsonOut([
+        'verified' => true,
+        'credentialId' => Base64::encode($record->publicKeyCredentialId),
+    ]);
+}
+
+function renamePasskey(Container $container): void
+{
+    $userHandle = requireLogin();
+    $body = readJson();
+    $credentialId = (string) base64_decode((string) ($body['credentialId'] ?? ''), true);
+    $label = trim((string) ($body['label'] ?? ''));
+    if ($credentialId === '' || $label === '') {
+        throw new \RuntimeException('credentialId and label are required.');
+    }
+    $ok = $container->credentialStore->rename($credentialId, $userHandle, $label);
+    if (! $ok) {
+        throw new \RuntimeException('Cannot rename this credential.');
+    }
+    jsonOut([
+        'renamed' => true,
+    ]);
+}
+
+/**
+ * Refuses to delete the last passkey of an account. Without a fallback (a
+ * password, an email magic link, ...) deleting the last passkey would lock
+ * the user out for good.
+ */
+function deletePasskey(Container $container): void
+{
+    $userHandle = requireLogin();
+    $body = readJson();
+    $credentialId = (string) base64_decode((string) ($body['credentialId'] ?? ''), true);
+    if ($credentialId === '') {
+        throw new \RuntimeException('credentialId is required.');
+    }
+    if ($container->credentialStore->countForUser($userHandle) <= 1) {
+        throw new \RuntimeException('Cannot delete the last passkey of this account.');
+    }
+    $ok = $container->credentialStore->delete($credentialId, $userHandle);
+    if (! $ok) {
+        throw new \RuntimeException('Cannot delete this credential.');
+    }
+    jsonOut([
+        'deleted' => true,
+    ]);
+}

--- a/docs/examples/basic-demo/same-origin/run.sh
+++ b/docs/examples/basic-demo/same-origin/run.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Boot the same-origin basic-demo on http://localhost:8000.
+# Usage:  ./same-origin/run.sh   (from docs/examples/basic-demo/)
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [[ ! -d vendor ]]; then
+    echo "vendor/ missing, running composer install"
+    composer install --no-interaction
+fi
+
+PORT=8000
+
+is_busy() { lsof -i ":$1" >/dev/null 2>&1 || ss -ltn 2>/dev/null | grep -q ":$1 "; }
+if is_busy "$PORT"; then
+    echo "Port $PORT already in use. Free it and retry." >&2
+    exit 1
+fi
+
+cleanup() {
+    echo
+    echo "Stopping server..."
+    [[ -n "${PID:-}" ]] && kill "$PID" 2>/dev/null || true
+    wait 2>/dev/null || true
+}
+trap cleanup INT TERM EXIT
+
+echo "Basic WebAuthn demo (same-origin) -> http://localhost:$PORT"
+echo
+echo "Steps:"
+echo "  1. open http://localhost:$PORT/                (landing page)"
+echo "  2. open http://localhost:$PORT/register.html   (register a new passkey)"
+echo "  3. open http://localhost:$PORT/login.html      (sign in with a registered passkey)"
+echo "  4. open http://localhost:$PORT/account.html    (list, add, rename, delete passkeys)"
+echo
+echo "Logs follow. Ctrl+C to stop."
+echo "----------------------------------------------------------------"
+
+php -S "localhost:$PORT" -t same-origin/public same-origin/router.php &
+PID=$!
+
+wait

--- a/docs/examples/basic-demo/src/CredentialStore.php
+++ b/docs/examples/basic-demo/src/CredentialStore.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BasicDemo;
+
+use Symfony\Component\Serializer\Serializer;
+use Webauthn\CredentialRecord;
+use Webauthn\PublicKeyCredentialDescriptor;
+
+/**
+ * Demo-only credential store. Each row keeps:
+ *
+ *  - `userHandle`         the binary user handle the credential is bound to
+ *                         (base64-encoded for JSON storage);
+ *  - `credentialId`       the binary credential ID (base64-encoded);
+ *  - `source`             the framework's CredentialRecord serialized to JSON.
+ *                         This is the canonical blob to persist after a
+ *                         successful attestation. It already contains the
+ *                         credential ID, the COSE public key, the signature
+ *                         counter, the AAGUID, transports and the backup flags;
+ *  - `label`              a human-friendly alias the user can rename;
+ *  - `addedAt`            registration timestamp;
+ *  - `lastUsedAt`         updated on every successful assertion.
+ *
+ * Production code MUST replace this with a real implementation of
+ * `Webauthn\CredentialRecordRepositoryInterface` (and optionally
+ * `Webauthn\CanSaveCredentialRecord` if it owns persistence). Doctrine users
+ * can reuse `DoctrineCredentialSourceRepository` from the Symfony bundle as
+ * a reference implementation.
+ */
+final class CredentialStore
+{
+    public function __construct(
+        private readonly string $file,
+        private readonly Serializer $serializer,
+    ) {
+        $dir = dirname($this->file);
+        if (! is_dir($dir)) {
+            mkdir($dir, 0o755, true);
+        }
+        if (! file_exists($this->file)) {
+            file_put_contents($this->file, '[]');
+        }
+    }
+
+    /**
+     * @return array<string, array{userHandle: string, credentialId: string, source: string, label: string, addedAt: int, lastUsedAt: ?int}>
+     */
+    private function readAll(): array
+    {
+        $raw = (string) file_get_contents($this->file);
+        $data = json_decode($raw, true);
+
+        return is_array($data) ? $data : [];
+    }
+
+    /**
+     * @param array<string, array{userHandle: string, credentialId: string, source: string, label: string, addedAt: int, lastUsedAt: ?int}> $data
+     */
+    private function writeAll(array $data): void
+    {
+        file_put_contents($this->file, json_encode($data, \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * Persist a freshly registered credential. Call this right after
+     * `AuthenticatorAttestationResponseValidator::check()` returns.
+     */
+    public function save(string $userHandle, CredentialRecord $record, string $label): void
+    {
+        $key = base64_encode($record->publicKeyCredentialId);
+        $all = $this->readAll();
+        $all[$key] = [
+            'userHandle' => base64_encode($userHandle),
+            'credentialId' => base64_encode($record->publicKeyCredentialId),
+            'source' => $this->serializer->serialize($record, 'json'),
+            'label' => $label,
+            'addedAt' => time(),
+            'lastUsedAt' => null,
+        ];
+        $this->writeAll($all);
+    }
+
+    /**
+     * Refresh the stored CredentialRecord after a successful assertion. The
+     * counter, backup flags and uvInitialized may have been updated in place
+     * by the validator, so we re-serialize the whole record.
+     */
+    public function updateAfterAssertion(CredentialRecord $record): void
+    {
+        $key = base64_encode($record->publicKeyCredentialId);
+        $all = $this->readAll();
+        if (! isset($all[$key])) {
+            return;
+        }
+        $all[$key]['source'] = $this->serializer->serialize($record, 'json');
+        $all[$key]['lastUsedAt'] = time();
+        $this->writeAll($all);
+    }
+
+    public function rename(string $credentialId, string $userHandle, string $label): bool
+    {
+        $key = base64_encode($credentialId);
+        $all = $this->readAll();
+        if (! isset($all[$key])) {
+            return false;
+        }
+        if ($all[$key]['userHandle'] !== base64_encode($userHandle)) {
+            return false;
+        }
+        $all[$key]['label'] = $label;
+        $this->writeAll($all);
+
+        return true;
+    }
+
+    public function delete(string $credentialId, string $userHandle): bool
+    {
+        $key = base64_encode($credentialId);
+        $all = $this->readAll();
+        if (! isset($all[$key])) {
+            return false;
+        }
+        if ($all[$key]['userHandle'] !== base64_encode($userHandle)) {
+            return false;
+        }
+        unset($all[$key]);
+        $this->writeAll($all);
+
+        return true;
+    }
+
+    public function findByCredentialId(string $credentialId): ?CredentialRecord
+    {
+        $key = base64_encode($credentialId);
+        $row = $this->readAll()[$key] ?? null;
+        if ($row === null) {
+            return null;
+        }
+        $record = $this->serializer->deserialize($row['source'], CredentialRecord::class, 'json');
+        \assert($record instanceof CredentialRecord);
+
+        return $record;
+    }
+
+    public function findUserHandleByCredentialId(string $credentialId): ?string
+    {
+        $key = base64_encode($credentialId);
+        $row = $this->readAll()[$key] ?? null;
+
+        return $row === null ? null : (string) base64_decode($row['userHandle'], true);
+    }
+
+    /**
+     * Build the `allowCredentials` list a relying party passes in
+     * PublicKeyCredentialRequestOptions to scope the assertion ceremony to a
+     * known user.
+     *
+     * @return PublicKeyCredentialDescriptor[]
+     */
+    public function allowCredentialsFor(string $userHandle): array
+    {
+        $needle = base64_encode($userHandle);
+        $descriptors = [];
+        foreach ($this->readAll() as $row) {
+            if ($row['userHandle'] !== $needle) {
+                continue;
+            }
+            $rawId = (string) base64_decode($row['credentialId'], true);
+            $descriptors[] = PublicKeyCredentialDescriptor::create('public-key', $rawId);
+        }
+
+        return $descriptors;
+    }
+
+    /**
+     * Build the `excludeCredentials` list a relying party passes in
+     * PublicKeyCredentialCreationOptions to prevent registering the same
+     * authenticator twice for the same user.
+     *
+     * @return PublicKeyCredentialDescriptor[]
+     */
+    public function excludeCredentialsFor(string $userHandle): array
+    {
+        return $this->allowCredentialsFor($userHandle);
+    }
+
+    /**
+     * @return list<array{credentialId: string, label: string, addedAt: int, lastUsedAt: ?int, counter: int, aaguid: string, transports: list<string>, backupEligible: ?bool, backupStatus: ?bool}>
+     */
+    public function listForUser(string $userHandle): array
+    {
+        $needle = base64_encode($userHandle);
+        $rows = [];
+        foreach ($this->readAll() as $row) {
+            if ($row['userHandle'] !== $needle) {
+                continue;
+            }
+            $record = $this->serializer->deserialize($row['source'], CredentialRecord::class, 'json');
+            \assert($record instanceof CredentialRecord);
+            $rows[] = [
+                'credentialId' => $row['credentialId'],
+                'label' => $row['label'],
+                'addedAt' => $row['addedAt'],
+                'lastUsedAt' => $row['lastUsedAt'],
+                'counter' => $record->counter,
+                'aaguid' => $record->aaguid->toRfc4122(),
+                'transports' => $record->transports,
+                'backupEligible' => $record->backupEligible,
+                'backupStatus' => $record->backupStatus,
+            ];
+        }
+
+        return $rows;
+    }
+
+    public function countForUser(string $userHandle): int
+    {
+        return count($this->listForUser($userHandle));
+    }
+}

--- a/docs/examples/basic-demo/src/UserStore.php
+++ b/docs/examples/basic-demo/src/UserStore.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\BasicDemo;
+
+/**
+ * Demo-only user store. Maps usernames to a stable WebAuthn user handle and a
+ * human display name.
+ *
+ * The user handle is the bytes the relying party puts in
+ * `PublicKeyCredentialUserEntity.id`. The W3C spec requires that it:
+ *
+ *  - is a unique, opaque byte string (NOT the username, NOT an email);
+ *  - never changes for the lifetime of the account;
+ *  - is at most 64 bytes long.
+ *
+ * In a real application the user handle is typically the binary form of the
+ * account's primary key (UUID, ULID, ...). This demo derives it deterministically
+ * from the username so the same username always maps to the same handle across
+ * fresh starts.
+ *
+ * Production code MUST persist users in a real database and treat the user
+ * handle as the opaque, immutable account identifier.
+ */
+final class UserStore
+{
+    public function __construct(
+        private readonly string $file,
+    ) {
+        $dir = dirname($this->file);
+        if (! is_dir($dir)) {
+            mkdir($dir, 0o755, true);
+        }
+        if (! file_exists($this->file)) {
+            file_put_contents($this->file, '[]');
+        }
+    }
+
+    /**
+     * @return array<string, array{userHandle: string, displayName: string, createdAt: int}>
+     */
+    private function readAll(): array
+    {
+        $raw = (string) file_get_contents($this->file);
+        $data = json_decode($raw, true);
+
+        return is_array($data) ? $data : [];
+    }
+
+    /**
+     * @param array<string, array{userHandle: string, displayName: string, createdAt: int}> $data
+     */
+    private function writeAll(array $data): void
+    {
+        file_put_contents($this->file, json_encode($data, \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * Look up an existing user by username, or create a fresh account on first sight.
+     * Returns the binary user handle the WebAuthn user entity expects.
+     */
+    public function findOrCreate(string $username, string $displayName): string
+    {
+        $all = $this->readAll();
+        if (isset($all[$username])) {
+            return (string) base64_decode($all[$username]['userHandle'], true);
+        }
+        $userHandle = random_bytes(32);
+        $all[$username] = [
+            'userHandle' => base64_encode($userHandle),
+            'displayName' => $displayName === '' ? $username : $displayName,
+            'createdAt' => time(),
+        ];
+        $this->writeAll($all);
+
+        return $userHandle;
+    }
+
+    /**
+     * Returns the binary user handle for a known username, or null if the
+     * account has never been seen.
+     */
+    public function findUserHandle(string $username): ?string
+    {
+        $row = $this->readAll()[$username] ?? null;
+
+        return $row === null ? null : (string) base64_decode($row['userHandle'], true);
+    }
+
+    /**
+     * Returns the username bound to a user handle. Used during sign-in to map
+     * the bytes the authenticator returned back to a human-readable identity.
+     */
+    public function findUsernameByHandle(string $userHandle): ?string
+    {
+        $needle = base64_encode($userHandle);
+        foreach ($this->readAll() as $username => $row) {
+            if ($row['userHandle'] === $needle) {
+                return $username;
+            }
+        }
+
+        return null;
+    }
+
+    public function findDisplayName(string $username): ?string
+    {
+        return $this->readAll()[$username]['displayName'] ?? null;
+    }
+}

--- a/docs/examples/basic-demo/src/bootstrap.php
+++ b/docs/examples/basic-demo/src/bootstrap.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\SpcDemo;
+namespace App\BasicDemo;
 
 use Cose\Algorithm\Manager;
 use Cose\Algorithm\Signature\ECDSA\ES256;
@@ -10,57 +10,72 @@ use Cose\Algorithm\Signature\RSA\RS256;
 use Symfony\Component\Serializer\Serializer;
 use Webauthn\AttestationStatement\AttestationStatementSupportManager;
 use Webauthn\AttestationStatement\NoneAttestationStatementSupport;
-use Webauthn\AuthenticationExtensions\ExtensionOutputCheckerHandler;
-use Webauthn\AuthenticationExtensions\PaymentExtensionOutputChecker;
 use Webauthn\AuthenticatorAssertionResponseValidator;
 use Webauthn\AuthenticatorAttestationResponseValidator;
 use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
-use Webauthn\ClientDataCollector\ClientDataCollectorManager;
-use Webauthn\ClientDataCollector\PaymentClientDataCollector;
-use Webauthn\ClientDataCollector\WebauthnAuthenticationCollector;
 use Webauthn\Denormalizer\WebauthnSerializerFactory;
 
 $autoload = __DIR__ . '/../vendor/autoload.php';
 if (! is_file($autoload)) {
-    fwrite(\STDERR, "Run `composer install` in docs/examples/spc-demo/ first.\n");
+    fwrite(\STDERR, "Run `composer install` in docs/examples/basic-demo/ first.\n");
     exit(1);
 }
 require_once $autoload;
 
+require_once __DIR__ . '/UserStore.php';
+require_once __DIR__ . '/CredentialStore.php';
+
 /**
- * Wires everything the SPC demo needs:
+ * Minimal service container for the demo.
  *
- *  - The Webauthn serializer (loads every denormalizer the lib ships with,
- *    including the SPC ones for `payment`, `total`, `instrument`, …).
- *  - A `CeremonyStepManagerFactory` configured with a
- *    `ClientDataCollectorManager` that handles BOTH `webauthn.get` /
- *    `webauthn.create` (standard WebAuthn) and `payment.get` (SPC).
- *  - Validators for registration (attestation) and authentication
- *    (assertion).
- *  - A trivial JSON-file storage for credentials so the demo runs
- *    out-of-the-box with `php -S`.
+ * Wires together the four things a pure-PHP relying party needs to run a
+ * WebAuthn ceremony:
+ *
+ *  - A serializer that knows how to (de)serialize the WebAuthn options
+ *    objects sent to the browser and the PublicKeyCredential JSON the
+ *    browser sends back.
+ *  - An attestation statement support manager. The demo accepts the `none`
+ *    format only, which is the default for platform authenticators and the
+ *    safe choice for a passwordless login that does not need attestation.
+ *  - A COSE algorithm manager. ES256 and RS256 cover every authenticator
+ *    in circulation, including platform and roaming.
+ *  - Two validators wired on top of a CeremonyStepManager configured with
+ *    the relying party's allowed origins.
+ *
+ * Persistence is delegated to two demo-only JSON-file stores
+ * (UserStore + CredentialStore). Production code MUST replace them with a
+ * real database behind the framework's repository interfaces.
  */
 final class Container
 {
     public string $relyingPartyId;
+
     public string $relyingPartyName;
+
     /** @var string[] */
     public array $allowedOrigins;
 
     public AttestationStatementSupportManager $attestationManager;
+
     public Manager $algorithmManager;
+
     public CeremonyStepManagerFactory $ceremonyFactory;
+
     public AuthenticatorAttestationResponseValidator $attestationValidator;
+
     public AuthenticatorAssertionResponseValidator $assertionValidator;
+
     public Serializer $serializer;
+
+    public UserStore $userStore;
+
     public CredentialStore $credentialStore;
-    public ChallengeStore $challengeStore;
 
     public function __construct()
     {
         $this->relyingPartyId = $_ENV['RP_ID'] ?? 'localhost';
-        $this->relyingPartyName = 'SPC Demo Bank';
-        $this->allowedOrigins = explode(',', $_ENV['ALLOWED_ORIGINS'] ?? 'http://localhost:8000,http://localhost:8001');
+        $this->relyingPartyName = 'Basic WebAuthn Demo';
+        $this->allowedOrigins = explode(',', $_ENV['ALLOWED_ORIGINS'] ?? 'http://localhost:8000');
 
         $this->attestationManager = new AttestationStatementSupportManager();
         $this->attestationManager->add(new NoneAttestationStatementSupport());
@@ -71,30 +86,20 @@ final class Container
         \assert($serializer instanceof Serializer);
         $this->serializer = $serializer;
 
-        $clientDataManager = new ClientDataCollectorManager([
-            new WebauthnAuthenticationCollector(),
-            new PaymentClientDataCollector($this->serializer),
-        ]);
-
-        $extensionHandler = ExtensionOutputCheckerHandler::create();
-        $extensionHandler->add(new PaymentExtensionOutputChecker());
-
         $this->ceremonyFactory = new CeremonyStepManagerFactory();
         $this->ceremonyFactory->setAttestationStatementSupportManager($this->attestationManager);
         $this->ceremonyFactory->setAlgorithmManager($this->algorithmManager);
-        $this->ceremonyFactory->setExtensionOutputCheckerHandler($extensionHandler);
-        $this->ceremonyFactory->setClientDataCollectorManager($clientDataManager);
         $this->ceremonyFactory->setAllowedOrigins($this->allowedOrigins);
 
         $this->attestationValidator = AuthenticatorAttestationResponseValidator::create(
-            ceremonyStepManager: $this->ceremonyFactory->creationCeremony(),
+            $this->ceremonyFactory->creationCeremony(),
         );
         $this->assertionValidator = AuthenticatorAssertionResponseValidator::create(
-            ceremonyStepManager: $this->ceremonyFactory->requestCeremony(),
+            $this->ceremonyFactory->requestCeremony(),
         );
 
         $varDir = $_ENV['VAR_DIR'] ?? __DIR__ . '/../var';
+        $this->userStore = new UserStore($varDir . '/users.json');
         $this->credentialStore = new CredentialStore($varDir . '/credentials.json', $this->serializer);
-        $this->challengeStore = new ChallengeStore($varDir . '/challenges.json');
     }
 }

--- a/docs/examples/extensions-demo/src/bootstrap.php
+++ b/docs/examples/extensions-demo/src/bootstrap.php
@@ -15,27 +15,12 @@ use Webauthn\AuthenticatorAttestationResponseValidator;
 use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
 use Webauthn\Denormalizer\WebauthnSerializerFactory;
 
-// Two ways to load the lib:
-//   1. Standalone — `composer install` in this directory pulls
-//      web-auth/webauthn-lib >= 5.4 into ./vendor.
-//   2. Inside the monorepo — fall back to the framework's own
-//      vendor/autoload.php which exposes the lib via PSR-4.
-$autoloads = [
-    __DIR__ . '/../vendor/autoload.php',
-    __DIR__ . '/../../../../vendor/autoload.php',
-];
-$loaded = false;
-foreach ($autoloads as $autoload) {
-    if (is_file($autoload)) {
-        require_once $autoload;
-        $loaded = true;
-        break;
-    }
-}
-if (! $loaded) {
+$autoload = __DIR__ . '/../vendor/autoload.php';
+if (! is_file($autoload)) {
     fwrite(\STDERR, "Run `composer install` in docs/examples/extensions-demo/ first.\n");
     exit(1);
 }
+require_once $autoload;
 
 /**
  * Wires the minimum the demo needs: serializer, attestation/assertion

--- a/docs/examples/passkey-upgrade-demo/.gitignore
+++ b/docs/examples/passkey-upgrade-demo/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+/var/*.json
+composer.lock

--- a/docs/examples/passkey-upgrade-demo/README.md
+++ b/docs/examples/passkey-upgrade-demo/README.md
@@ -1,0 +1,97 @@
+# Passkey Upgrade Demo, `web-auth/webauthn-lib`
+
+Pure-PHP example of the **passkey upgrade** flow, the most common
+real-world rollout pattern:
+
+1. Accounts are born with a username and a password (classic signup).
+2. Once signed in, the account page offers to enrol a passkey for
+   faster sign-in next time.
+3. Future logins accept either factor on the same form, so the user can
+   migrate at their own pace.
+
+The password is always a usable fallback, so losing every passkey is
+not the dead-end it is in the [basic-demo](../basic-demo).
+
+## Four pages, three flows
+
+| Page | What it does |
+|---|---|
+| [`/`](same-origin/public/index.html) | Landing page, shows the current session state, including which factor opened it (`authMethod`). |
+| [`/signup.html`](same-origin/public/signup.html) | Creates a brand-new account with `username + password + displayName`. The password is hashed with `password_hash(PASSWORD_BCRYPT)` and the session opens with `authMethod = 'password'`. |
+| [`/login.html`](same-origin/public/login.html) | Sign-in page that accepts both factors. The submit button uses the password, an "Use a passkey instead" button switches to a WebAuthn assertion. The page falls back gracefully when the account has no passkey enrolled. |
+| [`/account.html`](same-origin/public/account.html) | Protected page. Shows the active `authMethod`, lists enrolled passkeys (label, AAGUID, counter, backup state, last used), surfaces a yellow upgrade CTA when no passkey is enrolled, and lets the user enrol, rename or delete passkeys. Deleting the last passkey is allowed because the password fallback is still there. |
+
+## What this demo demonstrates
+
+- A password-only signup endpoint and a `password_verify`-driven login.
+- A login form that supports both factors so users can migrate at their
+  own pace.
+- The **passkey upgrade** call from `/account.html`:
+  `POST /api/account/passkey/add/options` then verify, with
+  `excludeCredentials` pre-filled to avoid double-enrolment of the same
+  authenticator.
+- An `authMethod` session field that tells the account page how the
+  user got in. A production RP would use that to decide whether to
+  require a step-up re-auth (re-type the password, recent strong
+  factor, ...) before the passkey enrolment.
+
+## Security note about the upgrade step
+
+The demo enrols a passkey on any logged-in session, including one
+opened by a password sign-in moments ago. A production RP **MUST** ask
+for a re-auth right before the enrolment, otherwise a stolen password
+lets an attacker silently bind their own passkey to the victim's
+account. Common patterns are:
+
+- re-type the password on the enrol page;
+- send a one-time code by email and require it;
+- require that the current session opened with a strong factor within
+  the last `N` minutes.
+
+The same applies to passkey delete in a production setting.
+
+## Run it
+
+```bash
+cd docs/examples/passkey-upgrade-demo
+./same-origin/run.sh
+```
+
+Then walk through the pages in order:
+
+1. <http://localhost:8000/signup.html>, create an account.
+2. <http://localhost:8000/account.html>, click *Enrol a passkey* in the
+   upgrade CTA.
+3. *Sign out* and head to <http://localhost:8000/login.html>. Try both
+   sign-in paths: the password submit button, and the *Use a passkey
+   instead* button.
+
+## What lives in `var/`
+
+- `var/users.json`: `username -> { userHandle, displayName,
+  passwordHash, createdAt }`. The password is bcrypt-hashed; the user
+  handle is a random 32-byte blob generated at signup.
+- `var/credentials.json`: same shape as the basic-demo,
+  `credentialId -> { userHandle, credentialId, source, label, addedAt,
+  lastUsedAt }`.
+
+Delete the two JSON files to reset the demo.
+
+## What this demo deliberately leaves out
+
+- Email verification, password reset, account recovery.
+- Step-up re-auth before passkey enrolment (see the security note
+  above).
+- Rate limiting, CSRF, password policy beyond minimum length.
+
+## Where to look in the code
+
+| What | File |
+|---|---|
+| Service wiring | [`src/bootstrap.php`](src/bootstrap.php) |
+| User table with password hash and user handle | [`src/UserStore.php`](src/UserStore.php) |
+| Credential persistence | [`src/CredentialStore.php`](src/CredentialStore.php) |
+| All HTTP endpoints (signup, password login, passkey login, passkey enrol, ...) | [`same-origin/router.php`](same-origin/router.php) |
+| Browser side, password signup | [`same-origin/public/signup.html`](same-origin/public/signup.html) |
+| Browser side, dual-factor login | [`same-origin/public/login.html`](same-origin/public/login.html) |
+| Browser side, account + upgrade CTA | [`same-origin/public/account.html`](same-origin/public/account.html) |

--- a/docs/examples/passkey-upgrade-demo/composer.json
+++ b/docs/examples/passkey-upgrade-demo/composer.json
@@ -1,0 +1,30 @@
+{
+    "name": "web-auth/passkey-upgrade-demo",
+    "description": "End-to-end pure-PHP demo of a password-based account that the user upgrades to passkey sign-in (passkey upgrade flow) using web-auth/webauthn-lib",
+    "type": "project",
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../..",
+            "options": {
+                "symlink": true,
+                "versions": {
+                    "web-auth/webauthn-framework": "5.4.x-dev"
+                }
+            }
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "ext-json": "*",
+        "ext-openssl": "*",
+        "web-auth/webauthn-framework": "5.4.x-dev",
+        "symfony/clock": "^6.4 || ^7.0",
+        "symfony/serializer": "^6.4 || ^7.0",
+        "symfony/property-access": "^6.4 || ^7.0",
+        "symfony/property-info": "^6.4 || ^7.0",
+        "symfony/uid": "^6.4 || ^7.0"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/docs/examples/passkey-upgrade-demo/same-origin/public/account.html
+++ b/docs/examples/passkey-upgrade-demo/same-origin/public/account.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Passkey Upgrade Demo, My account</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 860px; margin: 40px auto; padding: 20px; color: #1f2937; line-height: 1.55; }
+        h1 { font-size: 1.5rem; }
+        h2 { font-size: 1.1rem; margin-top: 2rem; }
+        nav a { color: #2563eb; margin-right: 1rem; }
+        button { background: #2563eb; color: #fff; border: none; cursor: pointer; padding: 0.45rem 0.85rem; border-radius: 6px; font-size: 0.95rem; margin-right: 0.4rem; }
+        button.ghost { background: transparent; color: #2563eb; border: 1px solid #2563eb; }
+        button.danger { background: #b91c1c; }
+        button:disabled { background: #94a3b8; cursor: not-allowed; }
+        table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+        th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid #e5e7eb; font-size: 0.92rem; vertical-align: top; }
+        th { background: #f9fafb; }
+        td.label input { padding: 0.3rem 0.5rem; font-size: 0.9rem; border-radius: 4px; border: 1px solid #d1d5db; width: 100%; box-sizing: border-box; }
+        td.actions { white-space: nowrap; }
+        code { background: #f3f4f6; padding: 1px 6px; border-radius: 4px; font-size: 0.85rem; }
+        pre { background: #f3f4f6; padding: 12px; border-radius: 6px; overflow-x: auto; max-height: 200px; white-space: pre-wrap; word-break: break-all; }
+        .ok { color: #047857; }
+        .err { color: #b91c1c; }
+        .hidden { display: none; }
+        .upgrade { background: #fef3c7; border-left: 4px solid #d97706; padding: 14px 18px; border-radius: 6px; margin: 1.2rem 0; }
+        .upgrade h3 { margin-top: 0; }
+    </style>
+</head>
+<body>
+<nav>
+    <a href="/">&larr; Home</a>
+    <a href="/login.html">Sign in as another user</a>
+</nav>
+
+<h1>My account</h1>
+
+<div id="unauthenticated" class="hidden">
+    <p class="err">You are not signed in.</p>
+    <p>
+        <a href="/login.html"><button>Sign in</button></a>
+        <a href="/signup.html"><button class="ghost">Sign up</button></a>
+    </p>
+</div>
+
+<div id="authenticated" class="hidden">
+    <p>
+        Signed in as <strong id="username"></strong> (<span id="displayName"></span>),
+        via <code id="authMethod"></code>.
+        <button id="logout" class="ghost" style="margin-left: 1rem;">Sign out</button>
+    </p>
+
+    <div id="upgrade-cta" class="upgrade hidden">
+        <h3>Speed up your next sign-in</h3>
+        <p>This account has no passkey yet. Enrol one now and you can sign in without typing your password next time.</p>
+        <p><button id="add-passkey">Enrol a passkey</button></p>
+    </div>
+
+    <h2>Sign-in methods</h2>
+    <ul>
+        <li>Password (always available, used to recover when every passkey is lost)</li>
+        <li>Passkeys (one or more, listed below)</li>
+    </ul>
+
+    <h2>Enrolled passkeys</h2>
+    <p>Adding or deleting passkeys never affects the password. <button id="add-passkey-extra" class="ghost">Enrol another passkey</button></p>
+    <table id="passkeys">
+        <thead>
+        <tr>
+            <th>Label</th>
+            <th>Credential ID</th>
+            <th>AAGUID</th>
+            <th>Counter</th>
+            <th>Backup</th>
+            <th>Last used</th>
+            <th>Actions</th>
+        </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</div>
+
+<h2>Activity log</h2>
+<pre id="output">Loading account...</pre>
+
+<script type="module">
+    const output = document.getElementById('output');
+    const log = (msg, cls = '') => {
+        const line = document.createElement('div');
+        if (cls) line.className = cls;
+        line.textContent = msg;
+        output.appendChild(line);
+    };
+
+    const b64u = {
+        encode: (buf) => {
+            const bytes = new Uint8Array(buf);
+            let str = '';
+            for (let i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i]);
+            return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+        },
+        decode: (s) => {
+            s = s.replace(/-/g, '+').replace(/_/g, '/');
+            const pad = (4 - (s.length % 4)) % 4;
+            s += '='.repeat(pad);
+            const bin = atob(s);
+            const out = new Uint8Array(bin.length);
+            for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+            return out;
+        },
+    };
+
+    const toCreateOptions = (json) => {
+        const o = { ...json };
+        o.challenge = b64u.decode(json.challenge);
+        o.user = { ...json.user, id: b64u.decode(json.user.id) };
+        if (json.excludeCredentials) {
+            o.excludeCredentials = json.excludeCredentials.map((c) => ({ ...c, id: b64u.decode(c.id) }));
+        }
+        return o;
+    };
+
+    const credentialToJson = (cred, label) => ({
+        id: cred.id,
+        rawId: b64u.encode(cred.rawId),
+        type: cred.type,
+        response: {
+            clientDataJSON: b64u.encode(cred.response.clientDataJSON),
+            attestationObject: b64u.encode(cred.response.attestationObject),
+        },
+        clientExtensionResults: { demoLabel: label },
+    });
+
+    const formatDate = (ts) => ts ? new Date(ts * 1000).toLocaleString() : 'never';
+    const formatBackup = (eligible, status) => {
+        if (eligible === null || eligible === undefined) return 'unknown';
+        return `${eligible ? 'eligible' : 'not eligible'} / ${status ? 'backed up' : 'local only'}`;
+    };
+
+    const renderPasskeys = (credentials) => {
+        const tbody = document.querySelector('#passkeys tbody');
+        tbody.innerHTML = '';
+        credentials.forEach((c) => {
+            const tr = document.createElement('tr');
+            const credIdShort = c.credentialId.length > 22
+                ? c.credentialId.slice(0, 12) + '...' + c.credentialId.slice(-6)
+                : c.credentialId;
+            tr.innerHTML = `
+                <td class="label"><input type="text" value="${c.label.replace(/"/g, '&quot;')}" data-cred="${c.credentialId}"></td>
+                <td><code title="${c.credentialId}">${credIdShort}</code></td>
+                <td><code>${c.aaguid}</code></td>
+                <td>${c.counter}</td>
+                <td>${formatBackup(c.backupEligible, c.backupStatus)}</td>
+                <td>${formatDate(c.lastUsedAt)}</td>
+                <td class="actions">
+                    <button class="ghost" data-action="rename" data-cred="${c.credentialId}">Rename</button>
+                    <button class="danger" data-action="delete" data-cred="${c.credentialId}">Delete</button>
+                </td>
+            `;
+            tbody.appendChild(tr);
+        });
+    };
+
+    const loadMe = async () => {
+        const r = await fetch('/api/me');
+        if (r.status === 401) {
+            document.getElementById('unauthenticated').classList.remove('hidden');
+            log('Not signed in.', 'err');
+            return null;
+        }
+        const me = await r.json();
+        document.getElementById('authenticated').classList.remove('hidden');
+        document.getElementById('username').textContent = me.username;
+        document.getElementById('displayName').textContent = me.displayName ?? '';
+        document.getElementById('authMethod').textContent = me.authMethod ?? 'unknown';
+        renderPasskeys(me.credentials);
+        document.getElementById('upgrade-cta').classList.toggle('hidden', me.credentials.length > 0);
+        log(`Loaded ${me.credentials.length} passkey(s) for ${me.username}.`, 'ok');
+        return me;
+    };
+
+    document.getElementById('logout').addEventListener('click', async () => {
+        await fetch('/api/logout', { method: 'POST' });
+        window.location.href = '/';
+    });
+
+    const enrolPasskey = async (btn) => {
+        btn.disabled = true;
+        try {
+            const label = window.prompt('Label for the new passkey (e.g. "my iPhone"):') ?? '';
+            log('Asking server for add-passkey options...');
+            const optResp = await fetch('/api/account/passkey/add/options', { method: 'POST' });
+            if (!optResp.ok) throw new Error(`options HTTP ${optResp.status}: ${await optResp.text()}`);
+            const optsJson = await optResp.json();
+            log('Options received. Calling navigator.credentials.create()...', 'ok');
+
+            const credential = await navigator.credentials.create({ publicKey: toCreateOptions(optsJson) });
+            log('Credential created. POST /api/account/passkey/add/verify ...', 'ok');
+
+            const verifyResp = await fetch('/api/account/passkey/add/verify', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(credentialToJson(credential, label)),
+            });
+            if (!verifyResp.ok) throw new Error(`verify HTTP ${verifyResp.status}: ${await verifyResp.text()}`);
+            log('Passkey enrolled. Refreshing list...', 'ok');
+            await loadMe();
+        } catch (err) {
+            log(`Error: ${err.message}`, 'err');
+        } finally {
+            btn.disabled = false;
+        }
+    };
+
+    document.getElementById('add-passkey').addEventListener('click', (e) => enrolPasskey(e.currentTarget));
+    document.getElementById('add-passkey-extra').addEventListener('click', (e) => enrolPasskey(e.currentTarget));
+
+    document.querySelector('#passkeys').addEventListener('click', async (e) => {
+        const btn = e.target.closest('button[data-action]');
+        if (!btn) return;
+        const credentialId = btn.dataset.cred;
+        const action = btn.dataset.action;
+        try {
+            if (action === 'rename') {
+                const input = document.querySelector(`input[data-cred="${CSS.escape(credentialId)}"]`);
+                const label = input?.value ?? '';
+                if (label.trim() === '') return;
+                const r = await fetch('/api/account/passkey/rename', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ credentialId, label }),
+                });
+                if (!r.ok) throw new Error(`rename HTTP ${r.status}: ${await r.text()}`);
+                log(`Renamed to "${label}".`, 'ok');
+            } else if (action === 'delete') {
+                if (!window.confirm('Delete this passkey ? You will still be able to sign in with your password.')) return;
+                const r = await fetch('/api/account/passkey/delete', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ credentialId }),
+                });
+                if (!r.ok) throw new Error(`delete HTTP ${r.status}: ${await r.text()}`);
+                log('Passkey deleted. Refreshing list...', 'ok');
+                await loadMe();
+            }
+        } catch (err) {
+            log(`Error: ${err.message}`, 'err');
+        }
+    });
+
+    output.textContent = '';
+    await loadMe();
+</script>
+</body>
+</html>

--- a/docs/examples/passkey-upgrade-demo/same-origin/public/index.html
+++ b/docs/examples/passkey-upgrade-demo/same-origin/public/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Passkey Upgrade Demo</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 720px; margin: 40px auto; padding: 20px; color: #1f2937; line-height: 1.55; }
+        h1 { font-size: 1.5rem; }
+        h2 { font-size: 1.1rem; margin-top: 2rem; }
+        a { color: #2563eb; }
+        .card { background: #f3f4f6; border-radius: 8px; padding: 16px 20px; margin: 1.2rem 0; }
+        .card h3 { margin-top: 0; font-size: 1rem; }
+        code { background: #f3f4f6; padding: 1px 6px; border-radius: 4px; font-size: 0.9rem; }
+        .status { font-size: 0.95rem; padding: 10px 14px; border-radius: 6px; margin: 1rem 0; }
+        .status.logged-in { background: #d1fae5; color: #065f46; }
+        .status.logged-out { background: #fee2e2; color: #991b1b; }
+        button { background: #2563eb; color: #fff; border: none; cursor: pointer; padding: 0.45rem 0.85rem; border-radius: 6px; font-size: 0.95rem; }
+        button.ghost { background: transparent; color: #2563eb; border: 1px solid #2563eb; }
+    </style>
+</head>
+<body>
+
+<h1>Passkey Upgrade Demo</h1>
+<p>
+    Real-world rollout pattern: accounts start with a classic username and
+    password, then the user is offered to enrol a passkey for faster sign-in.
+    Future logins can use either factor; deleting every passkey is harmless
+    because the password fallback is still there.
+</p>
+
+<div id="status" class="status logged-out">Loading session state...</div>
+
+<div class="card">
+    <h3>1. Sign up</h3>
+    <p>Create an account with a username, a display name and a password.</p>
+    <p><a href="/signup.html"><button>Sign up</button></a></p>
+</div>
+
+<div class="card">
+    <h3>2. Sign in</h3>
+    <p>Authenticate with the password, or, if you have enrolled one, switch to a passkey directly from the login form.</p>
+    <p><a href="/login.html"><button>Sign in</button></a></p>
+</div>
+
+<div class="card">
+    <h3>3. Upgrade to passkey</h3>
+    <p>Once signed in, your account page offers to add a passkey. The next sign-in then has the option to skip the password entirely.</p>
+    <p><a href="/account.html"><button class="ghost">Open my account</button></a></p>
+</div>
+
+<h2>What this demo demonstrates</h2>
+<ul>
+    <li>Password sign-up and sign-in (hashed with <code>password_hash</code> / verified with <code>password_verify</code>).</li>
+    <li>Post-login passkey enrolment, the most common real-world rollout.</li>
+    <li>A login page that supports BOTH factors so users can migrate at their own pace.</li>
+    <li>Why deleting the last passkey is fine here (the password is still a usable fallback), unlike the basic-demo.</li>
+</ul>
+
+<h2>What this demo deliberately leaves out</h2>
+<ul>
+    <li>Email verification, password reset, account recovery.</li>
+    <li>Step-up re-auth before passkey enrolment. A production RP would require the user to re-enter their password (or a recent strong factor) right before adding a passkey, otherwise a stolen password would let an attacker silently bind their own passkey.</li>
+    <li>Rate limiting, CSRF, password policy beyond minimum length.</li>
+</ul>
+
+<script type="module">
+    const status = document.getElementById('status');
+
+    try {
+        const r = await fetch('/api/me');
+        const me = await r.json();
+        if (me.authenticated) {
+            status.className = 'status logged-in';
+            status.textContent = `Signed in as ${me.username} via ${me.authMethod} (${me.credentials.length} passkey(s) enrolled).`;
+        } else {
+            status.className = 'status logged-out';
+            status.textContent = 'Not signed in.';
+        }
+    } catch (e) {
+        status.className = 'status logged-out';
+        status.textContent = 'Session check failed: ' + e.message;
+    }
+</script>
+
+</body>
+</html>

--- a/docs/examples/passkey-upgrade-demo/same-origin/public/login.html
+++ b/docs/examples/passkey-upgrade-demo/same-origin/public/login.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Passkey Upgrade Demo, Sign in</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 720px; margin: 40px auto; padding: 20px; color: #1f2937; line-height: 1.55; }
+        h1 { font-size: 1.5rem; }
+        label { display: block; margin: 0.6rem 0 0.25rem; font-weight: 500; }
+        input, button { padding: 0.55rem 0.75rem; font-size: 1rem; border-radius: 6px; border: 1px solid #d1d5db; box-sizing: border-box; }
+        input { width: 100%; }
+        button { background: #2563eb; color: #fff; border: none; cursor: pointer; }
+        button.ghost { background: transparent; color: #2563eb; border: 1px solid #2563eb; }
+        button:disabled { background: #94a3b8; cursor: not-allowed; }
+        pre { background: #f3f4f6; padding: 12px; border-radius: 6px; overflow-x: auto; max-height: 360px; white-space: pre-wrap; word-break: break-all; }
+        .ok { color: #047857; }
+        .err { color: #b91c1c; }
+        nav a { color: #2563eb; margin-right: 1rem; }
+    </style>
+</head>
+<body>
+<nav><a href="/">&larr; Home</a><a href="/signup.html">Create an account</a></nav>
+
+<h1>2. Sign in</h1>
+
+<p>
+    Two factors are accepted on the same form: classic password, or, if the
+    user has enrolled one, a passkey via <em>Use a passkey instead</em>. The
+    server treats both as fully-authenticated sessions.
+</p>
+
+<form id="login-form">
+    <label for="username">Username (email)</label>
+    <input id="username" name="username" type="email" required value="jane.doe@example.com" autocomplete="username webauthn">
+
+    <label for="password">Password</label>
+    <input id="password" name="password" type="password" autocomplete="current-password">
+
+    <p>
+        <button type="submit" id="submit">Sign in with password</button>
+        <button type="button" id="passkey" class="ghost">Use a passkey instead</button>
+    </p>
+</form>
+
+<h2>Output</h2>
+<pre id="output">Pick a sign-in method.</pre>
+
+<script type="module">
+    const form = document.getElementById('login-form');
+    const submit = document.getElementById('submit');
+    const passkeyBtn = document.getElementById('passkey');
+    const output = document.getElementById('output');
+
+    const log = (msg, cls = '') => {
+        const line = document.createElement('div');
+        if (cls) line.className = cls;
+        line.textContent = msg;
+        output.appendChild(line);
+    };
+
+    const b64u = {
+        encode: (buf) => {
+            const bytes = new Uint8Array(buf);
+            let str = '';
+            for (let i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i]);
+            return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+        },
+        decode: (s) => {
+            s = s.replace(/-/g, '+').replace(/_/g, '/');
+            const pad = (4 - (s.length % 4)) % 4;
+            s += '='.repeat(pad);
+            const bin = atob(s);
+            const out = new Uint8Array(bin.length);
+            for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+            return out;
+        },
+    };
+
+    const toGetOptions = (json) => {
+        const o = { ...json };
+        o.challenge = b64u.decode(json.challenge);
+        if (json.allowCredentials) {
+            o.allowCredentials = json.allowCredentials.map((c) => ({ ...c, id: b64u.decode(c.id) }));
+        }
+        return o;
+    };
+
+    const assertionToJson = (cred) => ({
+        id: cred.id,
+        rawId: b64u.encode(cred.rawId),
+        type: cred.type,
+        response: {
+            clientDataJSON: b64u.encode(cred.response.clientDataJSON),
+            authenticatorData: b64u.encode(cred.response.authenticatorData),
+            signature: b64u.encode(cred.response.signature),
+            userHandle: cred.response.userHandle ? b64u.encode(cred.response.userHandle) : null,
+        },
+    });
+
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        submit.disabled = true;
+        passkeyBtn.disabled = true;
+        output.textContent = '';
+
+        try {
+            const username = form.username.value;
+            const password = form.password.value;
+
+            log('POST /api/login/password ...');
+            const r = await fetch('/api/login/password', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username, password }),
+            });
+            if (!r.ok) throw new Error(`login HTTP ${r.status}: ${await r.text()}`);
+            const data = await r.json();
+            log(`Signed in as ${data.username} (via password). ${data.hasPasskey ? 'A passkey is already enrolled.' : 'No passkey enrolled yet, the account page will offer to add one.'}`, 'ok');
+            log('Redirecting to /account.html in 1.5s...');
+            setTimeout(() => { window.location.href = '/account.html'; }, 1500);
+        } catch (err) {
+            log(`Error: ${err.message}`, 'err');
+        } finally {
+            submit.disabled = false;
+            passkeyBtn.disabled = false;
+        }
+    });
+
+    passkeyBtn.addEventListener('click', async () => {
+        submit.disabled = true;
+        passkeyBtn.disabled = true;
+        output.textContent = '';
+
+        try {
+            const username = form.username.value;
+            if (!username) throw new Error('Type your username first, then hit Use a passkey instead.');
+
+            log('POST /api/login/passkey/options ...');
+            const optResp = await fetch('/api/login/passkey/options', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username }),
+            });
+            if (!optResp.ok) throw new Error(`options HTTP ${optResp.status}: ${await optResp.text()}`);
+            const optsJson = await optResp.json();
+            log(`Options received (${optsJson.allowCredentials?.length ?? 0} credential(s)).`, 'ok');
+
+            log('Calling navigator.credentials.get()...');
+            const credential = await navigator.credentials.get({ publicKey: toGetOptions(optsJson) });
+            log('Assertion produced. POST /api/login/passkey/verify ...', 'ok');
+
+            const verifyResp = await fetch('/api/login/passkey/verify', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(assertionToJson(credential)),
+            });
+            if (!verifyResp.ok) throw new Error(`verify HTTP ${verifyResp.status}: ${await verifyResp.text()}`);
+            const verified = await verifyResp.json();
+            log(`Signed in as ${verified.username} (via passkey). Redirecting...`, 'ok');
+            setTimeout(() => { window.location.href = '/account.html'; }, 1500);
+        } catch (err) {
+            log(`Error: ${err.message}`, 'err');
+        } finally {
+            submit.disabled = false;
+            passkeyBtn.disabled = false;
+        }
+    });
+</script>
+</body>
+</html>

--- a/docs/examples/passkey-upgrade-demo/same-origin/public/signup.html
+++ b/docs/examples/passkey-upgrade-demo/same-origin/public/signup.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Passkey Upgrade Demo, Sign up</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 720px; margin: 40px auto; padding: 20px; color: #1f2937; line-height: 1.55; }
+        h1 { font-size: 1.5rem; }
+        label { display: block; margin: 0.6rem 0 0.25rem; font-weight: 500; }
+        input, button { padding: 0.55rem 0.75rem; font-size: 1rem; border-radius: 6px; border: 1px solid #d1d5db; box-sizing: border-box; }
+        input { width: 100%; }
+        button { background: #2563eb; color: #fff; border: none; cursor: pointer; }
+        button:disabled { background: #94a3b8; cursor: not-allowed; }
+        pre { background: #f3f4f6; padding: 12px; border-radius: 6px; overflow-x: auto; max-height: 300px; white-space: pre-wrap; word-break: break-all; }
+        .ok { color: #047857; }
+        .err { color: #b91c1c; }
+        nav a { color: #2563eb; margin-right: 1rem; }
+    </style>
+</head>
+<body>
+<nav><a href="/">&larr; Home</a><a href="/login.html">Already have an account ?</a></nav>
+
+<h1>1. Sign up with a password</h1>
+
+<p>
+    The server hashes the password with <code>password_hash(PASSWORD_BCRYPT)</code>
+    and opens a session. No WebAuthn involved at this step; the passkey
+    enrolment happens later, from the account page.
+</p>
+
+<form id="signup-form">
+    <label for="username">Username (email)</label>
+    <input id="username" name="username" type="email" required value="jane.doe@example.com" autocomplete="username">
+
+    <label for="displayName">Display name</label>
+    <input id="displayName" name="displayName" type="text" value="Jane Doe">
+
+    <label for="password">Password (min 8 chars)</label>
+    <input id="password" name="password" type="password" required minlength="8" autocomplete="new-password">
+
+    <p><button type="submit" id="submit">Sign up</button></p>
+</form>
+
+<h2>Output</h2>
+<pre id="output">Submit the form to create an account.</pre>
+
+<script type="module">
+    const form = document.getElementById('signup-form');
+    const submit = document.getElementById('submit');
+    const output = document.getElementById('output');
+
+    const log = (msg, cls = '') => {
+        const line = document.createElement('div');
+        if (cls) line.className = cls;
+        line.textContent = msg;
+        output.appendChild(line);
+    };
+
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        submit.disabled = true;
+        output.textContent = '';
+
+        try {
+            const username = form.username.value;
+            const displayName = form.displayName.value;
+            const password = form.password.value;
+
+            log('POST /api/signup ...');
+            const r = await fetch('/api/signup', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username, displayName, password }),
+            });
+            if (!r.ok) throw new Error(`signup HTTP ${r.status}: ${await r.text()}`);
+            const data = await r.json();
+            log(`Account "${data.username}" created. You are now signed in via password.`, 'ok');
+            log('Redirecting to /account.html in 1.5s, where you can enrol a passkey.');
+            setTimeout(() => { window.location.href = '/account.html'; }, 1500);
+        } catch (err) {
+            log(`Error: ${err.message}`, 'err');
+        } finally {
+            submit.disabled = false;
+        }
+    });
+</script>
+</body>
+</html>

--- a/docs/examples/passkey-upgrade-demo/same-origin/router.php
+++ b/docs/examples/passkey-upgrade-demo/same-origin/router.php
@@ -1,0 +1,442 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Front controller for `php -S`. Routes the `/api/*` endpoints; for every
+ * other request returns false so the built-in server falls back to serving
+ * the matching static file from `public/`. Bare `/` is rewritten to
+ * `/index.html` because the built-in server does not auto-index.
+ *
+ * Run with: php -S localhost:8000 -t public router.php
+ */
+
+use App\PasskeyUpgradeDemo\Container;
+use ParagonIE\ConstantTime\Base64;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\AuthenticatorSelectionCriteria;
+use Webauthn\PublicKeyCredential;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialParameters;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\PublicKeyCredentialRpEntity;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+require_once __DIR__ . '/../src/bootstrap.php';
+
+session_start();
+$container = new Container();
+$path = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?: '/';
+
+if ($path === '/') {
+    $_SERVER['REQUEST_URI'] = '/index.html';
+
+    return false;
+}
+
+if (! str_starts_with($path, '/api/')) {
+    return false;
+}
+
+header('Content-Type: application/json');
+
+try {
+    match ($path) {
+        '/api/me' => me($container),
+        '/api/logout' => logout(),
+        '/api/signup' => signup($container),
+        '/api/login/password' => loginPassword($container),
+        '/api/login/passkey/options' => loginPasskeyOptions($container),
+        '/api/login/passkey/verify' => loginPasskeyVerify($container),
+        '/api/account/passkey/add/options' => addPasskeyOptions($container),
+        '/api/account/passkey/add/verify' => addPasskeyVerify($container),
+        '/api/account/passkey/rename' => renamePasskey($container),
+        '/api/account/passkey/delete' => deletePasskey($container),
+        default => notFound(),
+    };
+} catch (\Throwable $e) {
+    http_response_code(400);
+    echo json_encode([
+        'error' => $e->getMessage(),
+        'class' => $e::class,
+    ], \JSON_THROW_ON_ERROR);
+}
+
+function notFound(): void
+{
+    http_response_code(404);
+    echo json_encode([
+        'error' => 'Not found',
+    ], \JSON_THROW_ON_ERROR);
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function readJson(): array
+{
+    $body = file_get_contents('php://input') ?: '{}';
+    $json = json_decode($body, true, flags: \JSON_THROW_ON_ERROR);
+
+    return is_array($json) ? $json : [];
+}
+
+function jsonOut(mixed $payload): void
+{
+    echo json_encode($payload, \JSON_THROW_ON_ERROR);
+}
+
+function serializeOptions(Container $container, object $options): string
+{
+    return $container->serializer->serialize($options, 'json', [
+        'json_encode_options' => \JSON_THROW_ON_ERROR,
+        \Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+    ]);
+}
+
+function requireLogin(): string
+{
+    $userHandleB64 = $_SESSION['userHandle'] ?? null;
+    if (! is_string($userHandleB64) || $userHandleB64 === '') {
+        http_response_code(401);
+        echo json_encode([
+            'error' => 'Not authenticated',
+        ], \JSON_THROW_ON_ERROR);
+        exit;
+    }
+
+    return (string) base64_decode($userHandleB64, true);
+}
+
+function me(Container $container): void
+{
+    $userHandleB64 = $_SESSION['userHandle'] ?? null;
+    if (! is_string($userHandleB64) || $userHandleB64 === '') {
+        http_response_code(401);
+        jsonOut([
+            'authenticated' => false,
+        ]);
+
+        return;
+    }
+    $userHandle = (string) base64_decode($userHandleB64, true);
+    $username = $container->userStore->findUsernameByHandle($userHandle);
+    jsonOut([
+        'authenticated' => true,
+        'authMethod' => $_SESSION['authMethod'] ?? null,
+        'username' => $username,
+        'displayName' => $username === null ? null : $container->userStore->findDisplayName($username),
+        'credentials' => $container->credentialStore->listForUser($userHandle),
+    ]);
+}
+
+function logout(): void
+{
+    $_SESSION = [];
+    if (ini_get('session.use_cookies')) {
+        $params = session_get_cookie_params();
+        setcookie(
+            session_name(),
+            '',
+            time() - 42_000,
+            $params['path'],
+            $params['domain'],
+            $params['secure'],
+            $params['httponly']
+        );
+    }
+    session_destroy();
+    jsonOut([
+        'loggedOut' => true,
+    ]);
+}
+
+/**
+ * Creates a brand-new password-only account. No passkey involved yet, this is
+ * the classic signup. The user is logged in straight after, with
+ * `authMethod = 'password'`.
+ */
+function signup(Container $container): void
+{
+    $body = readJson();
+    $username = trim((string) ($body['username'] ?? ''));
+    $password = (string) ($body['password'] ?? '');
+    $displayName = trim((string) ($body['displayName'] ?? '')) ?: $username;
+    if ($username === '' || $password === '') {
+        throw new \RuntimeException('username and password are required.');
+    }
+    if (strlen($password) < 8) {
+        throw new \RuntimeException('Password must be at least 8 characters long.');
+    }
+    if ($container->userStore->exists($username)) {
+        throw new \RuntimeException('Username already taken.');
+    }
+
+    $userHandle = $container->userStore->create($username, $password, $displayName);
+
+    $_SESSION['username'] = $username;
+    $_SESSION['userHandle'] = base64_encode($userHandle);
+    $_SESSION['authMethod'] = 'password';
+
+    jsonOut([
+        'signedUp' => true,
+        'username' => $username,
+    ]);
+}
+
+/**
+ * Password sign-in. Always available, regardless of whether the account also
+ * has a passkey enrolled. `authMethod` records how the user got in so the
+ * account page can suggest the upgrade only to password-signed-in users that
+ * have not enrolled a passkey yet.
+ */
+function loginPassword(Container $container): void
+{
+    $body = readJson();
+    $username = trim((string) ($body['username'] ?? ''));
+    $password = (string) ($body['password'] ?? '');
+    if ($username === '' || $password === '') {
+        throw new \RuntimeException('username and password are required.');
+    }
+
+    $userHandle = $container->userStore->verifyPassword($username, $password);
+    if ($userHandle === null) {
+        usleep(200_000);
+        throw new \RuntimeException('Invalid credentials.');
+    }
+
+    $_SESSION['username'] = $username;
+    $_SESSION['userHandle'] = base64_encode($userHandle);
+    $_SESSION['authMethod'] = 'password';
+
+    jsonOut([
+        'verified' => true,
+        'username' => $username,
+        'hasPasskey' => $container->credentialStore->countForUser($userHandle) > 0,
+    ]);
+}
+
+/**
+ * Issue assertion options scoped to the requested account. The page calls
+ * this when the user clicks "Use a passkey instead" on the login page. If no
+ * passkey is registered, the endpoint returns an error so the page can
+ * gracefully fall back to the password form.
+ */
+function loginPasskeyOptions(Container $container): void
+{
+    $body = readJson();
+    $username = trim((string) ($body['username'] ?? ''));
+    if ($username === '') {
+        throw new \RuntimeException('username is required.');
+    }
+
+    $userHandle = $container->userStore->findUserHandle($username);
+    if ($userHandle === null) {
+        throw new \RuntimeException('Unknown user.');
+    }
+
+    $allowCredentials = $container->credentialStore->allowCredentialsFor($userHandle);
+    if ($allowCredentials === []) {
+        throw new \RuntimeException('No passkey enrolled for this account yet. Sign in with your password first, then add one from your account page.');
+    }
+
+    $challenge = random_bytes(32);
+    $_SESSION['login_passkey_challenge'] = base64_encode($challenge);
+    $_SESSION['login_passkey_username'] = $username;
+
+    $options = PublicKeyCredentialRequestOptions::create(
+        $challenge,
+        $container->relyingPartyId,
+        $allowCredentials,
+        PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_PREFERRED,
+    );
+    $options->timeout = 60_000;
+
+    echo serializeOptions($container, $options);
+}
+
+function loginPasskeyVerify(Container $container): void
+{
+    $body = file_get_contents('php://input') ?: '{}';
+    $credential = $container->serializer->deserialize($body, PublicKeyCredential::class, 'json');
+    \assert($credential instanceof PublicKeyCredential);
+
+    $response = $credential->response;
+    if (! $response instanceof AuthenticatorAssertionResponse) {
+        throw new \RuntimeException('Expected an AuthenticatorAssertionResponse.');
+    }
+
+    $challengeB64 = $_SESSION['login_passkey_challenge'] ?? null;
+    $username = (string) ($_SESSION['login_passkey_username'] ?? '');
+    if (! is_string($challengeB64) || $username === '') {
+        throw new \RuntimeException('Missing passkey-login session.');
+    }
+    $challenge = (string) base64_decode($challengeB64, true);
+
+    $userHandle = $container->userStore->findUserHandle($username);
+    if ($userHandle === null) {
+        throw new \RuntimeException('Unknown user.');
+    }
+
+    $record = $container->credentialStore->findByCredentialId($credential->rawId);
+    if ($record === null) {
+        throw new \RuntimeException('Unknown credential for this account.');
+    }
+
+    $options = PublicKeyCredentialRequestOptions::create(
+        $challenge,
+        $container->relyingPartyId,
+        $container->credentialStore->allowCredentialsFor($userHandle),
+        PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_PREFERRED,
+    );
+
+    $updated = $container->assertionValidator->check(
+        $record,
+        $response,
+        $options,
+        $container->relyingPartyId,
+        $userHandle,
+    );
+    $container->credentialStore->updateAfterAssertion($updated);
+
+    unset($_SESSION['login_passkey_challenge'], $_SESSION['login_passkey_username']);
+    $_SESSION['username'] = $username;
+    $_SESSION['userHandle'] = base64_encode($userHandle);
+    $_SESSION['authMethod'] = 'passkey';
+
+    jsonOut([
+        'verified' => true,
+        'username' => $username,
+    ]);
+}
+
+/**
+ * Enrol a passkey on the logged-in account. This is the "upgrade" call: the
+ * user authenticated with a password (or a previous passkey), and is now
+ * adding a passkey for next time.
+ *
+ * Production note: if the current auth method is a weak factor (just a
+ * password, no email verification step, no recent re-auth), a real RP should
+ * force a re-auth before this enrolment, because anyone with the password
+ * could otherwise silently bind their own passkey to the account.
+ */
+function addPasskeyOptions(Container $container): void
+{
+    $userHandle = requireLogin();
+    $username = $container->userStore->findUsernameByHandle($userHandle);
+    if ($username === null) {
+        throw new \RuntimeException('Session out of sync. Sign in again.');
+    }
+
+    $challenge = random_bytes(32);
+    $_SESSION['add_passkey_challenge'] = base64_encode($challenge);
+
+    $options = PublicKeyCredentialCreationOptions::create(
+        PublicKeyCredentialRpEntity::create($container->relyingPartyName, $container->relyingPartyId),
+        PublicKeyCredentialUserEntity::create($username, $userHandle, (string) $container->userStore->findDisplayName($username)),
+        $challenge,
+        [
+            PublicKeyCredentialParameters::create('public-key', -7),
+            PublicKeyCredentialParameters::create('public-key', -257),
+        ],
+        AuthenticatorSelectionCriteria::create(
+            null,
+            AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_PREFERRED,
+            AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_PREFERRED,
+        ),
+        PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
+        $container->credentialStore->excludeCredentialsFor($userHandle),
+    );
+    $options->timeout = 60_000;
+
+    echo serializeOptions($container, $options);
+}
+
+function addPasskeyVerify(Container $container): void
+{
+    $userHandle = requireLogin();
+    $username = $container->userStore->findUsernameByHandle($userHandle);
+    if ($username === null) {
+        throw new \RuntimeException('Session out of sync. Sign in again.');
+    }
+
+    $body = file_get_contents('php://input') ?: '{}';
+    $credential = $container->serializer->deserialize($body, PublicKeyCredential::class, 'json');
+    \assert($credential instanceof PublicKeyCredential);
+
+    $response = $credential->response;
+    if (! $response instanceof AuthenticatorAttestationResponse) {
+        throw new \RuntimeException('Expected an AuthenticatorAttestationResponse.');
+    }
+
+    $challengeB64 = $_SESSION['add_passkey_challenge'] ?? null;
+    if (! is_string($challengeB64)) {
+        throw new \RuntimeException('Missing add-passkey session.');
+    }
+    $challenge = (string) base64_decode($challengeB64, true);
+
+    $options = PublicKeyCredentialCreationOptions::create(
+        PublicKeyCredentialRpEntity::create($container->relyingPartyName, $container->relyingPartyId),
+        PublicKeyCredentialUserEntity::create($username, $userHandle, $username),
+        $challenge,
+        [
+            PublicKeyCredentialParameters::create('public-key', -7),
+            PublicKeyCredentialParameters::create('public-key', -257),
+        ],
+    );
+
+    $record = $container->attestationValidator->check($response, $options, $container->relyingPartyId);
+    $label = trim((string) ($credential->clientExtensionResults['demoLabel'] ?? ''));
+    if ($label === '') {
+        $label = sprintf('Passkey added on %s', date('Y-m-d H:i'));
+    }
+    $container->credentialStore->save($userHandle, $record, $label);
+    unset($_SESSION['add_passkey_challenge']);
+
+    jsonOut([
+        'verified' => true,
+        'credentialId' => Base64::encode($record->publicKeyCredentialId),
+    ]);
+}
+
+function renamePasskey(Container $container): void
+{
+    $userHandle = requireLogin();
+    $body = readJson();
+    $credentialId = (string) base64_decode((string) ($body['credentialId'] ?? ''), true);
+    $label = trim((string) ($body['label'] ?? ''));
+    if ($credentialId === '' || $label === '') {
+        throw new \RuntimeException('credentialId and label are required.');
+    }
+    $ok = $container->credentialStore->rename($credentialId, $userHandle, $label);
+    if (! $ok) {
+        throw new \RuntimeException('Cannot rename this credential.');
+    }
+    jsonOut([
+        'renamed' => true,
+    ]);
+}
+
+/**
+ * Allows deleting any passkey, including the last one, because the account
+ * always has a password fallback. This is the upside of the upgrade flow:
+ * losing every passkey is recoverable, the user just falls back to the
+ * password.
+ */
+function deletePasskey(Container $container): void
+{
+    $userHandle = requireLogin();
+    $body = readJson();
+    $credentialId = (string) base64_decode((string) ($body['credentialId'] ?? ''), true);
+    if ($credentialId === '') {
+        throw new \RuntimeException('credentialId is required.');
+    }
+    $ok = $container->credentialStore->delete($credentialId, $userHandle);
+    if (! $ok) {
+        throw new \RuntimeException('Cannot delete this credential.');
+    }
+    jsonOut([
+        'deleted' => true,
+    ]);
+}

--- a/docs/examples/passkey-upgrade-demo/same-origin/run.sh
+++ b/docs/examples/passkey-upgrade-demo/same-origin/run.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Boot the same-origin passkey-upgrade-demo on http://localhost:8000.
+# Usage:  ./same-origin/run.sh   (from docs/examples/passkey-upgrade-demo/)
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [[ ! -d vendor ]]; then
+    echo "vendor/ missing, running composer install"
+    composer install --no-interaction
+fi
+
+PORT=8000
+
+is_busy() { lsof -i ":$1" >/dev/null 2>&1 || ss -ltn 2>/dev/null | grep -q ":$1 "; }
+if is_busy "$PORT"; then
+    echo "Port $PORT already in use. Free it and retry." >&2
+    exit 1
+fi
+
+cleanup() {
+    echo
+    echo "Stopping server..."
+    [[ -n "${PID:-}" ]] && kill "$PID" 2>/dev/null || true
+    wait 2>/dev/null || true
+}
+trap cleanup INT TERM EXIT
+
+echo "Passkey-upgrade WebAuthn demo (same-origin) -> http://localhost:$PORT"
+echo
+echo "Steps:"
+echo "  1. open http://localhost:$PORT/                (landing page)"
+echo "  2. open http://localhost:$PORT/signup.html     (create a password-only account)"
+echo "  3. open http://localhost:$PORT/account.html    (enrol a passkey from the upgrade CTA)"
+echo "  4. open http://localhost:$PORT/login.html      (sign in with password OR with the passkey)"
+echo
+echo "Logs follow. Ctrl+C to stop."
+echo "----------------------------------------------------------------"
+
+php -S "localhost:$PORT" -t same-origin/public same-origin/router.php &
+PID=$!
+
+wait

--- a/docs/examples/passkey-upgrade-demo/src/CredentialStore.php
+++ b/docs/examples/passkey-upgrade-demo/src/CredentialStore.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\PasskeyUpgradeDemo;
+
+use Symfony\Component\Serializer\Serializer;
+use Webauthn\CredentialRecord;
+use Webauthn\PublicKeyCredentialDescriptor;
+
+/**
+ * Demo-only credential store. Each row keeps:
+ *
+ *  - `userHandle`         the binary user handle the credential is bound to
+ *                         (base64-encoded for JSON storage);
+ *  - `credentialId`       the binary credential ID (base64-encoded);
+ *  - `source`             the framework's CredentialRecord serialized to JSON.
+ *                         This is the canonical blob to persist after a
+ *                         successful attestation. It already contains the
+ *                         credential ID, the COSE public key, the signature
+ *                         counter, the AAGUID, transports and the backup flags;
+ *  - `label`              a human-friendly alias the user can rename;
+ *  - `addedAt`            registration timestamp;
+ *  - `lastUsedAt`         updated on every successful assertion.
+ *
+ * Production code MUST replace this with a real implementation of
+ * `Webauthn\CredentialRecordRepositoryInterface` (and optionally
+ * `Webauthn\CanSaveCredentialRecord` if it owns persistence). Doctrine users
+ * can reuse `DoctrineCredentialSourceRepository` from the Symfony bundle as
+ * a reference implementation.
+ */
+final class CredentialStore
+{
+    public function __construct(
+        private readonly string $file,
+        private readonly Serializer $serializer,
+    ) {
+        $dir = dirname($this->file);
+        if (! is_dir($dir)) {
+            mkdir($dir, 0o755, true);
+        }
+        if (! file_exists($this->file)) {
+            file_put_contents($this->file, '[]');
+        }
+    }
+
+    /**
+     * @return array<string, array{userHandle: string, credentialId: string, source: string, label: string, addedAt: int, lastUsedAt: ?int}>
+     */
+    private function readAll(): array
+    {
+        $raw = (string) file_get_contents($this->file);
+        $data = json_decode($raw, true);
+
+        return is_array($data) ? $data : [];
+    }
+
+    /**
+     * @param array<string, array{userHandle: string, credentialId: string, source: string, label: string, addedAt: int, lastUsedAt: ?int}> $data
+     */
+    private function writeAll(array $data): void
+    {
+        file_put_contents($this->file, json_encode($data, \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * Persist a freshly registered credential. Call this right after
+     * `AuthenticatorAttestationResponseValidator::check()` returns.
+     */
+    public function save(string $userHandle, CredentialRecord $record, string $label): void
+    {
+        $key = base64_encode($record->publicKeyCredentialId);
+        $all = $this->readAll();
+        $all[$key] = [
+            'userHandle' => base64_encode($userHandle),
+            'credentialId' => base64_encode($record->publicKeyCredentialId),
+            'source' => $this->serializer->serialize($record, 'json'),
+            'label' => $label,
+            'addedAt' => time(),
+            'lastUsedAt' => null,
+        ];
+        $this->writeAll($all);
+    }
+
+    /**
+     * Refresh the stored CredentialRecord after a successful assertion. The
+     * counter, backup flags and uvInitialized may have been updated in place
+     * by the validator, so we re-serialize the whole record.
+     */
+    public function updateAfterAssertion(CredentialRecord $record): void
+    {
+        $key = base64_encode($record->publicKeyCredentialId);
+        $all = $this->readAll();
+        if (! isset($all[$key])) {
+            return;
+        }
+        $all[$key]['source'] = $this->serializer->serialize($record, 'json');
+        $all[$key]['lastUsedAt'] = time();
+        $this->writeAll($all);
+    }
+
+    public function rename(string $credentialId, string $userHandle, string $label): bool
+    {
+        $key = base64_encode($credentialId);
+        $all = $this->readAll();
+        if (! isset($all[$key])) {
+            return false;
+        }
+        if ($all[$key]['userHandle'] !== base64_encode($userHandle)) {
+            return false;
+        }
+        $all[$key]['label'] = $label;
+        $this->writeAll($all);
+
+        return true;
+    }
+
+    public function delete(string $credentialId, string $userHandle): bool
+    {
+        $key = base64_encode($credentialId);
+        $all = $this->readAll();
+        if (! isset($all[$key])) {
+            return false;
+        }
+        if ($all[$key]['userHandle'] !== base64_encode($userHandle)) {
+            return false;
+        }
+        unset($all[$key]);
+        $this->writeAll($all);
+
+        return true;
+    }
+
+    public function findByCredentialId(string $credentialId): ?CredentialRecord
+    {
+        $key = base64_encode($credentialId);
+        $row = $this->readAll()[$key] ?? null;
+        if ($row === null) {
+            return null;
+        }
+        $record = $this->serializer->deserialize($row['source'], CredentialRecord::class, 'json');
+        \assert($record instanceof CredentialRecord);
+
+        return $record;
+    }
+
+    public function findUserHandleByCredentialId(string $credentialId): ?string
+    {
+        $key = base64_encode($credentialId);
+        $row = $this->readAll()[$key] ?? null;
+
+        return $row === null ? null : (string) base64_decode($row['userHandle'], true);
+    }
+
+    /**
+     * Build the `allowCredentials` list a relying party passes in
+     * PublicKeyCredentialRequestOptions to scope the assertion ceremony to a
+     * known user.
+     *
+     * @return PublicKeyCredentialDescriptor[]
+     */
+    public function allowCredentialsFor(string $userHandle): array
+    {
+        $needle = base64_encode($userHandle);
+        $descriptors = [];
+        foreach ($this->readAll() as $row) {
+            if ($row['userHandle'] !== $needle) {
+                continue;
+            }
+            $rawId = (string) base64_decode($row['credentialId'], true);
+            $descriptors[] = PublicKeyCredentialDescriptor::create('public-key', $rawId);
+        }
+
+        return $descriptors;
+    }
+
+    /**
+     * Build the `excludeCredentials` list a relying party passes in
+     * PublicKeyCredentialCreationOptions to prevent registering the same
+     * authenticator twice for the same user.
+     *
+     * @return PublicKeyCredentialDescriptor[]
+     */
+    public function excludeCredentialsFor(string $userHandle): array
+    {
+        return $this->allowCredentialsFor($userHandle);
+    }
+
+    /**
+     * @return list<array{credentialId: string, label: string, addedAt: int, lastUsedAt: ?int, counter: int, aaguid: string, transports: list<string>, backupEligible: ?bool, backupStatus: ?bool}>
+     */
+    public function listForUser(string $userHandle): array
+    {
+        $needle = base64_encode($userHandle);
+        $rows = [];
+        foreach ($this->readAll() as $row) {
+            if ($row['userHandle'] !== $needle) {
+                continue;
+            }
+            $record = $this->serializer->deserialize($row['source'], CredentialRecord::class, 'json');
+            \assert($record instanceof CredentialRecord);
+            $rows[] = [
+                'credentialId' => $row['credentialId'],
+                'label' => $row['label'],
+                'addedAt' => $row['addedAt'],
+                'lastUsedAt' => $row['lastUsedAt'],
+                'counter' => $record->counter,
+                'aaguid' => $record->aaguid->toRfc4122(),
+                'transports' => $record->transports,
+                'backupEligible' => $record->backupEligible,
+                'backupStatus' => $record->backupStatus,
+            ];
+        }
+
+        return $rows;
+    }
+
+    public function countForUser(string $userHandle): int
+    {
+        return count($this->listForUser($userHandle));
+    }
+}

--- a/docs/examples/passkey-upgrade-demo/src/UserStore.php
+++ b/docs/examples/passkey-upgrade-demo/src/UserStore.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\PasskeyUpgradeDemo;
+
+/**
+ * Demo-only user store. Unlike the basic-demo's UserStore, accounts here
+ * carry a password hash (PASSWORD_BCRYPT) so the first sign-in factor is a
+ * classic password. The passkey-upgrade flow then adds a passkey as an
+ * additional, stronger sign-in option on top of the password.
+ *
+ * The user handle is a 32-byte random blob generated at signup, NOT derived
+ * from the username, so that renaming or rotating the username later does
+ * not invalidate every passkey. Production code MUST persist users in a real
+ * database and treat the user handle as the opaque, immutable account
+ * identifier.
+ */
+final class UserStore
+{
+    public function __construct(
+        private readonly string $file,
+    ) {
+        $dir = dirname($this->file);
+        if (! is_dir($dir)) {
+            mkdir($dir, 0o755, true);
+        }
+        if (! file_exists($this->file)) {
+            file_put_contents($this->file, '[]');
+        }
+    }
+
+    /**
+     * @return array<string, array{userHandle: string, displayName: string, passwordHash: string, createdAt: int}>
+     */
+    private function readAll(): array
+    {
+        $raw = (string) file_get_contents($this->file);
+        $data = json_decode($raw, true);
+
+        return is_array($data) ? $data : [];
+    }
+
+    /**
+     * @param array<string, array{userHandle: string, displayName: string, passwordHash: string, createdAt: int}> $data
+     */
+    private function writeAll(array $data): void
+    {
+        file_put_contents($this->file, json_encode($data, \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR));
+    }
+
+    public function exists(string $username): bool
+    {
+        return isset($this->readAll()[$username]);
+    }
+
+    /**
+     * Create a brand-new account. Returns the binary user handle to bind
+     * future passkeys against. Throws if the username is already taken.
+     */
+    public function create(string $username, string $password, string $displayName): string
+    {
+        $all = $this->readAll();
+        if (isset($all[$username])) {
+            throw new \RuntimeException('Username already taken.');
+        }
+        $userHandle = random_bytes(32);
+        $all[$username] = [
+            'userHandle' => base64_encode($userHandle),
+            'displayName' => $displayName === '' ? $username : $displayName,
+            'passwordHash' => password_hash($password, \PASSWORD_BCRYPT),
+            'createdAt' => time(),
+        ];
+        $this->writeAll($all);
+
+        return $userHandle;
+    }
+
+    /**
+     * Verify a password and return the binary user handle on success.
+     * Returns null when the username does not exist or the password is wrong.
+     */
+    public function verifyPassword(string $username, string $password): ?string
+    {
+        $row = $this->readAll()[$username] ?? null;
+        if ($row === null) {
+            return null;
+        }
+        if (! password_verify($password, $row['passwordHash'])) {
+            return null;
+        }
+
+        return (string) base64_decode($row['userHandle'], true);
+    }
+
+    public function findUserHandle(string $username): ?string
+    {
+        $row = $this->readAll()[$username] ?? null;
+
+        return $row === null ? null : (string) base64_decode($row['userHandle'], true);
+    }
+
+    public function findUsernameByHandle(string $userHandle): ?string
+    {
+        $needle = base64_encode($userHandle);
+        foreach ($this->readAll() as $username => $row) {
+            if ($row['userHandle'] === $needle) {
+                return $username;
+            }
+        }
+
+        return null;
+    }
+
+    public function findDisplayName(string $username): ?string
+    {
+        return $this->readAll()[$username]['displayName'] ?? null;
+    }
+}

--- a/docs/examples/passkey-upgrade-demo/src/bootstrap.php
+++ b/docs/examples/passkey-upgrade-demo/src/bootstrap.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\PasskeyUpgradeDemo;
+
+use Cose\Algorithm\Manager;
+use Cose\Algorithm\Signature\ECDSA\ES256;
+use Cose\Algorithm\Signature\RSA\RS256;
+use Symfony\Component\Serializer\Serializer;
+use Webauthn\AttestationStatement\AttestationStatementSupportManager;
+use Webauthn\AttestationStatement\NoneAttestationStatementSupport;
+use Webauthn\AuthenticatorAssertionResponseValidator;
+use Webauthn\AuthenticatorAttestationResponseValidator;
+use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
+use Webauthn\Denormalizer\WebauthnSerializerFactory;
+
+$autoload = __DIR__ . '/../vendor/autoload.php';
+if (! is_file($autoload)) {
+    fwrite(\STDERR, "Run `composer install` in docs/examples/passkey-upgrade-demo/ first.\n");
+    exit(1);
+}
+require_once $autoload;
+
+require_once __DIR__ . '/UserStore.php';
+require_once __DIR__ . '/CredentialStore.php';
+
+/**
+ * Service container for the passkey-upgrade demo. The wiring is identical to
+ * the basic-demo: serializer + attestation/assertion validators + COSE
+ * algorithm manager. What changes is the application around them, not the
+ * WebAuthn plumbing itself.
+ *
+ * The two flows demonstrated are:
+ *
+ *  - sign up with `username + password`, then sign in with the same. No
+ *    passkey involved.
+ *  - once signed in, enrol a passkey from the account page so the next
+ *    sign-in can skip the password entirely.
+ */
+final class Container
+{
+    public string $relyingPartyId;
+
+    public string $relyingPartyName;
+
+    /** @var string[] */
+    public array $allowedOrigins;
+
+    public AttestationStatementSupportManager $attestationManager;
+
+    public Manager $algorithmManager;
+
+    public CeremonyStepManagerFactory $ceremonyFactory;
+
+    public AuthenticatorAttestationResponseValidator $attestationValidator;
+
+    public AuthenticatorAssertionResponseValidator $assertionValidator;
+
+    public Serializer $serializer;
+
+    public UserStore $userStore;
+
+    public CredentialStore $credentialStore;
+
+    public function __construct()
+    {
+        $this->relyingPartyId = $_ENV['RP_ID'] ?? 'localhost';
+        $this->relyingPartyName = 'Passkey Upgrade Demo';
+        $this->allowedOrigins = explode(',', $_ENV['ALLOWED_ORIGINS'] ?? 'http://localhost:8000');
+
+        $this->attestationManager = new AttestationStatementSupportManager();
+        $this->attestationManager->add(new NoneAttestationStatementSupport());
+
+        $this->algorithmManager = Manager::create()->add(ES256::create(), RS256::create());
+
+        $serializer = (new WebauthnSerializerFactory($this->attestationManager))->create();
+        \assert($serializer instanceof Serializer);
+        $this->serializer = $serializer;
+
+        $this->ceremonyFactory = new CeremonyStepManagerFactory();
+        $this->ceremonyFactory->setAttestationStatementSupportManager($this->attestationManager);
+        $this->ceremonyFactory->setAlgorithmManager($this->algorithmManager);
+        $this->ceremonyFactory->setAllowedOrigins($this->allowedOrigins);
+
+        $this->attestationValidator = AuthenticatorAttestationResponseValidator::create(
+            $this->ceremonyFactory->creationCeremony(),
+        );
+        $this->assertionValidator = AuthenticatorAssertionResponseValidator::create(
+            $this->ceremonyFactory->requestCeremony(),
+        );
+
+        $varDir = $_ENV['VAR_DIR'] ?? __DIR__ . '/../var';
+        $this->userStore = new UserStore($varDir . '/users.json');
+        $this->credentialStore = new CredentialStore($varDir . '/credentials.json', $this->serializer);
+    }
+}

--- a/docs/examples/prf-demo/src/bootstrap.php
+++ b/docs/examples/prf-demo/src/bootstrap.php
@@ -15,27 +15,12 @@ use Webauthn\AuthenticatorAttestationResponseValidator;
 use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
 use Webauthn\Denormalizer\WebauthnSerializerFactory;
 
-// Two ways to load the lib:
-//   1. Standalone — `composer install` in this directory pulls
-//      web-auth/webauthn-lib >= 5.4 into ./vendor.
-//   2. Inside the monorepo — fall back to the framework's own
-//      vendor/autoload.php which exposes the lib via PSR-4.
-$autoloads = [
-    __DIR__ . '/../vendor/autoload.php',
-    __DIR__ . '/../../../../vendor/autoload.php',
-];
-$loaded = false;
-foreach ($autoloads as $autoload) {
-    if (is_file($autoload)) {
-        require_once $autoload;
-        $loaded = true;
-        break;
-    }
-}
-if (! $loaded) {
+$autoload = __DIR__ . '/../vendor/autoload.php';
+if (! is_file($autoload)) {
     fwrite(\STDERR, "Run `composer install` in docs/examples/prf-demo/ first.\n");
     exit(1);
 }
+require_once $autoload;
 
 /**
  * Wires the minimum the PRF demo needs: serializer, attestation/assertion validators,

--- a/docs/examples/signal-api-demo/.gitignore
+++ b/docs/examples/signal-api-demo/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+/var/*.json
+composer.lock

--- a/docs/examples/signal-api-demo/README.md
+++ b/docs/examples/signal-api-demo/README.md
@@ -1,0 +1,107 @@
+# Signal API Demo, `web-auth/webauthn-lib`
+
+Pure-PHP example that exercises the three W3C
+[Signal](https://w3c.github.io/webauthn/#sctn-signal-methods) methods
+the spec exposes for keeping passkey-manager state in sync with the
+relying party.
+
+The Signal API runs **entirely in the browser**. The framework's job
+is just to hand the page a fresh, authoritative snapshot of what the
+RP currently considers valid: which credential IDs are still accepted
+for a user, and what the up-to-date `name` / `displayName` should be.
+The page then issues the JS calls.
+
+## The three methods
+
+| Call | When this demo fires it |
+|---|---|
+| `PublicKeyCredential.signalUnknownCredential({ rpId, credentialId })` | Right after `POST /api/account/passkey/delete` succeeds. Tells the passkey manager: this credential id is no longer recognised by the RP, prune it. |
+| `PublicKeyCredential.signalAllAcceptedCredentials({ rpId, userId, allAcceptedCredentialIds })` | On page load, after enrolling a passkey, after deleting one. The full, authoritative list of accepted credential IDs for the user. The manager prunes anything not in the list. |
+| `PublicKeyCredential.signalCurrentUserDetails({ rpId, userId, name, displayName })` | On page load, after the user renames the account. Refreshes the human-readable identity associated with this user in the manager UI. |
+
+Each unsupported method falls back to a no-op + a log line, so the demo
+keeps working on browsers that lack Signal support.
+
+## Four pages
+
+| Page | What it does |
+|---|---|
+| [`/`](same-origin/public/index.html) | Landing page, explains the API and shows the current session state. |
+| [`/register.html`](same-origin/public/register.html) | Standard registration ceremony, copied from the basic-demo. |
+| [`/login.html`](same-origin/public/login.html) | Standard assertion ceremony, copied from the basic-demo. |
+| [`/account.html`](same-origin/public/account.html) | The Signal API playground. Shows feature-detection results for the three methods, lets the user edit the display name (auto-fires `signalCurrentUserDetails`), enrol/rename/delete passkeys (auto-fires the relevant signals), and trigger any signal manually with explicit buttons. The action log shows every call as it happens. |
+
+## What the server contributes
+
+A single new endpoint, `GET /api/account/signal-payload`, returns the
+canonical snapshot:
+
+```json
+{
+  "rpId": "localhost",
+  "userId": "base64url-of-user-handle",
+  "name": "jane.doe@example.com",
+  "displayName": "Jane Doe",
+  "allAcceptedCredentialIds": ["base64url-1", "base64url-2"]
+}
+```
+
+The page reads this every time it is about to make a Signal call.
+Everything else is the same as the basic-demo:
+`register/options`+`verify`, `login/options`+`verify`,
+`account/passkey/{add,rename,delete}`, plus a new `account/rename` for
+changing the display name.
+
+## Run it
+
+```bash
+cd docs/examples/signal-api-demo
+./same-origin/run.sh
+```
+
+Walk through:
+
+1. <http://localhost:8000/register.html>, register a passkey.
+2. <http://localhost:8000/account.html>:
+   - watch the support panel at the top, it tells you which Signal
+     methods your browser exposes;
+   - the page auto-fires `signalCurrentUserDetails` and
+     `signalAllAcceptedCredentials` on load, you should see them in
+     the activity log;
+   - change the display name, hit *Save*: the server stores the
+     change, then `signalCurrentUserDetails` is sent;
+   - enrol a second passkey, the page fires
+     `signalAllAcceptedCredentials` with the new id;
+   - delete one, the page fires `signalUnknownCredential` with the
+     deleted id, then `signalAllAcceptedCredentials` with the
+     remaining ones.
+3. Open your OS passkey manager (macOS Keychain, Windows Settings ->
+   Sign-in options -> Passkeys, Android Google Password Manager) and
+   verify the changes propagated.
+
+## Browser support
+
+Signal is recent. Chromium-based browsers (Chrome 132+, Edge 132+)
+landed it first, Safari followed in 18.x. Firefox is trailing as of
+this writing. The account page detects each method individually so
+partial support is handled gracefully.
+
+## What lives in `var/`
+
+Same shape as the basic-demo:
+
+- `var/users.json`: `username -> { userHandle, displayName, createdAt }`.
+- `var/credentials.json`: `credentialId -> { userHandle, credentialId,
+  source, label, addedAt, lastUsedAt }`.
+
+Delete the two JSON files to reset the demo.
+
+## Where to look in the code
+
+| What | File |
+|---|---|
+| Service wiring | [`src/bootstrap.php`](src/bootstrap.php) |
+| User table (also exposes `updateDisplayName`) | [`src/UserStore.php`](src/UserStore.php) |
+| Credential persistence | [`src/CredentialStore.php`](src/CredentialStore.php) |
+| HTTP endpoints including `/api/account/signal-payload` and `/api/account/rename` | [`same-origin/router.php`](same-origin/router.php) |
+| Browser side, all three Signal calls + auto-fire wiring | [`same-origin/public/account.html`](same-origin/public/account.html) |

--- a/docs/examples/signal-api-demo/composer.json
+++ b/docs/examples/signal-api-demo/composer.json
@@ -1,0 +1,30 @@
+{
+    "name": "web-auth/signal-api-demo",
+    "description": "End-to-end pure-PHP demo of the W3C WebAuthn Signal API (signalUnknownCredential, signalAllAcceptedCredentials, signalCurrentUserDetails) on top of web-auth/webauthn-lib",
+    "type": "project",
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../..",
+            "options": {
+                "symlink": true,
+                "versions": {
+                    "web-auth/webauthn-framework": "5.4.x-dev"
+                }
+            }
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "ext-json": "*",
+        "ext-openssl": "*",
+        "web-auth/webauthn-framework": "5.4.x-dev",
+        "symfony/clock": "^6.4 || ^7.0",
+        "symfony/serializer": "^6.4 || ^7.0",
+        "symfony/property-access": "^6.4 || ^7.0",
+        "symfony/property-info": "^6.4 || ^7.0",
+        "symfony/uid": "^6.4 || ^7.0"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/docs/examples/signal-api-demo/same-origin/public/account.html
+++ b/docs/examples/signal-api-demo/same-origin/public/account.html
@@ -1,0 +1,357 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Signal API Demo, My account</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 920px; margin: 40px auto; padding: 20px; color: #1f2937; line-height: 1.55; }
+        h1 { font-size: 1.5rem; }
+        h2 { font-size: 1.1rem; margin-top: 2rem; }
+        nav a { color: #2563eb; margin-right: 1rem; }
+        button { background: #2563eb; color: #fff; border: none; cursor: pointer; padding: 0.45rem 0.85rem; border-radius: 6px; font-size: 0.95rem; margin-right: 0.4rem; }
+        button.ghost { background: transparent; color: #2563eb; border: 1px solid #2563eb; }
+        button.danger { background: #b91c1c; }
+        button:disabled { background: #94a3b8; cursor: not-allowed; }
+        table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+        th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid #e5e7eb; font-size: 0.92rem; vertical-align: top; }
+        th { background: #f9fafb; }
+        td.label input { padding: 0.3rem 0.5rem; font-size: 0.9rem; border-radius: 4px; border: 1px solid #d1d5db; width: 100%; box-sizing: border-box; }
+        td.actions { white-space: nowrap; }
+        code { background: #f3f4f6; padding: 1px 6px; border-radius: 4px; font-size: 0.85rem; }
+        pre { background: #f3f4f6; padding: 12px; border-radius: 6px; overflow-x: auto; max-height: 260px; white-space: pre-wrap; word-break: break-all; }
+        .ok { color: #047857; }
+        .err { color: #b91c1c; }
+        .hidden { display: none; }
+        .panel { background: #eff6ff; border-left: 4px solid #2563eb; padding: 14px 18px; border-radius: 6px; margin: 1.2rem 0; }
+        .panel h3 { margin-top: 0; }
+        .signal-row { display: flex; gap: 0.6rem; align-items: center; margin: 0.4rem 0; flex-wrap: wrap; }
+        .signal-row code { white-space: nowrap; }
+        input.text { padding: 0.4rem 0.6rem; font-size: 0.95rem; border-radius: 4px; border: 1px solid #d1d5db; }
+        .support { font-size: 0.85rem; color: #6b7280; }
+        .support .ok { color: #047857; }
+        .support .err { color: #b91c1c; }
+    </style>
+</head>
+<body>
+<nav>
+    <a href="/">&larr; Home</a>
+    <a href="/register.html">Register a different account</a>
+</nav>
+
+<h1>My account</h1>
+
+<div id="unauthenticated" class="hidden">
+    <p class="err">You are not signed in.</p>
+    <p><a href="/login.html"><button>Sign in</button></a></p>
+</div>
+
+<div id="authenticated" class="hidden">
+    <p>Signed in as <strong id="username"></strong>.
+        <button id="logout" class="ghost" style="margin-left: 1rem;">Sign out</button>
+    </p>
+
+    <div class="panel">
+        <h3>Signal API support</h3>
+        <ul class="support">
+            <li><code>signalUnknownCredential</code>: <span id="support-unknown"></span></li>
+            <li><code>signalAllAcceptedCredentials</code>: <span id="support-all"></span></li>
+            <li><code>signalCurrentUserDetails</code>: <span id="support-user"></span></li>
+        </ul>
+        <p>Each unsupported call falls back to a no-op + a log line.</p>
+    </div>
+
+    <h2>Account profile</h2>
+    <div class="signal-row">
+        Display name:
+        <input id="displayName" type="text" class="text" placeholder="Display name">
+        <button id="save-displayName">Save</button>
+        <button id="signal-user" class="ghost">Send <code>signalCurrentUserDetails</code></button>
+    </div>
+
+    <h2>Enrolled passkeys</h2>
+    <p>
+        <button id="add-passkey">Enrol another passkey</button>
+        <button id="signal-all" class="ghost">Send <code>signalAllAcceptedCredentials</code></button>
+    </p>
+    <table id="passkeys">
+        <thead>
+        <tr>
+            <th>Label</th>
+            <th>Credential ID</th>
+            <th>AAGUID</th>
+            <th>Counter</th>
+            <th>Last used</th>
+            <th>Actions</th>
+        </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</div>
+
+<h2>Activity log</h2>
+<pre id="output">Loading account...</pre>
+
+<script type="module">
+    const output = document.getElementById('output');
+    const log = (msg, cls = '') => {
+        const line = document.createElement('div');
+        if (cls) line.className = cls;
+        line.textContent = msg;
+        output.appendChild(line);
+        output.scrollTop = output.scrollHeight;
+    };
+
+    const b64u = {
+        encode: (buf) => {
+            const bytes = new Uint8Array(buf);
+            let str = '';
+            for (let i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i]);
+            return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+        },
+        decode: (s) => {
+            s = s.replace(/-/g, '+').replace(/_/g, '/');
+            const pad = (4 - (s.length % 4)) % 4;
+            s += '='.repeat(pad);
+            const bin = atob(s);
+            const out = new Uint8Array(bin.length);
+            for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+            return out;
+        },
+    };
+
+    const toCreateOptions = (json) => {
+        const o = { ...json };
+        o.challenge = b64u.decode(json.challenge);
+        o.user = { ...json.user, id: b64u.decode(json.user.id) };
+        if (json.excludeCredentials) {
+            o.excludeCredentials = json.excludeCredentials.map((c) => ({ ...c, id: b64u.decode(c.id) }));
+        }
+        return o;
+    };
+
+    const credentialToJson = (cred, label) => ({
+        id: cred.id,
+        rawId: b64u.encode(cred.rawId),
+        type: cred.type,
+        response: {
+            clientDataJSON: b64u.encode(cred.response.clientDataJSON),
+            attestationObject: b64u.encode(cred.response.attestationObject),
+        },
+        clientExtensionResults: { demoLabel: label },
+    });
+
+    const support = {
+        unknown: typeof PublicKeyCredential?.signalUnknownCredential === 'function',
+        all: typeof PublicKeyCredential?.signalAllAcceptedCredentials === 'function',
+        user: typeof PublicKeyCredential?.signalCurrentUserDetails === 'function',
+    };
+
+    const markSupport = (id, ok) => {
+        const el = document.getElementById(id);
+        el.innerHTML = ok ? '<span class="ok">supported</span>' : '<span class="err">not supported in this browser</span>';
+    };
+
+    const fetchPayload = async () => {
+        const r = await fetch('/api/account/signal-payload');
+        if (!r.ok) throw new Error(`signal-payload HTTP ${r.status}: ${await r.text()}`);
+        return await r.json();
+    };
+
+    const sendSignalUnknown = async (credentialIdB64Url) => {
+        if (!support.unknown) {
+            log(`signalUnknownCredential not available, skipping (would have signalled ${credentialIdB64Url}).`);
+            return;
+        }
+        const payload = await fetchPayload();
+        try {
+            await PublicKeyCredential.signalUnknownCredential({
+                rpId: payload.rpId,
+                credentialId: credentialIdB64Url,
+            });
+            log(`signalUnknownCredential sent for ${credentialIdB64Url}.`, 'ok');
+        } catch (err) {
+            log(`signalUnknownCredential error: ${err.message}`, 'err');
+        }
+    };
+
+    const sendSignalAllAccepted = async () => {
+        if (!support.all) {
+            log('signalAllAcceptedCredentials not available, skipping.');
+            return;
+        }
+        const payload = await fetchPayload();
+        try {
+            await PublicKeyCredential.signalAllAcceptedCredentials({
+                rpId: payload.rpId,
+                userId: payload.userId,
+                allAcceptedCredentialIds: payload.allAcceptedCredentialIds,
+            });
+            log(`signalAllAcceptedCredentials sent (${payload.allAcceptedCredentialIds.length} accepted IDs).`, 'ok');
+        } catch (err) {
+            log(`signalAllAcceptedCredentials error: ${err.message}`, 'err');
+        }
+    };
+
+    const sendSignalCurrentUser = async () => {
+        if (!support.user) {
+            log('signalCurrentUserDetails not available, skipping.');
+            return;
+        }
+        const payload = await fetchPayload();
+        try {
+            await PublicKeyCredential.signalCurrentUserDetails({
+                rpId: payload.rpId,
+                userId: payload.userId,
+                name: payload.name,
+                displayName: payload.displayName,
+            });
+            log(`signalCurrentUserDetails sent (name="${payload.name}", displayName="${payload.displayName}").`, 'ok');
+        } catch (err) {
+            log(`signalCurrentUserDetails error: ${err.message}`, 'err');
+        }
+    };
+
+    const renderPasskeys = (credentials) => {
+        const tbody = document.querySelector('#passkeys tbody');
+        tbody.innerHTML = '';
+        const lastOne = credentials.length === 1;
+        credentials.forEach((c) => {
+            const tr = document.createElement('tr');
+            const credIdShort = c.credentialId.length > 22
+                ? c.credentialId.slice(0, 12) + '...' + c.credentialId.slice(-6)
+                : c.credentialId;
+            const lastUsed = c.lastUsedAt ? new Date(c.lastUsedAt * 1000).toLocaleString() : 'never';
+            tr.innerHTML = `
+                <td class="label"><input type="text" value="${c.label.replace(/"/g, '&quot;')}" data-cred="${c.credentialId}"></td>
+                <td><code title="${c.credentialId}">${credIdShort}</code></td>
+                <td><code>${c.aaguid}</code></td>
+                <td>${c.counter}</td>
+                <td>${lastUsed}</td>
+                <td class="actions">
+                    <button class="ghost" data-action="rename" data-cred="${c.credentialId}">Rename</button>
+                    <button class="danger" data-action="delete" data-cred="${c.credentialId}" ${lastOne ? 'disabled title="Last passkey, deletion blocked in this demo"' : ''}>Delete</button>
+                </td>
+            `;
+            tbody.appendChild(tr);
+        });
+    };
+
+    const loadMe = async () => {
+        const r = await fetch('/api/me');
+        if (r.status === 401) {
+            document.getElementById('unauthenticated').classList.remove('hidden');
+            log('Not signed in.', 'err');
+            return null;
+        }
+        const me = await r.json();
+        document.getElementById('authenticated').classList.remove('hidden');
+        document.getElementById('username').textContent = me.username;
+        document.getElementById('displayName').value = me.displayName ?? '';
+        markSupport('support-unknown', support.unknown);
+        markSupport('support-all', support.all);
+        markSupport('support-user', support.user);
+        renderPasskeys(me.credentials);
+        log(`Loaded ${me.credentials.length} passkey(s) for ${me.username}.`, 'ok');
+        return me;
+    };
+
+    document.getElementById('logout').addEventListener('click', async () => {
+        await fetch('/api/logout', { method: 'POST' });
+        window.location.href = '/';
+    });
+
+    document.getElementById('signal-user').addEventListener('click', sendSignalCurrentUser);
+    document.getElementById('signal-all').addEventListener('click', sendSignalAllAccepted);
+
+    document.getElementById('save-displayName').addEventListener('click', async () => {
+        const displayName = document.getElementById('displayName').value.trim();
+        if (displayName === '') return;
+        try {
+            const r = await fetch('/api/account/rename', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ displayName }),
+            });
+            if (!r.ok) throw new Error(`rename HTTP ${r.status}: ${await r.text()}`);
+            log(`Display name updated server-side to "${displayName}". Propagating to the passkey manager...`, 'ok');
+            await sendSignalCurrentUser();
+        } catch (err) {
+            log(`Error: ${err.message}`, 'err');
+        }
+    });
+
+    document.getElementById('add-passkey').addEventListener('click', async (e) => {
+        const btn = e.currentTarget;
+        btn.disabled = true;
+        try {
+            const label = window.prompt('Label for the new passkey:') ?? '';
+            log('Asking server for add-passkey options...');
+            const optResp = await fetch('/api/account/passkey/add/options', { method: 'POST' });
+            if (!optResp.ok) throw new Error(`options HTTP ${optResp.status}: ${await optResp.text()}`);
+            const optsJson = await optResp.json();
+
+            const credential = await navigator.credentials.create({ publicKey: toCreateOptions(optsJson) });
+            log('Credential created. POST /api/account/passkey/add/verify ...', 'ok');
+
+            const verifyResp = await fetch('/api/account/passkey/add/verify', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(credentialToJson(credential, label)),
+            });
+            if (!verifyResp.ok) throw new Error(`verify HTTP ${verifyResp.status}: ${await verifyResp.text()}`);
+            log('New passkey stored. Refreshing list + sending signalAllAcceptedCredentials...', 'ok');
+            await loadMe();
+            await sendSignalAllAccepted();
+        } catch (err) {
+            log(`Error: ${err.message}`, 'err');
+        } finally {
+            btn.disabled = false;
+        }
+    });
+
+    document.querySelector('#passkeys').addEventListener('click', async (e) => {
+        const btn = e.target.closest('button[data-action]');
+        if (!btn) return;
+        const credentialIdB64 = btn.dataset.cred;
+        const action = btn.dataset.action;
+        try {
+            if (action === 'rename') {
+                const input = document.querySelector(`input[data-cred="${CSS.escape(credentialIdB64)}"]`);
+                const label = input?.value ?? '';
+                if (label.trim() === '') return;
+                const r = await fetch('/api/account/passkey/rename', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ credentialId: credentialIdB64, label }),
+                });
+                if (!r.ok) throw new Error(`rename HTTP ${r.status}: ${await r.text()}`);
+                log(`Renamed to "${label}". (The label is server-side metadata, no Signal API call needed.)`, 'ok');
+            } else if (action === 'delete') {
+                if (!window.confirm('Delete this passkey ?')) return;
+                const r = await fetch('/api/account/passkey/delete', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ credentialId: credentialIdB64 }),
+                });
+                if (!r.ok) throw new Error(`delete HTTP ${r.status}: ${await r.text()}`);
+                const data = await r.json();
+                log('Passkey deleted server-side. Sending signalUnknownCredential + signalAllAcceptedCredentials...', 'ok');
+                await sendSignalUnknown(data.credentialId);
+                await sendSignalAllAccepted();
+                await loadMe();
+            }
+        } catch (err) {
+            log(`Error: ${err.message}`, 'err');
+        }
+    });
+
+    output.textContent = '';
+    const me = await loadMe();
+    if (me !== null) {
+        log('Firing signalCurrentUserDetails + signalAllAcceptedCredentials on page load...');
+        await sendSignalCurrentUser();
+        await sendSignalAllAccepted();
+    }
+</script>
+</body>
+</html>

--- a/docs/examples/signal-api-demo/same-origin/public/index.html
+++ b/docs/examples/signal-api-demo/same-origin/public/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>WebAuthn Signal API Demo</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 720px; margin: 40px auto; padding: 20px; color: #1f2937; line-height: 1.55; }
+        h1 { font-size: 1.5rem; }
+        h2 { font-size: 1.1rem; margin-top: 2rem; }
+        a { color: #2563eb; }
+        .card { background: #f3f4f6; border-radius: 8px; padding: 16px 20px; margin: 1.2rem 0; }
+        .card h3 { margin-top: 0; font-size: 1rem; }
+        code { background: #f3f4f6; padding: 1px 6px; border-radius: 4px; font-size: 0.9rem; }
+        .status { font-size: 0.95rem; padding: 10px 14px; border-radius: 6px; margin: 1rem 0; }
+        .status.logged-in { background: #d1fae5; color: #065f46; }
+        .status.logged-out { background: #fee2e2; color: #991b1b; }
+        button { background: #2563eb; color: #fff; border: none; cursor: pointer; padding: 0.45rem 0.85rem; border-radius: 6px; font-size: 0.95rem; }
+        button.ghost { background: transparent; color: #2563eb; border: 1px solid #2563eb; }
+    </style>
+</head>
+<body>
+
+<h1>WebAuthn Signal API Demo</h1>
+<p>
+    The W3C <a href="https://w3c.github.io/webauthn/#sctn-signal-methods">Signal API</a>
+    lets a relying party tell the user agent that some local passkey-manager
+    state is out of date. Three methods are demonstrated:
+</p>
+
+<ul>
+    <li><code>PublicKeyCredential.signalUnknownCredential</code> after the user deletes a passkey on the server, so the passkey manager can prune the corresponding entry.</li>
+    <li><code>PublicKeyCredential.signalAllAcceptedCredentials</code> after any change, to send the authoritative list of valid credential IDs for the user. The manager prunes anything not in the list.</li>
+    <li><code>PublicKeyCredential.signalCurrentUserDetails</code> after a profile rename, so the manager shows the up-to-date <code>name</code> / <code>displayName</code> the next time the user picks this passkey.</li>
+</ul>
+
+<p>Server-side, the API is just data plumbing: the page asks <code>/api/account/signal-payload</code> for the current authoritative snapshot, then makes the JS calls itself. No new validation runs on the server.</p>
+
+<div id="status" class="status logged-out">Loading session state...</div>
+
+<div class="card">
+    <h3>1. Register a passkey</h3>
+    <p><a href="/register.html"><button>Register a new account</button></a></p>
+</div>
+
+<div class="card">
+    <h3>2. Sign in</h3>
+    <p><a href="/login.html"><button>Sign in</button></a></p>
+</div>
+
+<div class="card">
+    <h3>3. Trigger Signal API calls</h3>
+    <p>The account page has explicit buttons for each Signal method and also fires them automatically on every relevant action (delete, rename, account rename, signin).</p>
+    <p><a href="/account.html"><button class="ghost">Open my account</button></a></p>
+</div>
+
+<h2>Browser support</h2>
+<p>The Signal API is recent. Chrome 132+, Edge 132+, Safari 18+. Firefox is trailing. The account page detects support and reports what each call did.</p>
+
+<script type="module">
+    const status = document.getElementById('status');
+
+    try {
+        const r = await fetch('/api/me');
+        const me = await r.json();
+        if (me.authenticated) {
+            status.className = 'status logged-in';
+            status.textContent = `Signed in as ${me.username} (${me.credentials.length} passkey(s) registered).`;
+        } else {
+            status.className = 'status logged-out';
+            status.textContent = 'Not signed in.';
+        }
+    } catch (e) {
+        status.className = 'status logged-out';
+        status.textContent = 'Session check failed: ' + e.message;
+    }
+</script>
+
+</body>
+</html>

--- a/docs/examples/signal-api-demo/same-origin/public/login.html
+++ b/docs/examples/signal-api-demo/same-origin/public/login.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Signal API Demo, Sign in</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 720px; margin: 40px auto; padding: 20px; color: #1f2937; line-height: 1.55; }
+        h1 { font-size: 1.5rem; }
+        label { display: block; margin: 0.6rem 0 0.25rem; font-weight: 500; }
+        input, button { padding: 0.55rem 0.75rem; font-size: 1rem; border-radius: 6px; border: 1px solid #d1d5db; box-sizing: border-box; }
+        input { width: 100%; }
+        button { background: #2563eb; color: #fff; border: none; cursor: pointer; }
+        button:disabled { background: #94a3b8; cursor: not-allowed; }
+        pre { background: #f3f4f6; padding: 12px; border-radius: 6px; overflow-x: auto; max-height: 360px; white-space: pre-wrap; word-break: break-all; }
+        .ok { color: #047857; }
+        .err { color: #b91c1c; }
+        nav a { color: #2563eb; margin-right: 1rem; }
+    </style>
+</head>
+<body>
+<nav><a href="/">&larr; Home</a><a href="/register.html">Register a new account</a></nav>
+
+<h1>2. Sign in with a registered passkey</h1>
+
+<p>
+    The page asks the server for <code>PublicKeyCredentialRequestOptions</code>
+    scoped to the username (pre-filled <code>allowCredentials</code>), calls
+    <code>navigator.credentials.get()</code> and posts the assertion back for
+    validation. On success the server updates the credential counter and opens
+    a PHP session.
+</p>
+
+<form id="login-form">
+    <label for="username">Username (email)</label>
+    <input id="username" name="username" type="email" required value="jane.doe@example.com" autocomplete="username">
+
+    <p><button type="submit" id="submit">Sign in</button></p>
+</form>
+
+<h2>Output</h2>
+<pre id="output">Submit the form to start an assertion ceremony.</pre>
+
+<script type="module">
+    const form = document.getElementById('login-form');
+    const submit = document.getElementById('submit');
+    const output = document.getElementById('output');
+
+    const log = (msg, cls = '') => {
+        const line = document.createElement('div');
+        if (cls) line.className = cls;
+        line.textContent = msg;
+        output.appendChild(line);
+    };
+
+    const b64u = {
+        encode: (buf) => {
+            const bytes = new Uint8Array(buf);
+            let str = '';
+            for (let i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i]);
+            return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+        },
+        decode: (s) => {
+            s = s.replace(/-/g, '+').replace(/_/g, '/');
+            const pad = (4 - (s.length % 4)) % 4;
+            s += '='.repeat(pad);
+            const bin = atob(s);
+            const out = new Uint8Array(bin.length);
+            for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+            return out;
+        },
+    };
+
+    const toGetOptions = (json) => {
+        const o = { ...json };
+        o.challenge = b64u.decode(json.challenge);
+        if (json.allowCredentials) {
+            o.allowCredentials = json.allowCredentials.map((c) => ({
+                ...c,
+                id: b64u.decode(c.id),
+            }));
+        }
+        return o;
+    };
+
+    const assertionToJson = (cred) => ({
+        id: cred.id,
+        rawId: b64u.encode(cred.rawId),
+        type: cred.type,
+        response: {
+            clientDataJSON: b64u.encode(cred.response.clientDataJSON),
+            authenticatorData: b64u.encode(cred.response.authenticatorData),
+            signature: b64u.encode(cred.response.signature),
+            userHandle: cred.response.userHandle ? b64u.encode(cred.response.userHandle) : null,
+        },
+    });
+
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        submit.disabled = true;
+        output.textContent = '';
+
+        try {
+            const username = form.username.value;
+
+            log('Asking server for assertion options...');
+            const optResp = await fetch('/api/login/options', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username }),
+            });
+            if (!optResp.ok) throw new Error(`options HTTP ${optResp.status}: ${await optResp.text()}`);
+            const optsJson = await optResp.json();
+            log(`Options received (${optsJson.allowCredentials?.length ?? 0} credential(s) allowed).`, 'ok');
+
+            log('Calling navigator.credentials.get()...');
+            const credential = await navigator.credentials.get({ publicKey: toGetOptions(optsJson) });
+            log('Assertion produced by the authenticator.', 'ok');
+
+            log('POST /api/login/verify ...');
+            const verifyResp = await fetch('/api/login/verify', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(assertionToJson(credential)),
+            });
+            if (!verifyResp.ok) throw new Error(`verify HTTP ${verifyResp.status}: ${await verifyResp.text()}`);
+            const verified = await verifyResp.json();
+            log(`Signed in as ${verified.username}.`, 'ok');
+            log('Redirecting to /account.html in 1.5s...');
+            setTimeout(() => { window.location.href = '/account.html'; }, 1500);
+        } catch (err) {
+            log(`Error: ${err.message}`, 'err');
+        } finally {
+            submit.disabled = false;
+        }
+    });
+</script>
+</body>
+</html>

--- a/docs/examples/signal-api-demo/same-origin/public/register.html
+++ b/docs/examples/signal-api-demo/same-origin/public/register.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Signal API Demo, Register</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 720px; margin: 40px auto; padding: 20px; color: #1f2937; line-height: 1.55; }
+        h1 { font-size: 1.5rem; }
+        label { display: block; margin: 0.6rem 0 0.25rem; font-weight: 500; }
+        input, button { padding: 0.55rem 0.75rem; font-size: 1rem; border-radius: 6px; border: 1px solid #d1d5db; box-sizing: border-box; }
+        input { width: 100%; }
+        button { background: #2563eb; color: #fff; border: none; cursor: pointer; }
+        button:disabled { background: #94a3b8; cursor: not-allowed; }
+        pre { background: #f3f4f6; padding: 12px; border-radius: 6px; overflow-x: auto; max-height: 360px; white-space: pre-wrap; word-break: break-all; }
+        .ok { color: #047857; }
+        .err { color: #b91c1c; }
+        nav a { color: #2563eb; margin-right: 1rem; }
+    </style>
+</head>
+<body>
+<nav><a href="/">&larr; Home</a><a href="/login.html">Sign in &rarr;</a></nav>
+
+<h1>1. Register a passkey for a new account</h1>
+
+<p>
+    The page asks the server for <code>PublicKeyCredentialCreationOptions</code>,
+    calls <code>navigator.credentials.create()</code> with them, and posts the
+    resulting credential back for server-side validation. On success the
+    server persists a <code>CredentialRecord</code> bound to the user handle.
+</p>
+
+<form id="register-form">
+    <label for="username">Username (email)</label>
+    <input id="username" name="username" type="email" required value="jane.doe@example.com">
+
+    <label for="displayName">Display name</label>
+    <input id="displayName" name="displayName" type="text" value="Jane Doe">
+
+    <label for="label">Passkey label (shown on /account.html)</label>
+    <input id="label" name="label" type="text" placeholder="e.g. My iPhone">
+
+    <p><button type="submit" id="submit">Register</button></p>
+</form>
+
+<h2>Output</h2>
+<pre id="output">Submit the form to start a registration ceremony.</pre>
+
+<script type="module">
+    const form = document.getElementById('register-form');
+    const submit = document.getElementById('submit');
+    const output = document.getElementById('output');
+
+    const log = (msg, cls = '') => {
+        const line = document.createElement('div');
+        if (cls) line.className = cls;
+        line.textContent = msg;
+        output.appendChild(line);
+    };
+
+    const b64u = {
+        encode: (buf) => {
+            const bytes = new Uint8Array(buf);
+            let str = '';
+            for (let i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i]);
+            return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+        },
+        decode: (s) => {
+            s = s.replace(/-/g, '+').replace(/_/g, '/');
+            const pad = (4 - (s.length % 4)) % 4;
+            s += '='.repeat(pad);
+            const bin = atob(s);
+            const out = new Uint8Array(bin.length);
+            for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+            return out;
+        },
+    };
+
+    const toCreateOptions = (json) => {
+        const o = { ...json };
+        o.challenge = b64u.decode(json.challenge);
+        o.user = { ...json.user, id: b64u.decode(json.user.id) };
+        if (json.excludeCredentials) {
+            o.excludeCredentials = json.excludeCredentials.map((c) => ({
+                ...c,
+                id: b64u.decode(c.id),
+            }));
+        }
+        return o;
+    };
+
+    const credentialToJson = (cred, label) => ({
+        id: cred.id,
+        rawId: b64u.encode(cred.rawId),
+        type: cred.type,
+        response: {
+            clientDataJSON: b64u.encode(cred.response.clientDataJSON),
+            attestationObject: b64u.encode(cred.response.attestationObject),
+        },
+        clientExtensionResults: { demoLabel: label },
+    });
+
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        submit.disabled = true;
+        output.textContent = '';
+
+        try {
+            const username = form.username.value;
+            const displayName = form.displayName.value;
+            const label = form.label.value;
+
+            log('Asking server for creation options...');
+            const optResp = await fetch('/api/register/options', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username, displayName }),
+            });
+            if (!optResp.ok) throw new Error(`options HTTP ${optResp.status}: ${await optResp.text()}`);
+            const optsJson = await optResp.json();
+            log('Options received from /api/register/options.', 'ok');
+
+            log('Calling navigator.credentials.create()...');
+            const credential = await navigator.credentials.create({ publicKey: toCreateOptions(optsJson) });
+            log('Credential created by the authenticator.', 'ok');
+
+            log('POST /api/register/verify ...');
+            const verifyResp = await fetch('/api/register/verify', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(credentialToJson(credential, label)),
+            });
+            if (!verifyResp.ok) throw new Error(`verify HTTP ${verifyResp.status}: ${await verifyResp.text()}`);
+            const verified = await verifyResp.json();
+            log(`Stored. credentialId=${verified.credentialId}`, 'ok');
+            log('You are now signed in. Redirecting to /account.html in 1.5s...');
+            setTimeout(() => { window.location.href = '/account.html'; }, 1500);
+        } catch (err) {
+            log(`Error: ${err.message}`, 'err');
+        } finally {
+            submit.disabled = false;
+        }
+    });
+</script>
+</body>
+</html>

--- a/docs/examples/signal-api-demo/same-origin/router.php
+++ b/docs/examples/signal-api-demo/same-origin/router.php
@@ -1,0 +1,510 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Front controller for `php -S`. Same shape as the basic-demo plus a
+ * `/api/account/signal-payload` endpoint that the page calls right before
+ * issuing the W3C Signal API methods. The server's role in Signal is just
+ * to hand the page a fresh, authoritative snapshot, the API calls themselves
+ * happen entirely in the browser (`PublicKeyCredential.signal*`).
+ *
+ * Run with: php -S localhost:8000 -t public router.php
+ */
+
+use App\SignalApiDemo\Container;
+use ParagonIE\ConstantTime\Base64;
+use ParagonIE\ConstantTime\Base64UrlSafe;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\AuthenticatorSelectionCriteria;
+use Webauthn\PublicKeyCredential;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialParameters;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\PublicKeyCredentialRpEntity;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+require_once __DIR__ . '/../src/bootstrap.php';
+
+session_start();
+$container = new Container();
+$path = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?: '/';
+
+if ($path === '/') {
+    $_SERVER['REQUEST_URI'] = '/index.html';
+
+    return false;
+}
+
+if (! str_starts_with($path, '/api/')) {
+    return false;
+}
+
+header('Content-Type: application/json');
+
+try {
+    match ($path) {
+        '/api/me' => me($container),
+        '/api/logout' => logout(),
+        '/api/register/options' => registerOptions($container),
+        '/api/register/verify' => registerVerify($container),
+        '/api/login/options' => loginOptions($container),
+        '/api/login/verify' => loginVerify($container),
+        '/api/account/passkey/add/options' => addPasskeyOptions($container),
+        '/api/account/passkey/add/verify' => addPasskeyVerify($container),
+        '/api/account/passkey/rename' => renamePasskey($container),
+        '/api/account/passkey/delete' => deletePasskey($container),
+        '/api/account/rename' => renameAccount($container),
+        '/api/account/signal-payload' => signalPayload($container),
+        default => notFound(),
+    };
+} catch (\Throwable $e) {
+    http_response_code(400);
+    echo json_encode([
+        'error' => $e->getMessage(),
+        'class' => $e::class,
+    ], \JSON_THROW_ON_ERROR);
+}
+
+function notFound(): void
+{
+    http_response_code(404);
+    echo json_encode([
+        'error' => 'Not found',
+    ], \JSON_THROW_ON_ERROR);
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function readJson(): array
+{
+    $body = file_get_contents('php://input') ?: '{}';
+    $json = json_decode($body, true, flags: \JSON_THROW_ON_ERROR);
+
+    return is_array($json) ? $json : [];
+}
+
+function jsonOut(mixed $payload): void
+{
+    echo json_encode($payload, \JSON_THROW_ON_ERROR);
+}
+
+function serializeOptions(Container $container, object $options): string
+{
+    return $container->serializer->serialize($options, 'json', [
+        'json_encode_options' => \JSON_THROW_ON_ERROR,
+        \Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+    ]);
+}
+
+function requireLogin(): string
+{
+    $userHandleB64 = $_SESSION['userHandle'] ?? null;
+    if (! is_string($userHandleB64) || $userHandleB64 === '') {
+        http_response_code(401);
+        echo json_encode([
+            'error' => 'Not authenticated',
+        ], \JSON_THROW_ON_ERROR);
+        exit;
+    }
+
+    return (string) base64_decode($userHandleB64, true);
+}
+
+function me(Container $container): void
+{
+    $userHandleB64 = $_SESSION['userHandle'] ?? null;
+    if (! is_string($userHandleB64) || $userHandleB64 === '') {
+        http_response_code(401);
+        jsonOut([
+            'authenticated' => false,
+        ]);
+
+        return;
+    }
+    $userHandle = (string) base64_decode($userHandleB64, true);
+    $username = $container->userStore->findUsernameByHandle($userHandle);
+    jsonOut([
+        'authenticated' => true,
+        'username' => $username,
+        'displayName' => $username === null ? null : $container->userStore->findDisplayName($username),
+        'credentials' => $container->credentialStore->listForUser($userHandle),
+    ]);
+}
+
+function logout(): void
+{
+    $_SESSION = [];
+    if (ini_get('session.use_cookies')) {
+        $params = session_get_cookie_params();
+        setcookie(
+            session_name(),
+            '',
+            time() - 42_000,
+            $params['path'],
+            $params['domain'],
+            $params['secure'],
+            $params['httponly']
+        );
+    }
+    session_destroy();
+    jsonOut([
+        'loggedOut' => true,
+    ]);
+}
+
+/**
+ * Returns the snapshot the page feeds to the Signal API.
+ *
+ *  - `rpId`                        the relying party ID the browser must use;
+ *  - `userId`                      base64url-encoded user handle, the
+ *                                  identifier the passkey manager keys its
+ *                                  user-level data on;
+ *  - `name` / `displayName`        the current authoritative values, fed to
+ *                                  `signalCurrentUserDetails`;
+ *  - `allAcceptedCredentialIds`    base64url-encoded credential IDs the
+ *                                  server still accepts for this user, fed
+ *                                  to `signalAllAcceptedCredentials`. Sending
+ *                                  this list periodically lets the passkey
+ *                                  manager prune entries the RP no longer
+ *                                  considers valid.
+ */
+function signalPayload(Container $container): void
+{
+    $userHandle = requireLogin();
+    $username = $container->userStore->findUsernameByHandle($userHandle);
+    if ($username === null) {
+        throw new \RuntimeException('Session out of sync. Sign in again.');
+    }
+
+    $credentialIds = array_map(
+        static fn (array $row): string => Base64UrlSafe::encodeUnpadded(
+            (string) base64_decode($row['credentialId'], true),
+        ),
+        $container->credentialStore->listForUser($userHandle),
+    );
+
+    jsonOut([
+        'rpId' => $container->relyingPartyId,
+        'userId' => Base64UrlSafe::encodeUnpadded($userHandle),
+        'name' => $username,
+        'displayName' => $container->userStore->findDisplayName($username) ?? $username,
+        'allAcceptedCredentialIds' => array_values($credentialIds),
+    ]);
+}
+
+function registerOptions(Container $container): void
+{
+    $body = readJson();
+    $username = trim((string) ($body['username'] ?? ''));
+    $displayName = trim((string) ($body['displayName'] ?? '')) ?: $username;
+    if ($username === '') {
+        throw new \RuntimeException('username is required.');
+    }
+
+    $userHandle = $container->userStore->findOrCreate($username, $displayName);
+    $_SESSION['register_username'] = $username;
+    $_SESSION['register_userHandle'] = base64_encode($userHandle);
+
+    $challenge = random_bytes(32);
+    $_SESSION['register_challenge'] = base64_encode($challenge);
+
+    $options = PublicKeyCredentialCreationOptions::create(
+        PublicKeyCredentialRpEntity::create($container->relyingPartyName, $container->relyingPartyId),
+        PublicKeyCredentialUserEntity::create($username, $userHandle, $displayName),
+        $challenge,
+        [
+            PublicKeyCredentialParameters::create('public-key', -7),
+            PublicKeyCredentialParameters::create('public-key', -257),
+        ],
+        AuthenticatorSelectionCriteria::create(
+            null,
+            AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_PREFERRED,
+            AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_PREFERRED,
+        ),
+        PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
+        $container->credentialStore->excludeCredentialsFor($userHandle),
+    );
+    $options->timeout = 60_000;
+
+    echo serializeOptions($container, $options);
+}
+
+function registerVerify(Container $container): void
+{
+    $body = file_get_contents('php://input') ?: '{}';
+    $credential = $container->serializer->deserialize($body, PublicKeyCredential::class, 'json');
+    \assert($credential instanceof PublicKeyCredential);
+
+    $response = $credential->response;
+    if (! $response instanceof AuthenticatorAttestationResponse) {
+        throw new \RuntimeException('Expected an AuthenticatorAttestationResponse.');
+    }
+
+    $challengeB64 = $_SESSION['register_challenge'] ?? null;
+    $username = (string) ($_SESSION['register_username'] ?? '');
+    $userHandleB64 = $_SESSION['register_userHandle'] ?? null;
+    if (! is_string($challengeB64) || $username === '' || ! is_string($userHandleB64)) {
+        throw new \RuntimeException('Missing registration session.');
+    }
+    $challenge = (string) base64_decode($challengeB64, true);
+    $userHandle = (string) base64_decode($userHandleB64, true);
+
+    $options = PublicKeyCredentialCreationOptions::create(
+        PublicKeyCredentialRpEntity::create($container->relyingPartyName, $container->relyingPartyId),
+        PublicKeyCredentialUserEntity::create($username, $userHandle, $username),
+        $challenge,
+        [
+            PublicKeyCredentialParameters::create('public-key', -7),
+            PublicKeyCredentialParameters::create('public-key', -257),
+        ],
+    );
+
+    $record = $container->attestationValidator->check($response, $options, $container->relyingPartyId);
+    $label = trim((string) ($credential->clientExtensionResults['demoLabel'] ?? ''));
+    if ($label === '') {
+        $label = sprintf('Passkey added on %s', date('Y-m-d H:i'));
+    }
+    $container->credentialStore->save($userHandle, $record, $label);
+
+    unset($_SESSION['register_challenge'], $_SESSION['register_username'], $_SESSION['register_userHandle']);
+    $_SESSION['username'] = $username;
+    $_SESSION['userHandle'] = $userHandleB64;
+
+    jsonOut([
+        'verified' => true,
+        'credentialId' => Base64::encode($record->publicKeyCredentialId),
+    ]);
+}
+
+function loginOptions(Container $container): void
+{
+    $body = readJson();
+    $username = trim((string) ($body['username'] ?? ''));
+    if ($username === '') {
+        throw new \RuntimeException('username is required.');
+    }
+
+    $userHandle = $container->userStore->findUserHandle($username);
+    if ($userHandle === null) {
+        throw new \RuntimeException('Unknown user.');
+    }
+
+    $allowCredentials = $container->credentialStore->allowCredentialsFor($userHandle);
+    if ($allowCredentials === []) {
+        throw new \RuntimeException('No passkey registered for this account.');
+    }
+
+    $challenge = random_bytes(32);
+    $_SESSION['login_challenge'] = base64_encode($challenge);
+    $_SESSION['login_username'] = $username;
+
+    $options = PublicKeyCredentialRequestOptions::create(
+        $challenge,
+        $container->relyingPartyId,
+        $allowCredentials,
+        PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_PREFERRED,
+    );
+    $options->timeout = 60_000;
+
+    echo serializeOptions($container, $options);
+}
+
+function loginVerify(Container $container): void
+{
+    $body = file_get_contents('php://input') ?: '{}';
+    $credential = $container->serializer->deserialize($body, PublicKeyCredential::class, 'json');
+    \assert($credential instanceof PublicKeyCredential);
+
+    $response = $credential->response;
+    if (! $response instanceof AuthenticatorAssertionResponse) {
+        throw new \RuntimeException('Expected an AuthenticatorAssertionResponse.');
+    }
+
+    $challengeB64 = $_SESSION['login_challenge'] ?? null;
+    $username = (string) ($_SESSION['login_username'] ?? '');
+    if (! is_string($challengeB64) || $username === '') {
+        throw new \RuntimeException('Missing login session.');
+    }
+    $challenge = (string) base64_decode($challengeB64, true);
+
+    $userHandle = $container->userStore->findUserHandle($username);
+    if ($userHandle === null) {
+        throw new \RuntimeException('Unknown user.');
+    }
+
+    $record = $container->credentialStore->findByCredentialId($credential->rawId);
+    if ($record === null) {
+        throw new \RuntimeException('Unknown credential.');
+    }
+
+    $options = PublicKeyCredentialRequestOptions::create(
+        $challenge,
+        $container->relyingPartyId,
+        $container->credentialStore->allowCredentialsFor($userHandle),
+        PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_PREFERRED,
+    );
+
+    $updated = $container->assertionValidator->check(
+        $record,
+        $response,
+        $options,
+        $container->relyingPartyId,
+        $userHandle,
+    );
+    $container->credentialStore->updateAfterAssertion($updated);
+
+    unset($_SESSION['login_challenge'], $_SESSION['login_username']);
+    $_SESSION['username'] = $username;
+    $_SESSION['userHandle'] = base64_encode($userHandle);
+
+    jsonOut([
+        'verified' => true,
+        'username' => $username,
+    ]);
+}
+
+function addPasskeyOptions(Container $container): void
+{
+    $userHandle = requireLogin();
+    $username = $container->userStore->findUsernameByHandle($userHandle);
+    if ($username === null) {
+        throw new \RuntimeException('Session out of sync.');
+    }
+
+    $challenge = random_bytes(32);
+    $_SESSION['add_passkey_challenge'] = base64_encode($challenge);
+
+    $options = PublicKeyCredentialCreationOptions::create(
+        PublicKeyCredentialRpEntity::create($container->relyingPartyName, $container->relyingPartyId),
+        PublicKeyCredentialUserEntity::create($username, $userHandle, (string) $container->userStore->findDisplayName($username)),
+        $challenge,
+        [
+            PublicKeyCredentialParameters::create('public-key', -7),
+            PublicKeyCredentialParameters::create('public-key', -257),
+        ],
+        AuthenticatorSelectionCriteria::create(
+            null,
+            AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_PREFERRED,
+            AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_PREFERRED,
+        ),
+        PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
+        $container->credentialStore->excludeCredentialsFor($userHandle),
+    );
+    $options->timeout = 60_000;
+
+    echo serializeOptions($container, $options);
+}
+
+function addPasskeyVerify(Container $container): void
+{
+    $userHandle = requireLogin();
+    $username = $container->userStore->findUsernameByHandle($userHandle);
+    if ($username === null) {
+        throw new \RuntimeException('Session out of sync.');
+    }
+
+    $body = file_get_contents('php://input') ?: '{}';
+    $credential = $container->serializer->deserialize($body, PublicKeyCredential::class, 'json');
+    \assert($credential instanceof PublicKeyCredential);
+
+    $response = $credential->response;
+    if (! $response instanceof AuthenticatorAttestationResponse) {
+        throw new \RuntimeException('Expected an AuthenticatorAttestationResponse.');
+    }
+
+    $challengeB64 = $_SESSION['add_passkey_challenge'] ?? null;
+    if (! is_string($challengeB64)) {
+        throw new \RuntimeException('Missing add-passkey session.');
+    }
+    $challenge = (string) base64_decode($challengeB64, true);
+
+    $options = PublicKeyCredentialCreationOptions::create(
+        PublicKeyCredentialRpEntity::create($container->relyingPartyName, $container->relyingPartyId),
+        PublicKeyCredentialUserEntity::create($username, $userHandle, $username),
+        $challenge,
+        [
+            PublicKeyCredentialParameters::create('public-key', -7),
+            PublicKeyCredentialParameters::create('public-key', -257),
+        ],
+    );
+
+    $record = $container->attestationValidator->check($response, $options, $container->relyingPartyId);
+    $label = trim((string) ($credential->clientExtensionResults['demoLabel'] ?? ''));
+    if ($label === '') {
+        $label = sprintf('Passkey added on %s', date('Y-m-d H:i'));
+    }
+    $container->credentialStore->save($userHandle, $record, $label);
+    unset($_SESSION['add_passkey_challenge']);
+
+    jsonOut([
+        'verified' => true,
+        'credentialId' => Base64::encode($record->publicKeyCredentialId),
+    ]);
+}
+
+function renamePasskey(Container $container): void
+{
+    $userHandle = requireLogin();
+    $body = readJson();
+    $credentialId = (string) base64_decode((string) ($body['credentialId'] ?? ''), true);
+    $label = trim((string) ($body['label'] ?? ''));
+    if ($credentialId === '' || $label === '') {
+        throw new \RuntimeException('credentialId and label are required.');
+    }
+    $ok = $container->credentialStore->rename($credentialId, $userHandle, $label);
+    if (! $ok) {
+        throw new \RuntimeException('Cannot rename this credential.');
+    }
+    jsonOut([
+        'renamed' => true,
+    ]);
+}
+
+function deletePasskey(Container $container): void
+{
+    $userHandle = requireLogin();
+    $body = readJson();
+    $credentialId = (string) base64_decode((string) ($body['credentialId'] ?? ''), true);
+    if ($credentialId === '') {
+        throw new \RuntimeException('credentialId is required.');
+    }
+    if ($container->credentialStore->countForUser($userHandle) <= 1) {
+        throw new \RuntimeException('Cannot delete the last passkey of this account.');
+    }
+    $ok = $container->credentialStore->delete($credentialId, $userHandle);
+    if (! $ok) {
+        throw new \RuntimeException('Cannot delete this credential.');
+    }
+    jsonOut([
+        'deleted' => true,
+        'credentialId' => Base64UrlSafe::encodeUnpadded($credentialId),
+    ]);
+}
+
+/**
+ * Renames the account at the application level. Useful to demonstrate
+ * `signalCurrentUserDetails`: after a rename, the page propagates the new
+ * `name` / `displayName` to the passkey manager so that the next time the
+ * user picks this passkey, the UI shows the up-to-date identity.
+ */
+function renameAccount(Container $container): void
+{
+    $userHandle = requireLogin();
+    $username = $container->userStore->findUsernameByHandle($userHandle);
+    if ($username === null) {
+        throw new \RuntimeException('Session out of sync.');
+    }
+    $body = readJson();
+    $displayName = trim((string) ($body['displayName'] ?? ''));
+    if ($displayName === '') {
+        throw new \RuntimeException('displayName is required.');
+    }
+    $container->userStore->updateDisplayName($username, $displayName);
+    jsonOut([
+        'updated' => true,
+        'displayName' => $displayName,
+    ]);
+}

--- a/docs/examples/signal-api-demo/same-origin/run.sh
+++ b/docs/examples/signal-api-demo/same-origin/run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Boot the same-origin signal-api-demo on http://localhost:8000.
+# Usage:  ./same-origin/run.sh   (from docs/examples/signal-api-demo/)
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [[ ! -d vendor ]]; then
+    echo "vendor/ missing, running composer install"
+    composer install --no-interaction
+fi
+
+PORT=8000
+
+is_busy() { lsof -i ":$1" >/dev/null 2>&1 || ss -ltn 2>/dev/null | grep -q ":$1 "; }
+if is_busy "$PORT"; then
+    echo "Port $PORT already in use. Free it and retry." >&2
+    exit 1
+fi
+
+cleanup() {
+    echo
+    echo "Stopping server..."
+    [[ -n "${PID:-}" ]] && kill "$PID" 2>/dev/null || true
+    wait 2>/dev/null || true
+}
+trap cleanup INT TERM EXIT
+
+echo "Signal API WebAuthn demo (same-origin) -> http://localhost:$PORT"
+echo
+echo "Steps:"
+echo "  1. open http://localhost:$PORT/                (landing page)"
+echo "  2. open http://localhost:$PORT/register.html   (register a passkey)"
+echo "  3. open http://localhost:$PORT/account.html    (see Signal API support, fire calls manually or via actions)"
+echo
+echo "Logs follow. Ctrl+C to stop."
+echo "----------------------------------------------------------------"
+
+php -S "localhost:$PORT" -t same-origin/public same-origin/router.php &
+PID=$!
+
+wait

--- a/docs/examples/signal-api-demo/src/CredentialStore.php
+++ b/docs/examples/signal-api-demo/src/CredentialStore.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\SignalApiDemo;
+
+use Symfony\Component\Serializer\Serializer;
+use Webauthn\CredentialRecord;
+use Webauthn\PublicKeyCredentialDescriptor;
+
+/**
+ * Demo-only credential store. Each row keeps:
+ *
+ *  - `userHandle`         the binary user handle the credential is bound to
+ *                         (base64-encoded for JSON storage);
+ *  - `credentialId`       the binary credential ID (base64-encoded);
+ *  - `source`             the framework's CredentialRecord serialized to JSON.
+ *                         This is the canonical blob to persist after a
+ *                         successful attestation. It already contains the
+ *                         credential ID, the COSE public key, the signature
+ *                         counter, the AAGUID, transports and the backup flags;
+ *  - `label`              a human-friendly alias the user can rename;
+ *  - `addedAt`            registration timestamp;
+ *  - `lastUsedAt`         updated on every successful assertion.
+ *
+ * Production code MUST replace this with a real implementation of
+ * `Webauthn\CredentialRecordRepositoryInterface` (and optionally
+ * `Webauthn\CanSaveCredentialRecord` if it owns persistence). Doctrine users
+ * can reuse `DoctrineCredentialSourceRepository` from the Symfony bundle as
+ * a reference implementation.
+ */
+final class CredentialStore
+{
+    public function __construct(
+        private readonly string $file,
+        private readonly Serializer $serializer,
+    ) {
+        $dir = dirname($this->file);
+        if (! is_dir($dir)) {
+            mkdir($dir, 0o755, true);
+        }
+        if (! file_exists($this->file)) {
+            file_put_contents($this->file, '[]');
+        }
+    }
+
+    /**
+     * @return array<string, array{userHandle: string, credentialId: string, source: string, label: string, addedAt: int, lastUsedAt: ?int}>
+     */
+    private function readAll(): array
+    {
+        $raw = (string) file_get_contents($this->file);
+        $data = json_decode($raw, true);
+
+        return is_array($data) ? $data : [];
+    }
+
+    /**
+     * @param array<string, array{userHandle: string, credentialId: string, source: string, label: string, addedAt: int, lastUsedAt: ?int}> $data
+     */
+    private function writeAll(array $data): void
+    {
+        file_put_contents($this->file, json_encode($data, \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * Persist a freshly registered credential. Call this right after
+     * `AuthenticatorAttestationResponseValidator::check()` returns.
+     */
+    public function save(string $userHandle, CredentialRecord $record, string $label): void
+    {
+        $key = base64_encode($record->publicKeyCredentialId);
+        $all = $this->readAll();
+        $all[$key] = [
+            'userHandle' => base64_encode($userHandle),
+            'credentialId' => base64_encode($record->publicKeyCredentialId),
+            'source' => $this->serializer->serialize($record, 'json'),
+            'label' => $label,
+            'addedAt' => time(),
+            'lastUsedAt' => null,
+        ];
+        $this->writeAll($all);
+    }
+
+    /**
+     * Refresh the stored CredentialRecord after a successful assertion. The
+     * counter, backup flags and uvInitialized may have been updated in place
+     * by the validator, so we re-serialize the whole record.
+     */
+    public function updateAfterAssertion(CredentialRecord $record): void
+    {
+        $key = base64_encode($record->publicKeyCredentialId);
+        $all = $this->readAll();
+        if (! isset($all[$key])) {
+            return;
+        }
+        $all[$key]['source'] = $this->serializer->serialize($record, 'json');
+        $all[$key]['lastUsedAt'] = time();
+        $this->writeAll($all);
+    }
+
+    public function rename(string $credentialId, string $userHandle, string $label): bool
+    {
+        $key = base64_encode($credentialId);
+        $all = $this->readAll();
+        if (! isset($all[$key])) {
+            return false;
+        }
+        if ($all[$key]['userHandle'] !== base64_encode($userHandle)) {
+            return false;
+        }
+        $all[$key]['label'] = $label;
+        $this->writeAll($all);
+
+        return true;
+    }
+
+    public function delete(string $credentialId, string $userHandle): bool
+    {
+        $key = base64_encode($credentialId);
+        $all = $this->readAll();
+        if (! isset($all[$key])) {
+            return false;
+        }
+        if ($all[$key]['userHandle'] !== base64_encode($userHandle)) {
+            return false;
+        }
+        unset($all[$key]);
+        $this->writeAll($all);
+
+        return true;
+    }
+
+    public function findByCredentialId(string $credentialId): ?CredentialRecord
+    {
+        $key = base64_encode($credentialId);
+        $row = $this->readAll()[$key] ?? null;
+        if ($row === null) {
+            return null;
+        }
+        $record = $this->serializer->deserialize($row['source'], CredentialRecord::class, 'json');
+        \assert($record instanceof CredentialRecord);
+
+        return $record;
+    }
+
+    public function findUserHandleByCredentialId(string $credentialId): ?string
+    {
+        $key = base64_encode($credentialId);
+        $row = $this->readAll()[$key] ?? null;
+
+        return $row === null ? null : (string) base64_decode($row['userHandle'], true);
+    }
+
+    /**
+     * Build the `allowCredentials` list a relying party passes in
+     * PublicKeyCredentialRequestOptions to scope the assertion ceremony to a
+     * known user.
+     *
+     * @return PublicKeyCredentialDescriptor[]
+     */
+    public function allowCredentialsFor(string $userHandle): array
+    {
+        $needle = base64_encode($userHandle);
+        $descriptors = [];
+        foreach ($this->readAll() as $row) {
+            if ($row['userHandle'] !== $needle) {
+                continue;
+            }
+            $rawId = (string) base64_decode($row['credentialId'], true);
+            $descriptors[] = PublicKeyCredentialDescriptor::create('public-key', $rawId);
+        }
+
+        return $descriptors;
+    }
+
+    /**
+     * Build the `excludeCredentials` list a relying party passes in
+     * PublicKeyCredentialCreationOptions to prevent registering the same
+     * authenticator twice for the same user.
+     *
+     * @return PublicKeyCredentialDescriptor[]
+     */
+    public function excludeCredentialsFor(string $userHandle): array
+    {
+        return $this->allowCredentialsFor($userHandle);
+    }
+
+    /**
+     * @return list<array{credentialId: string, label: string, addedAt: int, lastUsedAt: ?int, counter: int, aaguid: string, transports: list<string>, backupEligible: ?bool, backupStatus: ?bool}>
+     */
+    public function listForUser(string $userHandle): array
+    {
+        $needle = base64_encode($userHandle);
+        $rows = [];
+        foreach ($this->readAll() as $row) {
+            if ($row['userHandle'] !== $needle) {
+                continue;
+            }
+            $record = $this->serializer->deserialize($row['source'], CredentialRecord::class, 'json');
+            \assert($record instanceof CredentialRecord);
+            $rows[] = [
+                'credentialId' => $row['credentialId'],
+                'label' => $row['label'],
+                'addedAt' => $row['addedAt'],
+                'lastUsedAt' => $row['lastUsedAt'],
+                'counter' => $record->counter,
+                'aaguid' => $record->aaguid->toRfc4122(),
+                'transports' => $record->transports,
+                'backupEligible' => $record->backupEligible,
+                'backupStatus' => $record->backupStatus,
+            ];
+        }
+
+        return $rows;
+    }
+
+    public function countForUser(string $userHandle): int
+    {
+        return count($this->listForUser($userHandle));
+    }
+}

--- a/docs/examples/signal-api-demo/src/UserStore.php
+++ b/docs/examples/signal-api-demo/src/UserStore.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\SignalApiDemo;
+
+/**
+ * Demo-only user store. Maps usernames to a stable WebAuthn user handle and a
+ * human display name.
+ *
+ * The user handle is the bytes the relying party puts in
+ * `PublicKeyCredentialUserEntity.id`. The W3C spec requires that it:
+ *
+ *  - is a unique, opaque byte string (NOT the username, NOT an email);
+ *  - never changes for the lifetime of the account;
+ *  - is at most 64 bytes long.
+ *
+ * In a real application the user handle is typically the binary form of the
+ * account's primary key (UUID, ULID, ...). This demo derives it deterministically
+ * from the username so the same username always maps to the same handle across
+ * fresh starts.
+ *
+ * Production code MUST persist users in a real database and treat the user
+ * handle as the opaque, immutable account identifier.
+ */
+final class UserStore
+{
+    public function __construct(
+        private readonly string $file,
+    ) {
+        $dir = dirname($this->file);
+        if (! is_dir($dir)) {
+            mkdir($dir, 0o755, true);
+        }
+        if (! file_exists($this->file)) {
+            file_put_contents($this->file, '[]');
+        }
+    }
+
+    /**
+     * @return array<string, array{userHandle: string, displayName: string, createdAt: int}>
+     */
+    private function readAll(): array
+    {
+        $raw = (string) file_get_contents($this->file);
+        $data = json_decode($raw, true);
+
+        return is_array($data) ? $data : [];
+    }
+
+    /**
+     * @param array<string, array{userHandle: string, displayName: string, createdAt: int}> $data
+     */
+    private function writeAll(array $data): void
+    {
+        file_put_contents($this->file, json_encode($data, \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * Look up an existing user by username, or create a fresh account on first sight.
+     * Returns the binary user handle the WebAuthn user entity expects.
+     */
+    public function findOrCreate(string $username, string $displayName): string
+    {
+        $all = $this->readAll();
+        if (isset($all[$username])) {
+            return (string) base64_decode($all[$username]['userHandle'], true);
+        }
+        $userHandle = random_bytes(32);
+        $all[$username] = [
+            'userHandle' => base64_encode($userHandle),
+            'displayName' => $displayName === '' ? $username : $displayName,
+            'createdAt' => time(),
+        ];
+        $this->writeAll($all);
+
+        return $userHandle;
+    }
+
+    /**
+     * Returns the binary user handle for a known username, or null if the
+     * account has never been seen.
+     */
+    public function findUserHandle(string $username): ?string
+    {
+        $row = $this->readAll()[$username] ?? null;
+
+        return $row === null ? null : (string) base64_decode($row['userHandle'], true);
+    }
+
+    /**
+     * Returns the username bound to a user handle. Used during sign-in to map
+     * the bytes the authenticator returned back to a human-readable identity.
+     */
+    public function findUsernameByHandle(string $userHandle): ?string
+    {
+        $needle = base64_encode($userHandle);
+        foreach ($this->readAll() as $username => $row) {
+            if ($row['userHandle'] === $needle) {
+                return $username;
+            }
+        }
+
+        return null;
+    }
+
+    public function findDisplayName(string $username): ?string
+    {
+        return $this->readAll()[$username]['displayName'] ?? null;
+    }
+
+    public function updateDisplayName(string $username, string $displayName): void
+    {
+        $all = $this->readAll();
+        if (! isset($all[$username])) {
+            return;
+        }
+        $all[$username]['displayName'] = $displayName;
+        $this->writeAll($all);
+    }
+}

--- a/docs/examples/signal-api-demo/src/bootstrap.php
+++ b/docs/examples/signal-api-demo/src/bootstrap.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\SignalApiDemo;
+
+use Cose\Algorithm\Manager;
+use Cose\Algorithm\Signature\ECDSA\ES256;
+use Cose\Algorithm\Signature\RSA\RS256;
+use Symfony\Component\Serializer\Serializer;
+use Webauthn\AttestationStatement\AttestationStatementSupportManager;
+use Webauthn\AttestationStatement\NoneAttestationStatementSupport;
+use Webauthn\AuthenticatorAssertionResponseValidator;
+use Webauthn\AuthenticatorAttestationResponseValidator;
+use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
+use Webauthn\Denormalizer\WebauthnSerializerFactory;
+
+$autoload = __DIR__ . '/../vendor/autoload.php';
+if (! is_file($autoload)) {
+    fwrite(\STDERR, "Run `composer install` in docs/examples/signal-api-demo/ first.\n");
+    exit(1);
+}
+require_once $autoload;
+
+require_once __DIR__ . '/UserStore.php';
+require_once __DIR__ . '/CredentialStore.php';
+
+/**
+ * Minimal service container for the demo.
+ *
+ * Wires together the four things a pure-PHP relying party needs to run a
+ * WebAuthn ceremony:
+ *
+ *  - A serializer that knows how to (de)serialize the WebAuthn options
+ *    objects sent to the browser and the PublicKeyCredential JSON the
+ *    browser sends back.
+ *  - An attestation statement support manager. The demo accepts the `none`
+ *    format only, which is the default for platform authenticators and the
+ *    safe choice for a passwordless login that does not need attestation.
+ *  - A COSE algorithm manager. ES256 and RS256 cover every authenticator
+ *    in circulation, including platform and roaming.
+ *  - Two validators wired on top of a CeremonyStepManager configured with
+ *    the relying party's allowed origins.
+ *
+ * Persistence is delegated to two demo-only JSON-file stores
+ * (UserStore + CredentialStore). Production code MUST replace them with a
+ * real database behind the framework's repository interfaces.
+ */
+final class Container
+{
+    public string $relyingPartyId;
+
+    public string $relyingPartyName;
+
+    /** @var string[] */
+    public array $allowedOrigins;
+
+    public AttestationStatementSupportManager $attestationManager;
+
+    public Manager $algorithmManager;
+
+    public CeremonyStepManagerFactory $ceremonyFactory;
+
+    public AuthenticatorAttestationResponseValidator $attestationValidator;
+
+    public AuthenticatorAssertionResponseValidator $assertionValidator;
+
+    public Serializer $serializer;
+
+    public UserStore $userStore;
+
+    public CredentialStore $credentialStore;
+
+    public function __construct()
+    {
+        $this->relyingPartyId = $_ENV['RP_ID'] ?? 'localhost';
+        $this->relyingPartyName = 'WebAuthn Signal API Demo';
+        $this->allowedOrigins = explode(',', $_ENV['ALLOWED_ORIGINS'] ?? 'http://localhost:8000');
+
+        $this->attestationManager = new AttestationStatementSupportManager();
+        $this->attestationManager->add(new NoneAttestationStatementSupport());
+
+        $this->algorithmManager = Manager::create()->add(ES256::create(), RS256::create());
+
+        $serializer = (new WebauthnSerializerFactory($this->attestationManager))->create();
+        \assert($serializer instanceof Serializer);
+        $this->serializer = $serializer;
+
+        $this->ceremonyFactory = new CeremonyStepManagerFactory();
+        $this->ceremonyFactory->setAttestationStatementSupportManager($this->attestationManager);
+        $this->ceremonyFactory->setAlgorithmManager($this->algorithmManager);
+        $this->ceremonyFactory->setAllowedOrigins($this->allowedOrigins);
+
+        $this->attestationValidator = AuthenticatorAttestationResponseValidator::create(
+            $this->ceremonyFactory->creationCeremony(),
+        );
+        $this->assertionValidator = AuthenticatorAssertionResponseValidator::create(
+            $this->ceremonyFactory->requestCeremony(),
+        );
+
+        $varDir = $_ENV['VAR_DIR'] ?? __DIR__ . '/../var';
+        $this->userStore = new UserStore($varDir . '/users.json');
+        $this->credentialStore = new CredentialStore($varDir . '/credentials.json', $this->serializer);
+    }
+}

--- a/docs/examples/usernameless-demo/.gitignore
+++ b/docs/examples/usernameless-demo/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+/var/*.json
+composer.lock

--- a/docs/examples/usernameless-demo/README.md
+++ b/docs/examples/usernameless-demo/README.md
@@ -1,0 +1,88 @@
+# Usernameless (discoverable) Demo, `web-auth/webauthn-lib`
+
+A pure-PHP example of a sign-in flow that does NOT take a username as
+input. Companion to the [basic-demo](../basic-demo). The relying party
+hands the browser an assertion challenge with an empty
+`allowCredentials` list and the user agent surfaces a Conditional UI
+passkey picker. Server-side, the account is resolved from the credential
+id plus the user handle the authenticator returns in
+`response.userHandle`.
+
+## Four pages, three flows
+
+| Page | What it does |
+|---|---|
+| [`/`](same-origin/public/index.html) | Landing page, shows the current session state and links to the other pages. |
+| [`/register.html`](same-origin/public/register.html) | Creates an account secured by a discoverable passkey. The page calls `navigator.credentials.create()` with `residentKey: required` and `userVerification: required`. The authenticator stores the user handle locally so future sign-ins can surface this account without being told a username. |
+| [`/login.html`](same-origin/public/login.html) | Signs the user in without a username. The page calls `navigator.credentials.get({ mediation: 'conditional', publicKey })` on load to arm a Conditional UI picker; a manual fallback button is also provided. The server identifies the user from the credential id and verifies that `response.userHandle` matches the binding stored at registration. |
+| [`/account.html`](same-origin/public/account.html) | Same passkey management UI as the basic-demo: list, add another passkey (also discoverable), rename, delete. The last passkey of an account cannot be deleted. |
+
+## How it differs from the basic-demo
+
+| Concern | basic-demo | usernameless-demo |
+|---|---|---|
+| `residentKey` at registration | `preferred` (works either way) | `required` (forces a discoverable credential) |
+| `userVerification` at registration | `preferred` | `required` (so the credential is a single-factor passkey) |
+| Login form | username input | no input; Conditional UI picker via `autocomplete="username webauthn"` + a manual fallback button |
+| `allowCredentials` at sign-in | populated from the user's stored credentials | empty (`[]`); the authenticator picks any matching credential |
+| Server-side user lookup at verify | by session-stored username | by credential id, then verified against `response.userHandle` |
+
+## Run it
+
+```bash
+cd docs/examples/usernameless-demo
+./same-origin/run.sh
+```
+
+The script `composer install`s on first run and boots the demo on
+<http://localhost:8000>. The shipped `composer.json` symlinks
+`web-auth/webauthn-framework` from this checkout (`../../..`).
+
+Open <http://localhost:8000> in a browser with passkey support AND
+Conditional UI support:
+
+- Chrome 108+, Edge 108+, Safari 16+, Firefox 119+ for Conditional UI.
+- A platform authenticator (Touch ID, Windows Hello, Android device
+  unlock) or a roaming hardware key.
+- A secure context (`localhost` qualifies).
+
+Walk through the pages in order:
+
+1. <http://localhost:8000/register.html>, register a discoverable
+   passkey. You are redirected to `/account.html`.
+2. Hit *Sign out* on `/account.html`, then
+   <http://localhost:8000/login.html>. Click the username field, the
+   browser should offer the passkey you just registered. Pick it.
+3. On <http://localhost:8000/account.html> click *Add another passkey* to
+   enrol a second device (also as a discoverable credential).
+
+## What lives in `var/`
+
+Same shape as the basic-demo:
+
+- `var/users.json`: `username -> { userHandle, displayName, createdAt }`.
+- `var/credentials.json`: `credentialId -> { userHandle, credentialId,
+  source, label, addedAt, lastUsedAt }`. The `source` field holds the
+  `CredentialRecord` JSON.
+
+Delete the two JSON files to reset the demo.
+
+## What this demo deliberately leaves out
+
+- A real database. Production code MUST plug a real
+  `Webauthn\CredentialRecordRepositoryInterface` against a real
+  persistence layer.
+- Account recovery, email verification, CSRF, rate limiting, ...
+- Multi-RP / cross-origin setups.
+
+## Where to look in the code
+
+| What | File |
+|---|---|
+| Service wiring | [`src/bootstrap.php`](src/bootstrap.php) |
+| User table (username -> userHandle mapping) | [`src/UserStore.php`](src/UserStore.php) |
+| Credential persistence | [`src/CredentialStore.php`](src/CredentialStore.php) |
+| All HTTP endpoints, including the usernameless login | [`same-origin/router.php`](same-origin/router.php) |
+| Browser side, attestation with `residentKey: required` | [`same-origin/public/register.html`](same-origin/public/register.html) |
+| Browser side, assertion with Conditional UI | [`same-origin/public/login.html`](same-origin/public/login.html) |
+| Browser side, account management | [`same-origin/public/account.html`](same-origin/public/account.html) |

--- a/docs/examples/usernameless-demo/composer.json
+++ b/docs/examples/usernameless-demo/composer.json
@@ -1,0 +1,30 @@
+{
+    "name": "web-auth/usernameless-demo",
+    "description": "End-to-end pure-PHP demo of usernameless (discoverable-credential / Conditional UI) passkey login using web-auth/webauthn-lib",
+    "type": "project",
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../..",
+            "options": {
+                "symlink": true,
+                "versions": {
+                    "web-auth/webauthn-framework": "5.4.x-dev"
+                }
+            }
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "ext-json": "*",
+        "ext-openssl": "*",
+        "web-auth/webauthn-framework": "5.4.x-dev",
+        "symfony/clock": "^6.4 || ^7.0",
+        "symfony/serializer": "^6.4 || ^7.0",
+        "symfony/property-access": "^6.4 || ^7.0",
+        "symfony/property-info": "^6.4 || ^7.0",
+        "symfony/uid": "^6.4 || ^7.0"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/docs/examples/usernameless-demo/same-origin/public/account.html
+++ b/docs/examples/usernameless-demo/same-origin/public/account.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Usernameless Demo, My account</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 860px; margin: 40px auto; padding: 20px; color: #1f2937; line-height: 1.55; }
+        h1 { font-size: 1.5rem; }
+        h2 { font-size: 1.1rem; margin-top: 2rem; }
+        nav a { color: #2563eb; margin-right: 1rem; }
+        button { background: #2563eb; color: #fff; border: none; cursor: pointer; padding: 0.45rem 0.85rem; border-radius: 6px; font-size: 0.95rem; margin-right: 0.4rem; }
+        button.ghost { background: transparent; color: #2563eb; border: 1px solid #2563eb; }
+        button.danger { background: #b91c1c; }
+        button:disabled { background: #94a3b8; cursor: not-allowed; }
+        table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+        th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid #e5e7eb; font-size: 0.92rem; vertical-align: top; }
+        th { background: #f9fafb; }
+        td.label input { padding: 0.3rem 0.5rem; font-size: 0.9rem; border-radius: 4px; border: 1px solid #d1d5db; width: 100%; box-sizing: border-box; }
+        td.actions { white-space: nowrap; }
+        code { background: #f3f4f6; padding: 1px 6px; border-radius: 4px; font-size: 0.85rem; }
+        pre { background: #f3f4f6; padding: 12px; border-radius: 6px; overflow-x: auto; max-height: 200px; white-space: pre-wrap; word-break: break-all; }
+        .ok { color: #047857; }
+        .err { color: #b91c1c; }
+        .hidden { display: none; }
+    </style>
+</head>
+<body>
+<nav>
+    <a href="/">&larr; Home</a>
+    <a href="/register.html">Register a different account</a>
+</nav>
+
+<h1>My account</h1>
+
+<div id="unauthenticated" class="hidden">
+    <p class="err">You are not signed in.</p>
+    <p><a href="/login.html"><button>Sign in</button></a></p>
+</div>
+
+<div id="authenticated" class="hidden">
+    <p>Signed in as <strong id="username"></strong> (<span id="displayName"></span>).</p>
+    <p>
+        <button id="add-passkey">Add another passkey</button>
+        <button id="logout" class="ghost">Sign out</button>
+    </p>
+
+    <h2>Registered passkeys</h2>
+    <p>Each row maps to a stored <code>CredentialRecord</code>. The label is purely server-side metadata.</p>
+    <table id="passkeys">
+        <thead>
+        <tr>
+            <th>Label</th>
+            <th>Credential ID</th>
+            <th>AAGUID</th>
+            <th>Counter</th>
+            <th>Backup</th>
+            <th>Last used</th>
+            <th>Actions</th>
+        </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</div>
+
+<h2>Activity log</h2>
+<pre id="output">Loading account...</pre>
+
+<script type="module">
+    const output = document.getElementById('output');
+    const log = (msg, cls = '') => {
+        const line = document.createElement('div');
+        if (cls) line.className = cls;
+        line.textContent = msg;
+        output.appendChild(line);
+    };
+
+    const b64u = {
+        encode: (buf) => {
+            const bytes = new Uint8Array(buf);
+            let str = '';
+            for (let i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i]);
+            return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+        },
+        decode: (s) => {
+            s = s.replace(/-/g, '+').replace(/_/g, '/');
+            const pad = (4 - (s.length % 4)) % 4;
+            s += '='.repeat(pad);
+            const bin = atob(s);
+            const out = new Uint8Array(bin.length);
+            for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+            return out;
+        },
+    };
+
+    const toCreateOptions = (json) => {
+        const o = { ...json };
+        o.challenge = b64u.decode(json.challenge);
+        o.user = { ...json.user, id: b64u.decode(json.user.id) };
+        if (json.excludeCredentials) {
+            o.excludeCredentials = json.excludeCredentials.map((c) => ({
+                ...c,
+                id: b64u.decode(c.id),
+            }));
+        }
+        return o;
+    };
+
+    const credentialToJson = (cred, label) => ({
+        id: cred.id,
+        rawId: b64u.encode(cred.rawId),
+        type: cred.type,
+        response: {
+            clientDataJSON: b64u.encode(cred.response.clientDataJSON),
+            attestationObject: b64u.encode(cred.response.attestationObject),
+        },
+        clientExtensionResults: { demoLabel: label },
+    });
+
+    const formatDate = (ts) => ts ? new Date(ts * 1000).toLocaleString() : 'never';
+    const formatBackup = (eligible, status) => {
+        if (eligible === null || eligible === undefined) return 'unknown';
+        return `${eligible ? 'eligible' : 'not eligible'} / ${status ? 'backed up' : 'local only'}`;
+    };
+
+    const renderPasskeys = (credentials) => {
+        const tbody = document.querySelector('#passkeys tbody');
+        tbody.innerHTML = '';
+        const lastOne = credentials.length === 1;
+        credentials.forEach((c) => {
+            const tr = document.createElement('tr');
+            const credIdShort = c.credentialId.length > 22
+                ? c.credentialId.slice(0, 12) + '...' + c.credentialId.slice(-6)
+                : c.credentialId;
+            tr.innerHTML = `
+                <td class="label"><input type="text" value="${c.label.replace(/"/g, '&quot;')}" data-cred="${c.credentialId}"></td>
+                <td><code title="${c.credentialId}">${credIdShort}</code></td>
+                <td><code>${c.aaguid}</code></td>
+                <td>${c.counter}</td>
+                <td>${formatBackup(c.backupEligible, c.backupStatus)}</td>
+                <td>${formatDate(c.lastUsedAt)}</td>
+                <td class="actions">
+                    <button class="ghost" data-action="rename" data-cred="${c.credentialId}">Rename</button>
+                    <button class="danger" data-action="delete" data-cred="${c.credentialId}" ${lastOne ? 'disabled title="The last passkey of an account cannot be deleted in this demo."' : ''}>Delete</button>
+                </td>
+            `;
+            tbody.appendChild(tr);
+        });
+    };
+
+    const loadMe = async () => {
+        const r = await fetch('/api/me');
+        if (r.status === 401) {
+            document.getElementById('unauthenticated').classList.remove('hidden');
+            log('Not signed in.', 'err');
+            return null;
+        }
+        const me = await r.json();
+        document.getElementById('authenticated').classList.remove('hidden');
+        document.getElementById('username').textContent = me.username;
+        document.getElementById('displayName').textContent = me.displayName ?? '';
+        renderPasskeys(me.credentials);
+        log(`Loaded ${me.credentials.length} passkey(s) for ${me.username}.`, 'ok');
+        return me;
+    };
+
+    document.getElementById('logout').addEventListener('click', async () => {
+        await fetch('/api/logout', { method: 'POST' });
+        window.location.href = '/';
+    });
+
+    document.getElementById('add-passkey').addEventListener('click', async (e) => {
+        const btn = e.currentTarget;
+        btn.disabled = true;
+        try {
+            const label = window.prompt('Label for the new passkey (e.g. "my YubiKey"):') ?? '';
+            log('Asking server for add-passkey options...');
+            const optResp = await fetch('/api/account/passkey/add/options', { method: 'POST' });
+            if (!optResp.ok) throw new Error(`options HTTP ${optResp.status}: ${await optResp.text()}`);
+            const optsJson = await optResp.json();
+            log('Options received. Calling navigator.credentials.create()...', 'ok');
+
+            const credential = await navigator.credentials.create({ publicKey: toCreateOptions(optsJson) });
+            log('Credential created. POST /api/account/passkey/add/verify ...', 'ok');
+
+            const verifyResp = await fetch('/api/account/passkey/add/verify', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(credentialToJson(credential, label)),
+            });
+            if (!verifyResp.ok) throw new Error(`verify HTTP ${verifyResp.status}: ${await verifyResp.text()}`);
+            log('New passkey stored. Refreshing list...', 'ok');
+            await loadMe();
+        } catch (err) {
+            log(`Error: ${err.message}`, 'err');
+        } finally {
+            btn.disabled = false;
+        }
+    });
+
+    document.querySelector('#passkeys').addEventListener('click', async (e) => {
+        const btn = e.target.closest('button[data-action]');
+        if (!btn) return;
+        const credentialId = btn.dataset.cred;
+        const action = btn.dataset.action;
+        try {
+            if (action === 'rename') {
+                const input = document.querySelector(`input[data-cred="${CSS.escape(credentialId)}"]`);
+                const label = input?.value ?? '';
+                if (label.trim() === '') return;
+                const r = await fetch('/api/account/passkey/rename', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ credentialId, label }),
+                });
+                if (!r.ok) throw new Error(`rename HTTP ${r.status}: ${await r.text()}`);
+                log(`Renamed to "${label}".`, 'ok');
+            } else if (action === 'delete') {
+                if (!window.confirm('Delete this passkey?')) return;
+                const r = await fetch('/api/account/passkey/delete', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ credentialId }),
+                });
+                if (!r.ok) throw new Error(`delete HTTP ${r.status}: ${await r.text()}`);
+                log('Passkey deleted. Refreshing list...', 'ok');
+                await loadMe();
+            }
+        } catch (err) {
+            log(`Error: ${err.message}`, 'err');
+        }
+    });
+
+    output.textContent = '';
+    await loadMe();
+</script>
+</body>
+</html>

--- a/docs/examples/usernameless-demo/same-origin/public/index.html
+++ b/docs/examples/usernameless-demo/same-origin/public/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Usernameless WebAuthn Demo</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 720px; margin: 40px auto; padding: 20px; color: #1f2937; line-height: 1.55; }
+        h1 { font-size: 1.5rem; }
+        h2 { font-size: 1.1rem; margin-top: 2rem; }
+        a { color: #2563eb; }
+        .card { background: #f3f4f6; border-radius: 8px; padding: 16px 20px; margin: 1.2rem 0; }
+        .card h3 { margin-top: 0; font-size: 1rem; }
+        nav { margin-bottom: 2rem; }
+        nav a { margin-right: 1rem; }
+        code { background: #f3f4f6; padding: 1px 6px; border-radius: 4px; font-size: 0.9rem; }
+        .status { font-size: 0.95rem; padding: 10px 14px; border-radius: 6px; margin: 1rem 0; }
+        .status.logged-in { background: #d1fae5; color: #065f46; }
+        .status.logged-out { background: #fee2e2; color: #991b1b; }
+        button { background: #2563eb; color: #fff; border: none; cursor: pointer; padding: 0.45rem 0.85rem; border-radius: 6px; font-size: 0.95rem; }
+        button.ghost { background: transparent; color: #2563eb; border: 1px solid #2563eb; }
+    </style>
+</head>
+<body>
+
+<h1>Usernameless (discoverable) WebAuthn Demo</h1>
+<p>
+    Like the <a href="https://github.com/web-auth/webauthn-framework/tree/5.4.x/docs/examples/basic-demo">basic-demo</a>,
+    but the sign-in page does not ask for a username. The browser surfaces a
+    Conditional UI passkey picker and the server identifies the account from
+    the credential id alone.
+</p>
+
+<div id="status" class="status logged-out">Loading session state...</div>
+
+<div class="card">
+    <h3>1. Register a discoverable passkey</h3>
+    <p>Creates an account secured by a passkey with <code>residentKey: required</code> and <code>userVerification: required</code>. The user handle is stored on the authenticator so the browser can offer this account on a future sign-in without being told a username.</p>
+    <p><a href="/register.html"><button>Register a new account</button></a></p>
+</div>
+
+<div class="card">
+    <h3>2. Sign in without a username</h3>
+    <p>No username field. The browser picks a passkey from its autofill suggestions or the Conditional UI prompt, and the server identifies the account from the credential id and the authenticator-returned user handle.</p>
+    <p><a href="/login.html"><button>Sign in</button></a></p>
+</div>
+
+<div class="card">
+    <h3>3. Manage passkeys</h3>
+    <p>List, add, rename and delete passkeys for the signed-in account. Same UI as the basic-demo.</p>
+    <p><a href="/account.html"><button class="ghost">Open my account</button></a></p>
+</div>
+
+<h2>How it differs from the basic-demo</h2>
+<ul>
+    <li>Registration sets <code>residentKey: required</code> and <code>userVerification: required</code>, so the credential is discoverable.</li>
+    <li>Login options are issued with an empty <code>allowCredentials</code> list and the page calls <code>navigator.credentials.get({ mediation: 'conditional' })</code>. The user agent surfaces a passkey picker tied to the username input's autofill suggestions.</li>
+    <li>On verify, the server resolves the account from the credential id and validates that <code>response.userHandle</code> matches the binding stored at registration.</li>
+</ul>
+
+<h2>What this demo deliberately leaves out</h2>
+<ul>
+    <li>A real database (JSON files under <code>var/</code>).</li>
+    <li>Account recovery, email verification, CSRF, rate limiting, ...</li>
+</ul>
+
+<script type="module">
+    const status = document.getElementById('status');
+
+    try {
+        const r = await fetch('/api/me');
+        const me = await r.json();
+        if (me.authenticated) {
+            status.className = 'status logged-in';
+            status.textContent = `Signed in as ${me.username} (${me.credentials.length} passkey(s) registered).`;
+        } else {
+            status.className = 'status logged-out';
+            status.textContent = 'Not signed in.';
+        }
+    } catch (e) {
+        status.className = 'status logged-out';
+        status.textContent = 'Session check failed: ' + e.message;
+    }
+</script>
+
+</body>
+</html>

--- a/docs/examples/usernameless-demo/same-origin/public/login.html
+++ b/docs/examples/usernameless-demo/same-origin/public/login.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Usernameless Demo, Sign in</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 720px; margin: 40px auto; padding: 20px; color: #1f2937; line-height: 1.55; }
+        h1 { font-size: 1.5rem; }
+        label { display: block; margin: 0.6rem 0 0.25rem; font-weight: 500; }
+        input, button { padding: 0.55rem 0.75rem; font-size: 1rem; border-radius: 6px; border: 1px solid #d1d5db; box-sizing: border-box; }
+        input { width: 100%; }
+        button { background: #2563eb; color: #fff; border: none; cursor: pointer; }
+        button:disabled { background: #94a3b8; cursor: not-allowed; }
+        pre { background: #f3f4f6; padding: 12px; border-radius: 6px; overflow-x: auto; max-height: 360px; white-space: pre-wrap; word-break: break-all; }
+        .ok { color: #047857; }
+        .err { color: #b91c1c; }
+        nav a { color: #2563eb; margin-right: 1rem; }
+        .note { background: #eff6ff; border-left: 4px solid #2563eb; padding: 10px 14px; border-radius: 6px; margin: 1rem 0; font-size: 0.92rem; }
+    </style>
+</head>
+<body>
+<nav><a href="/">&larr; Home</a><a href="/register.html">Register a new account</a></nav>
+
+<h1>2. Sign in without a username</h1>
+
+<p>
+    Server-side, the assertion options carry an empty <code>allowCredentials</code>
+    list. Browser-side, the page calls
+    <code>navigator.credentials.get({ mediation: 'conditional', publicKey })</code>
+    so the user agent surfaces a passkey picker as autofill suggestions on the
+    (visually empty) username input. Picking a passkey triggers the assertion.
+</p>
+
+<div class="note">
+    If your browser does not support Conditional UI, click the <em>Sign in
+    manually</em> button below to fall back to a modal passkey picker.
+</div>
+
+<form id="login-form">
+    <label for="username">Username (passkey picker)</label>
+    <input id="username" name="username" type="text" autocomplete="username webauthn" placeholder="Start typing or use the autofill prompt">
+
+    <p>
+        <button type="button" id="manual">Sign in manually</button>
+    </p>
+</form>
+
+<h2>Output</h2>
+<pre id="output">Conditional UI armed. Focus the username field to surface the passkey picker, or click "Sign in manually".</pre>
+
+<script type="module">
+    const form = document.getElementById('login-form');
+    const manualBtn = document.getElementById('manual');
+    const output = document.getElementById('output');
+
+    const log = (msg, cls = '') => {
+        const line = document.createElement('div');
+        if (cls) line.className = cls;
+        line.textContent = msg;
+        output.appendChild(line);
+    };
+
+    const b64u = {
+        encode: (buf) => {
+            const bytes = new Uint8Array(buf);
+            let str = '';
+            for (let i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i]);
+            return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+        },
+        decode: (s) => {
+            s = s.replace(/-/g, '+').replace(/_/g, '/');
+            const pad = (4 - (s.length % 4)) % 4;
+            s += '='.repeat(pad);
+            const bin = atob(s);
+            const out = new Uint8Array(bin.length);
+            for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+            return out;
+        },
+    };
+
+    const toGetOptions = (json) => {
+        const o = { ...json };
+        o.challenge = b64u.decode(json.challenge);
+        o.allowCredentials = [];
+        return o;
+    };
+
+    const assertionToJson = (cred) => ({
+        id: cred.id,
+        rawId: b64u.encode(cred.rawId),
+        type: cred.type,
+        response: {
+            clientDataJSON: b64u.encode(cred.response.clientDataJSON),
+            authenticatorData: b64u.encode(cred.response.authenticatorData),
+            signature: b64u.encode(cred.response.signature),
+            userHandle: cred.response.userHandle ? b64u.encode(cred.response.userHandle) : null,
+        },
+    });
+
+    const fetchOptions = async () => {
+        const optResp = await fetch('/api/login/options', { method: 'POST' });
+        if (!optResp.ok) throw new Error(`options HTTP ${optResp.status}: ${await optResp.text()}`);
+        return await optResp.json();
+    };
+
+    const verify = async (credential) => {
+        const verifyResp = await fetch('/api/login/verify', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(assertionToJson(credential)),
+        });
+        if (!verifyResp.ok) throw new Error(`verify HTTP ${verifyResp.status}: ${await verifyResp.text()}`);
+        return await verifyResp.json();
+    };
+
+    const runManual = async () => {
+        manualBtn.disabled = true;
+        output.textContent = '';
+        try {
+            log('Asking server for assertion options...');
+            const optsJson = await fetchOptions();
+            log('Options received. Calling navigator.credentials.get()...', 'ok');
+            const credential = await navigator.credentials.get({ publicKey: toGetOptions(optsJson) });
+            log('Assertion produced. POST /api/login/verify ...', 'ok');
+            const verified = await verify(credential);
+            log(`Signed in as ${verified.username}. Redirecting in 1.5s...`, 'ok');
+            setTimeout(() => { window.location.href = '/account.html'; }, 1500);
+        } catch (err) {
+            log(`Error: ${err.message}`, 'err');
+        } finally {
+            manualBtn.disabled = false;
+        }
+    };
+
+    manualBtn.addEventListener('click', runManual);
+
+    const conditionalAvailable = window.PublicKeyCredential
+        && typeof PublicKeyCredential.isConditionalMediationAvailable === 'function'
+        && await PublicKeyCredential.isConditionalMediationAvailable();
+
+    if (conditionalAvailable) {
+        try {
+            log('Conditional UI is supported. Arming background assertion...');
+            const optsJson = await fetchOptions();
+            const credential = await navigator.credentials.get({
+                mediation: 'conditional',
+                publicKey: toGetOptions(optsJson),
+            });
+            log('User picked a passkey. POST /api/login/verify ...', 'ok');
+            const verified = await verify(credential);
+            log(`Signed in as ${verified.username}. Redirecting in 1.5s...`, 'ok');
+            setTimeout(() => { window.location.href = '/account.html'; }, 1500);
+        } catch (err) {
+            if (err.name !== 'AbortError' && err.name !== 'NotAllowedError') {
+                log(`Conditional UI error: ${err.message}`, 'err');
+            }
+        }
+    } else {
+        log('Conditional UI is not available. Use the manual button instead.');
+    }
+</script>
+</body>
+</html>

--- a/docs/examples/usernameless-demo/same-origin/public/register.html
+++ b/docs/examples/usernameless-demo/same-origin/public/register.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Usernameless Demo, Register</title>
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; max-width: 720px; margin: 40px auto; padding: 20px; color: #1f2937; line-height: 1.55; }
+        h1 { font-size: 1.5rem; }
+        label { display: block; margin: 0.6rem 0 0.25rem; font-weight: 500; }
+        input, button { padding: 0.55rem 0.75rem; font-size: 1rem; border-radius: 6px; border: 1px solid #d1d5db; box-sizing: border-box; }
+        input { width: 100%; }
+        button { background: #2563eb; color: #fff; border: none; cursor: pointer; }
+        button:disabled { background: #94a3b8; cursor: not-allowed; }
+        pre { background: #f3f4f6; padding: 12px; border-radius: 6px; overflow-x: auto; max-height: 360px; white-space: pre-wrap; word-break: break-all; }
+        .ok { color: #047857; }
+        .err { color: #b91c1c; }
+        nav a { color: #2563eb; margin-right: 1rem; }
+        .note { background: #eff6ff; border-left: 4px solid #2563eb; padding: 10px 14px; border-radius: 6px; margin: 1rem 0; font-size: 0.92rem; }
+    </style>
+</head>
+<body>
+<nav><a href="/">&larr; Home</a><a href="/login.html">Sign in &rarr;</a></nav>
+
+<h1>1. Register a discoverable passkey</h1>
+
+<p>
+    The page asks the server for <code>PublicKeyCredentialCreationOptions</code>
+    configured with <code>residentKey: required</code> and
+    <code>userVerification: required</code>. The authenticator stores the user
+    handle locally, which is what makes the later sign-in possible without a
+    username.
+</p>
+
+<div class="note">
+    The username field below is part of <em>this</em> registration step only.
+    Once the passkey is enrolled, the sign-in page does not need it any more.
+</div>
+
+<form id="register-form">
+    <label for="username">Username (email)</label>
+    <input id="username" name="username" type="email" required value="jane.doe@example.com">
+
+    <label for="displayName">Display name</label>
+    <input id="displayName" name="displayName" type="text" value="Jane Doe">
+
+    <label for="label">Passkey label (shown on /account.html)</label>
+    <input id="label" name="label" type="text" placeholder="e.g. My iPhone">
+
+    <p><button type="submit" id="submit">Register</button></p>
+</form>
+
+<h2>Output</h2>
+<pre id="output">Submit the form to start a registration ceremony.</pre>
+
+<script type="module">
+    const form = document.getElementById('register-form');
+    const submit = document.getElementById('submit');
+    const output = document.getElementById('output');
+
+    const log = (msg, cls = '') => {
+        const line = document.createElement('div');
+        if (cls) line.className = cls;
+        line.textContent = msg;
+        output.appendChild(line);
+    };
+
+    const b64u = {
+        encode: (buf) => {
+            const bytes = new Uint8Array(buf);
+            let str = '';
+            for (let i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i]);
+            return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+        },
+        decode: (s) => {
+            s = s.replace(/-/g, '+').replace(/_/g, '/');
+            const pad = (4 - (s.length % 4)) % 4;
+            s += '='.repeat(pad);
+            const bin = atob(s);
+            const out = new Uint8Array(bin.length);
+            for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+            return out;
+        },
+    };
+
+    const toCreateOptions = (json) => {
+        const o = { ...json };
+        o.challenge = b64u.decode(json.challenge);
+        o.user = { ...json.user, id: b64u.decode(json.user.id) };
+        if (json.excludeCredentials) {
+            o.excludeCredentials = json.excludeCredentials.map((c) => ({
+                ...c,
+                id: b64u.decode(c.id),
+            }));
+        }
+        return o;
+    };
+
+    const credentialToJson = (cred, label) => ({
+        id: cred.id,
+        rawId: b64u.encode(cred.rawId),
+        type: cred.type,
+        response: {
+            clientDataJSON: b64u.encode(cred.response.clientDataJSON),
+            attestationObject: b64u.encode(cred.response.attestationObject),
+        },
+        clientExtensionResults: { demoLabel: label },
+    });
+
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        submit.disabled = true;
+        output.textContent = '';
+
+        try {
+            const username = form.username.value;
+            const displayName = form.displayName.value;
+            const label = form.label.value;
+
+            log('Asking server for creation options...');
+            const optResp = await fetch('/api/register/options', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username, displayName }),
+            });
+            if (!optResp.ok) throw new Error(`options HTTP ${optResp.status}: ${await optResp.text()}`);
+            const optsJson = await optResp.json();
+            log(`Options received (residentKey=${optsJson.authenticatorSelection?.residentKey}, userVerification=${optsJson.authenticatorSelection?.userVerification}).`, 'ok');
+
+            log('Calling navigator.credentials.create()...');
+            const credential = await navigator.credentials.create({ publicKey: toCreateOptions(optsJson) });
+            log('Credential created by the authenticator (discoverable).', 'ok');
+
+            log('POST /api/register/verify ...');
+            const verifyResp = await fetch('/api/register/verify', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(credentialToJson(credential, label)),
+            });
+            if (!verifyResp.ok) throw new Error(`verify HTTP ${verifyResp.status}: ${await verifyResp.text()}`);
+            const verified = await verifyResp.json();
+            log(`Stored. credentialId=${verified.credentialId}`, 'ok');
+            log('You are now signed in. Redirecting to /account.html in 1.5s...');
+            setTimeout(() => { window.location.href = '/account.html'; }, 1500);
+        } catch (err) {
+            log(`Error: ${err.message}`, 'err');
+        } finally {
+            submit.disabled = false;
+        }
+    });
+</script>
+</body>
+</html>

--- a/docs/examples/usernameless-demo/same-origin/router.php
+++ b/docs/examples/usernameless-demo/same-origin/router.php
@@ -1,0 +1,469 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Front controller for `php -S`. Same shape as the basic-demo, plus the
+ * usernameless-specific differences:
+ *
+ *  - /api/register/options forces `residentKey: required` and
+ *    `userVerification: required` so the credential is discoverable and the
+ *    authenticator stores the user handle locally;
+ *  - /api/login/options does NOT take a username. The server issues a
+ *    challenge with an empty `allowCredentials` list, the browser uses the
+ *    `mediation: 'conditional'` UI mode to surface a passkey picker;
+ *  - /api/login/verify resolves the user via the credential id and verifies
+ *    that `response.userHandle` matches the binding stored at registration.
+ *
+ * Run with: php -S localhost:8000 -t public router.php
+ */
+
+use App\UsernamelessDemo\Container;
+use ParagonIE\ConstantTime\Base64;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\AuthenticatorSelectionCriteria;
+use Webauthn\PublicKeyCredential;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialParameters;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\PublicKeyCredentialRpEntity;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+require_once __DIR__ . '/../src/bootstrap.php';
+
+session_start();
+$container = new Container();
+$path = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?: '/';
+
+if ($path === '/') {
+    $_SERVER['REQUEST_URI'] = '/index.html';
+
+    return false;
+}
+
+if (! str_starts_with($path, '/api/')) {
+    return false;
+}
+
+header('Content-Type: application/json');
+
+try {
+    match ($path) {
+        '/api/me' => me($container),
+        '/api/logout' => logout(),
+        '/api/register/options' => registerOptions($container),
+        '/api/register/verify' => registerVerify($container),
+        '/api/login/options' => loginOptions($container),
+        '/api/login/verify' => loginVerify($container),
+        '/api/account/passkey/add/options' => addPasskeyOptions($container),
+        '/api/account/passkey/add/verify' => addPasskeyVerify($container),
+        '/api/account/passkey/rename' => renamePasskey($container),
+        '/api/account/passkey/delete' => deletePasskey($container),
+        default => notFound(),
+    };
+} catch (\Throwable $e) {
+    http_response_code(400);
+    echo json_encode([
+        'error' => $e->getMessage(),
+        'class' => $e::class,
+    ], \JSON_THROW_ON_ERROR);
+}
+
+function notFound(): void
+{
+    http_response_code(404);
+    echo json_encode([
+        'error' => 'Not found',
+    ], \JSON_THROW_ON_ERROR);
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function readJson(): array
+{
+    $body = file_get_contents('php://input') ?: '{}';
+    $json = json_decode($body, true, flags: \JSON_THROW_ON_ERROR);
+
+    return is_array($json) ? $json : [];
+}
+
+function jsonOut(mixed $payload): void
+{
+    echo json_encode($payload, \JSON_THROW_ON_ERROR);
+}
+
+function serializeOptions(Container $container, object $options): string
+{
+    return $container->serializer->serialize($options, 'json', [
+        'json_encode_options' => \JSON_THROW_ON_ERROR,
+        \Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+    ]);
+}
+
+function requireLogin(): string
+{
+    $userHandleB64 = $_SESSION['userHandle'] ?? null;
+    if (! is_string($userHandleB64) || $userHandleB64 === '') {
+        http_response_code(401);
+        echo json_encode([
+            'error' => 'Not authenticated',
+        ], \JSON_THROW_ON_ERROR);
+        exit;
+    }
+
+    return (string) base64_decode($userHandleB64, true);
+}
+
+function me(Container $container): void
+{
+    $userHandleB64 = $_SESSION['userHandle'] ?? null;
+    if (! is_string($userHandleB64) || $userHandleB64 === '') {
+        http_response_code(401);
+        jsonOut([
+            'authenticated' => false,
+        ]);
+
+        return;
+    }
+    $userHandle = (string) base64_decode($userHandleB64, true);
+    $username = $container->userStore->findUsernameByHandle($userHandle);
+    jsonOut([
+        'authenticated' => true,
+        'username' => $username,
+        'displayName' => $username === null ? null : $container->userStore->findDisplayName($username),
+        'credentials' => $container->credentialStore->listForUser($userHandle),
+    ]);
+}
+
+function logout(): void
+{
+    $_SESSION = [];
+    if (ini_get('session.use_cookies')) {
+        $params = session_get_cookie_params();
+        setcookie(
+            session_name(),
+            '',
+            time() - 42_000,
+            $params['path'],
+            $params['domain'],
+            $params['secure'],
+            $params['httponly']
+        );
+    }
+    session_destroy();
+    jsonOut([
+        'loggedOut' => true,
+    ]);
+}
+
+/**
+ * Step 1 of registration: server generates the creation options.
+ *
+ * Two flags drive the usernameless behaviour:
+ *
+ *  - `residentKey: required` tells the authenticator to store a discoverable
+ *    credential, which keeps the user handle on the device and lets the
+ *    browser surface the account on a future Conditional UI prompt without
+ *    being told a username;
+ *  - `userVerification: required` makes the authenticator perform user
+ *    verification (biometric, PIN, ...) at every ceremony. This is what
+ *    turns the credential into a single-factor passkey instead of a
+ *    second factor.
+ */
+function registerOptions(Container $container): void
+{
+    $body = readJson();
+    $username = trim((string) ($body['username'] ?? ''));
+    $displayName = trim((string) ($body['displayName'] ?? '')) ?: $username;
+    if ($username === '') {
+        throw new \RuntimeException('username is required.');
+    }
+
+    $userHandle = $container->userStore->findOrCreate($username, $displayName);
+    $_SESSION['register_username'] = $username;
+    $_SESSION['register_userHandle'] = base64_encode($userHandle);
+
+    $challenge = random_bytes(32);
+    $_SESSION['register_challenge'] = base64_encode($challenge);
+
+    $options = PublicKeyCredentialCreationOptions::create(
+        PublicKeyCredentialRpEntity::create($container->relyingPartyName, $container->relyingPartyId),
+        PublicKeyCredentialUserEntity::create($username, $userHandle, $displayName),
+        $challenge,
+        [
+            PublicKeyCredentialParameters::create('public-key', -7),
+            PublicKeyCredentialParameters::create('public-key', -257),
+        ],
+        AuthenticatorSelectionCriteria::create(
+            null,
+            AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_REQUIRED,
+            AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_REQUIRED,
+        ),
+        PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
+        $container->credentialStore->excludeCredentialsFor($userHandle),
+    );
+    $options->timeout = 60_000;
+
+    echo serializeOptions($container, $options);
+}
+
+function registerVerify(Container $container): void
+{
+    $body = file_get_contents('php://input') ?: '{}';
+    $credential = $container->serializer->deserialize($body, PublicKeyCredential::class, 'json');
+    \assert($credential instanceof PublicKeyCredential);
+
+    $response = $credential->response;
+    if (! $response instanceof AuthenticatorAttestationResponse) {
+        throw new \RuntimeException('Expected an AuthenticatorAttestationResponse.');
+    }
+
+    $challengeB64 = $_SESSION['register_challenge'] ?? null;
+    $username = (string) ($_SESSION['register_username'] ?? '');
+    $userHandleB64 = $_SESSION['register_userHandle'] ?? null;
+    if (! is_string($challengeB64) || $username === '' || ! is_string($userHandleB64)) {
+        throw new \RuntimeException('Missing registration session. Start over from /register.html.');
+    }
+    $challenge = (string) base64_decode($challengeB64, true);
+    $userHandle = (string) base64_decode($userHandleB64, true);
+
+    $options = PublicKeyCredentialCreationOptions::create(
+        PublicKeyCredentialRpEntity::create($container->relyingPartyName, $container->relyingPartyId),
+        PublicKeyCredentialUserEntity::create($username, $userHandle, $username),
+        $challenge,
+        [
+            PublicKeyCredentialParameters::create('public-key', -7),
+            PublicKeyCredentialParameters::create('public-key', -257),
+        ],
+    );
+
+    $record = $container->attestationValidator->check($response, $options, $container->relyingPartyId);
+    $label = trim((string) ($credential->clientExtensionResults['demoLabel'] ?? ''));
+    if ($label === '') {
+        $label = sprintf('Passkey added on %s', date('Y-m-d H:i'));
+    }
+    $container->credentialStore->save($userHandle, $record, $label);
+
+    unset($_SESSION['register_challenge'], $_SESSION['register_username'], $_SESSION['register_userHandle']);
+    $_SESSION['username'] = $username;
+    $_SESSION['userHandle'] = $userHandleB64;
+
+    jsonOut([
+        'verified' => true,
+        'credentialId' => Base64::encode($record->publicKeyCredentialId),
+    ]);
+}
+
+/**
+ * Step 1 of login: server hands out a challenge with an empty
+ * `allowCredentials` list. The page asks the user agent to surface a
+ * Conditional UI prompt, which lets the user pick any discoverable
+ * credential bound to this relying party (rpId). No username known to the
+ * server yet.
+ */
+function loginOptions(Container $container): void
+{
+    $challenge = random_bytes(32);
+    $_SESSION['login_challenge'] = base64_encode($challenge);
+
+    $options = PublicKeyCredentialRequestOptions::create(
+        $challenge,
+        $container->relyingPartyId,
+        [],
+        PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_REQUIRED,
+    );
+    $options->timeout = 60_000;
+
+    echo serializeOptions($container, $options);
+}
+
+/**
+ * Step 2 of login: resolve the user from the credential.
+ *
+ * The browser includes `response.userHandle` because the authenticator was
+ * enrolled as a discoverable credential. We use the credential id to fetch
+ * the stored CredentialRecord, then verify that the stored userHandle
+ * matches the one the authenticator returned, then hand both to the
+ * assertion validator (which double-checks the binding on its own).
+ */
+function loginVerify(Container $container): void
+{
+    $body = file_get_contents('php://input') ?: '{}';
+    $credential = $container->serializer->deserialize($body, PublicKeyCredential::class, 'json');
+    \assert($credential instanceof PublicKeyCredential);
+
+    $response = $credential->response;
+    if (! $response instanceof AuthenticatorAssertionResponse) {
+        throw new \RuntimeException('Expected an AuthenticatorAssertionResponse.');
+    }
+
+    $challengeB64 = $_SESSION['login_challenge'] ?? null;
+    if (! is_string($challengeB64)) {
+        throw new \RuntimeException('Missing login session. Start over from /login.html.');
+    }
+    $challenge = (string) base64_decode($challengeB64, true);
+
+    $record = $container->credentialStore->findByCredentialId($credential->rawId);
+    if ($record === null) {
+        throw new \RuntimeException('Unknown credential.');
+    }
+    $storedUserHandle = $container->credentialStore->findUserHandleByCredentialId($credential->rawId);
+    if ($storedUserHandle === null) {
+        throw new \RuntimeException('Credential is not bound to any user.');
+    }
+    $username = $container->userStore->findUsernameByHandle($storedUserHandle);
+    if ($username === null) {
+        throw new \RuntimeException('User no longer exists.');
+    }
+
+    if ($response->userHandle === null || $response->userHandle === '') {
+        throw new \RuntimeException('Authenticator did not return a user handle. Discoverable-credential ceremonies require it.');
+    }
+    if (! hash_equals($storedUserHandle, $response->userHandle)) {
+        throw new \RuntimeException('User handle mismatch between authenticator and server-stored record.');
+    }
+
+    $options = PublicKeyCredentialRequestOptions::create(
+        $challenge,
+        $container->relyingPartyId,
+        [],
+        PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_REQUIRED,
+    );
+
+    $updated = $container->assertionValidator->check(
+        $record,
+        $response,
+        $options,
+        $container->relyingPartyId,
+        $storedUserHandle,
+    );
+    $container->credentialStore->updateAfterAssertion($updated);
+
+    unset($_SESSION['login_challenge']);
+    $_SESSION['username'] = $username;
+    $_SESSION['userHandle'] = base64_encode($storedUserHandle);
+
+    jsonOut([
+        'verified' => true,
+        'username' => $username,
+    ]);
+}
+
+function addPasskeyOptions(Container $container): void
+{
+    $userHandle = requireLogin();
+    $username = $container->userStore->findUsernameByHandle($userHandle);
+    if ($username === null) {
+        throw new \RuntimeException('Session out of sync. Sign in again.');
+    }
+
+    $challenge = random_bytes(32);
+    $_SESSION['add_passkey_challenge'] = base64_encode($challenge);
+
+    $options = PublicKeyCredentialCreationOptions::create(
+        PublicKeyCredentialRpEntity::create($container->relyingPartyName, $container->relyingPartyId),
+        PublicKeyCredentialUserEntity::create($username, $userHandle, (string) $container->userStore->findDisplayName($username)),
+        $challenge,
+        [
+            PublicKeyCredentialParameters::create('public-key', -7),
+            PublicKeyCredentialParameters::create('public-key', -257),
+        ],
+        AuthenticatorSelectionCriteria::create(
+            null,
+            AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_REQUIRED,
+            AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_REQUIRED,
+        ),
+        PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
+        $container->credentialStore->excludeCredentialsFor($userHandle),
+    );
+    $options->timeout = 60_000;
+
+    echo serializeOptions($container, $options);
+}
+
+function addPasskeyVerify(Container $container): void
+{
+    $userHandle = requireLogin();
+    $username = $container->userStore->findUsernameByHandle($userHandle);
+    if ($username === null) {
+        throw new \RuntimeException('Session out of sync. Sign in again.');
+    }
+
+    $body = file_get_contents('php://input') ?: '{}';
+    $credential = $container->serializer->deserialize($body, PublicKeyCredential::class, 'json');
+    \assert($credential instanceof PublicKeyCredential);
+
+    $response = $credential->response;
+    if (! $response instanceof AuthenticatorAttestationResponse) {
+        throw new \RuntimeException('Expected an AuthenticatorAttestationResponse.');
+    }
+
+    $challengeB64 = $_SESSION['add_passkey_challenge'] ?? null;
+    if (! is_string($challengeB64)) {
+        throw new \RuntimeException('Missing add-passkey session.');
+    }
+    $challenge = (string) base64_decode($challengeB64, true);
+
+    $options = PublicKeyCredentialCreationOptions::create(
+        PublicKeyCredentialRpEntity::create($container->relyingPartyName, $container->relyingPartyId),
+        PublicKeyCredentialUserEntity::create($username, $userHandle, $username),
+        $challenge,
+        [
+            PublicKeyCredentialParameters::create('public-key', -7),
+            PublicKeyCredentialParameters::create('public-key', -257),
+        ],
+    );
+
+    $record = $container->attestationValidator->check($response, $options, $container->relyingPartyId);
+    $label = trim((string) ($credential->clientExtensionResults['demoLabel'] ?? ''));
+    if ($label === '') {
+        $label = sprintf('Passkey added on %s', date('Y-m-d H:i'));
+    }
+    $container->credentialStore->save($userHandle, $record, $label);
+    unset($_SESSION['add_passkey_challenge']);
+
+    jsonOut([
+        'verified' => true,
+        'credentialId' => Base64::encode($record->publicKeyCredentialId),
+    ]);
+}
+
+function renamePasskey(Container $container): void
+{
+    $userHandle = requireLogin();
+    $body = readJson();
+    $credentialId = (string) base64_decode((string) ($body['credentialId'] ?? ''), true);
+    $label = trim((string) ($body['label'] ?? ''));
+    if ($credentialId === '' || $label === '') {
+        throw new \RuntimeException('credentialId and label are required.');
+    }
+    $ok = $container->credentialStore->rename($credentialId, $userHandle, $label);
+    if (! $ok) {
+        throw new \RuntimeException('Cannot rename this credential.');
+    }
+    jsonOut([
+        'renamed' => true,
+    ]);
+}
+
+function deletePasskey(Container $container): void
+{
+    $userHandle = requireLogin();
+    $body = readJson();
+    $credentialId = (string) base64_decode((string) ($body['credentialId'] ?? ''), true);
+    if ($credentialId === '') {
+        throw new \RuntimeException('credentialId is required.');
+    }
+    if ($container->credentialStore->countForUser($userHandle) <= 1) {
+        throw new \RuntimeException('Cannot delete the last passkey of this account.');
+    }
+    $ok = $container->credentialStore->delete($credentialId, $userHandle);
+    if (! $ok) {
+        throw new \RuntimeException('Cannot delete this credential.');
+    }
+    jsonOut([
+        'deleted' => true,
+    ]);
+}

--- a/docs/examples/usernameless-demo/same-origin/run.sh
+++ b/docs/examples/usernameless-demo/same-origin/run.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Boot the same-origin usernameless-demo on http://localhost:8000.
+# Usage:  ./same-origin/run.sh   (from docs/examples/usernameless-demo/)
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [[ ! -d vendor ]]; then
+    echo "vendor/ missing, running composer install"
+    composer install --no-interaction
+fi
+
+PORT=8000
+
+is_busy() { lsof -i ":$1" >/dev/null 2>&1 || ss -ltn 2>/dev/null | grep -q ":$1 "; }
+if is_busy "$PORT"; then
+    echo "Port $PORT already in use. Free it and retry." >&2
+    exit 1
+fi
+
+cleanup() {
+    echo
+    echo "Stopping server..."
+    [[ -n "${PID:-}" ]] && kill "$PID" 2>/dev/null || true
+    wait 2>/dev/null || true
+}
+trap cleanup INT TERM EXIT
+
+echo "Usernameless WebAuthn demo (same-origin) -> http://localhost:$PORT"
+echo
+echo "Steps:"
+echo "  1. open http://localhost:$PORT/                (landing page)"
+echo "  2. open http://localhost:$PORT/register.html   (register a discoverable passkey)"
+echo "  3. open http://localhost:$PORT/login.html      (sign in via Conditional UI)"
+echo "  4. open http://localhost:$PORT/account.html    (list, add, rename, delete passkeys)"
+echo
+echo "Logs follow. Ctrl+C to stop."
+echo "----------------------------------------------------------------"
+
+php -S "localhost:$PORT" -t same-origin/public same-origin/router.php &
+PID=$!
+
+wait

--- a/docs/examples/usernameless-demo/src/CredentialStore.php
+++ b/docs/examples/usernameless-demo/src/CredentialStore.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\UsernamelessDemo;
+
+use Symfony\Component\Serializer\Serializer;
+use Webauthn\CredentialRecord;
+use Webauthn\PublicKeyCredentialDescriptor;
+
+/**
+ * Demo-only credential store. Each row keeps:
+ *
+ *  - `userHandle`         the binary user handle the credential is bound to
+ *                         (base64-encoded for JSON storage);
+ *  - `credentialId`       the binary credential ID (base64-encoded);
+ *  - `source`             the framework's CredentialRecord serialized to JSON.
+ *                         This is the canonical blob to persist after a
+ *                         successful attestation. It already contains the
+ *                         credential ID, the COSE public key, the signature
+ *                         counter, the AAGUID, transports and the backup flags;
+ *  - `label`              a human-friendly alias the user can rename;
+ *  - `addedAt`            registration timestamp;
+ *  - `lastUsedAt`         updated on every successful assertion.
+ *
+ * Production code MUST replace this with a real implementation of
+ * `Webauthn\CredentialRecordRepositoryInterface` (and optionally
+ * `Webauthn\CanSaveCredentialRecord` if it owns persistence). Doctrine users
+ * can reuse `DoctrineCredentialSourceRepository` from the Symfony bundle as
+ * a reference implementation.
+ */
+final class CredentialStore
+{
+    public function __construct(
+        private readonly string $file,
+        private readonly Serializer $serializer,
+    ) {
+        $dir = dirname($this->file);
+        if (! is_dir($dir)) {
+            mkdir($dir, 0o755, true);
+        }
+        if (! file_exists($this->file)) {
+            file_put_contents($this->file, '[]');
+        }
+    }
+
+    /**
+     * @return array<string, array{userHandle: string, credentialId: string, source: string, label: string, addedAt: int, lastUsedAt: ?int}>
+     */
+    private function readAll(): array
+    {
+        $raw = (string) file_get_contents($this->file);
+        $data = json_decode($raw, true);
+
+        return is_array($data) ? $data : [];
+    }
+
+    /**
+     * @param array<string, array{userHandle: string, credentialId: string, source: string, label: string, addedAt: int, lastUsedAt: ?int}> $data
+     */
+    private function writeAll(array $data): void
+    {
+        file_put_contents($this->file, json_encode($data, \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * Persist a freshly registered credential. Call this right after
+     * `AuthenticatorAttestationResponseValidator::check()` returns.
+     */
+    public function save(string $userHandle, CredentialRecord $record, string $label): void
+    {
+        $key = base64_encode($record->publicKeyCredentialId);
+        $all = $this->readAll();
+        $all[$key] = [
+            'userHandle' => base64_encode($userHandle),
+            'credentialId' => base64_encode($record->publicKeyCredentialId),
+            'source' => $this->serializer->serialize($record, 'json'),
+            'label' => $label,
+            'addedAt' => time(),
+            'lastUsedAt' => null,
+        ];
+        $this->writeAll($all);
+    }
+
+    /**
+     * Refresh the stored CredentialRecord after a successful assertion. The
+     * counter, backup flags and uvInitialized may have been updated in place
+     * by the validator, so we re-serialize the whole record.
+     */
+    public function updateAfterAssertion(CredentialRecord $record): void
+    {
+        $key = base64_encode($record->publicKeyCredentialId);
+        $all = $this->readAll();
+        if (! isset($all[$key])) {
+            return;
+        }
+        $all[$key]['source'] = $this->serializer->serialize($record, 'json');
+        $all[$key]['lastUsedAt'] = time();
+        $this->writeAll($all);
+    }
+
+    public function rename(string $credentialId, string $userHandle, string $label): bool
+    {
+        $key = base64_encode($credentialId);
+        $all = $this->readAll();
+        if (! isset($all[$key])) {
+            return false;
+        }
+        if ($all[$key]['userHandle'] !== base64_encode($userHandle)) {
+            return false;
+        }
+        $all[$key]['label'] = $label;
+        $this->writeAll($all);
+
+        return true;
+    }
+
+    public function delete(string $credentialId, string $userHandle): bool
+    {
+        $key = base64_encode($credentialId);
+        $all = $this->readAll();
+        if (! isset($all[$key])) {
+            return false;
+        }
+        if ($all[$key]['userHandle'] !== base64_encode($userHandle)) {
+            return false;
+        }
+        unset($all[$key]);
+        $this->writeAll($all);
+
+        return true;
+    }
+
+    public function findByCredentialId(string $credentialId): ?CredentialRecord
+    {
+        $key = base64_encode($credentialId);
+        $row = $this->readAll()[$key] ?? null;
+        if ($row === null) {
+            return null;
+        }
+        $record = $this->serializer->deserialize($row['source'], CredentialRecord::class, 'json');
+        \assert($record instanceof CredentialRecord);
+
+        return $record;
+    }
+
+    public function findUserHandleByCredentialId(string $credentialId): ?string
+    {
+        $key = base64_encode($credentialId);
+        $row = $this->readAll()[$key] ?? null;
+
+        return $row === null ? null : (string) base64_decode($row['userHandle'], true);
+    }
+
+    /**
+     * Build the `allowCredentials` list a relying party passes in
+     * PublicKeyCredentialRequestOptions to scope the assertion ceremony to a
+     * known user.
+     *
+     * @return PublicKeyCredentialDescriptor[]
+     */
+    public function allowCredentialsFor(string $userHandle): array
+    {
+        $needle = base64_encode($userHandle);
+        $descriptors = [];
+        foreach ($this->readAll() as $row) {
+            if ($row['userHandle'] !== $needle) {
+                continue;
+            }
+            $rawId = (string) base64_decode($row['credentialId'], true);
+            $descriptors[] = PublicKeyCredentialDescriptor::create('public-key', $rawId);
+        }
+
+        return $descriptors;
+    }
+
+    /**
+     * Build the `excludeCredentials` list a relying party passes in
+     * PublicKeyCredentialCreationOptions to prevent registering the same
+     * authenticator twice for the same user.
+     *
+     * @return PublicKeyCredentialDescriptor[]
+     */
+    public function excludeCredentialsFor(string $userHandle): array
+    {
+        return $this->allowCredentialsFor($userHandle);
+    }
+
+    /**
+     * @return list<array{credentialId: string, label: string, addedAt: int, lastUsedAt: ?int, counter: int, aaguid: string, transports: list<string>, backupEligible: ?bool, backupStatus: ?bool}>
+     */
+    public function listForUser(string $userHandle): array
+    {
+        $needle = base64_encode($userHandle);
+        $rows = [];
+        foreach ($this->readAll() as $row) {
+            if ($row['userHandle'] !== $needle) {
+                continue;
+            }
+            $record = $this->serializer->deserialize($row['source'], CredentialRecord::class, 'json');
+            \assert($record instanceof CredentialRecord);
+            $rows[] = [
+                'credentialId' => $row['credentialId'],
+                'label' => $row['label'],
+                'addedAt' => $row['addedAt'],
+                'lastUsedAt' => $row['lastUsedAt'],
+                'counter' => $record->counter,
+                'aaguid' => $record->aaguid->toRfc4122(),
+                'transports' => $record->transports,
+                'backupEligible' => $record->backupEligible,
+                'backupStatus' => $record->backupStatus,
+            ];
+        }
+
+        return $rows;
+    }
+
+    public function countForUser(string $userHandle): int
+    {
+        return count($this->listForUser($userHandle));
+    }
+}

--- a/docs/examples/usernameless-demo/src/UserStore.php
+++ b/docs/examples/usernameless-demo/src/UserStore.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\UsernamelessDemo;
+
+/**
+ * Demo-only user store. Maps usernames to a stable WebAuthn user handle and a
+ * human display name.
+ *
+ * The user handle is the bytes the relying party puts in
+ * `PublicKeyCredentialUserEntity.id`. The W3C spec requires that it:
+ *
+ *  - is a unique, opaque byte string (NOT the username, NOT an email);
+ *  - never changes for the lifetime of the account;
+ *  - is at most 64 bytes long.
+ *
+ * In a real application the user handle is typically the binary form of the
+ * account's primary key (UUID, ULID, ...). This demo derives it deterministically
+ * from the username so the same username always maps to the same handle across
+ * fresh starts.
+ *
+ * Production code MUST persist users in a real database and treat the user
+ * handle as the opaque, immutable account identifier.
+ */
+final class UserStore
+{
+    public function __construct(
+        private readonly string $file,
+    ) {
+        $dir = dirname($this->file);
+        if (! is_dir($dir)) {
+            mkdir($dir, 0o755, true);
+        }
+        if (! file_exists($this->file)) {
+            file_put_contents($this->file, '[]');
+        }
+    }
+
+    /**
+     * @return array<string, array{userHandle: string, displayName: string, createdAt: int}>
+     */
+    private function readAll(): array
+    {
+        $raw = (string) file_get_contents($this->file);
+        $data = json_decode($raw, true);
+
+        return is_array($data) ? $data : [];
+    }
+
+    /**
+     * @param array<string, array{userHandle: string, displayName: string, createdAt: int}> $data
+     */
+    private function writeAll(array $data): void
+    {
+        file_put_contents($this->file, json_encode($data, \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * Look up an existing user by username, or create a fresh account on first sight.
+     * Returns the binary user handle the WebAuthn user entity expects.
+     */
+    public function findOrCreate(string $username, string $displayName): string
+    {
+        $all = $this->readAll();
+        if (isset($all[$username])) {
+            return (string) base64_decode($all[$username]['userHandle'], true);
+        }
+        $userHandle = random_bytes(32);
+        $all[$username] = [
+            'userHandle' => base64_encode($userHandle),
+            'displayName' => $displayName === '' ? $username : $displayName,
+            'createdAt' => time(),
+        ];
+        $this->writeAll($all);
+
+        return $userHandle;
+    }
+
+    /**
+     * Returns the binary user handle for a known username, or null if the
+     * account has never been seen.
+     */
+    public function findUserHandle(string $username): ?string
+    {
+        $row = $this->readAll()[$username] ?? null;
+
+        return $row === null ? null : (string) base64_decode($row['userHandle'], true);
+    }
+
+    /**
+     * Returns the username bound to a user handle. Used during sign-in to map
+     * the bytes the authenticator returned back to a human-readable identity.
+     */
+    public function findUsernameByHandle(string $userHandle): ?string
+    {
+        $needle = base64_encode($userHandle);
+        foreach ($this->readAll() as $username => $row) {
+            if ($row['userHandle'] === $needle) {
+                return $username;
+            }
+        }
+
+        return null;
+    }
+
+    public function findDisplayName(string $username): ?string
+    {
+        return $this->readAll()[$username]['displayName'] ?? null;
+    }
+}

--- a/docs/examples/usernameless-demo/src/bootstrap.php
+++ b/docs/examples/usernameless-demo/src/bootstrap.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\SpcDemo;
+namespace App\UsernamelessDemo;
 
 use Cose\Algorithm\Manager;
 use Cose\Algorithm\Signature\ECDSA\ES256;
@@ -10,57 +10,71 @@ use Cose\Algorithm\Signature\RSA\RS256;
 use Symfony\Component\Serializer\Serializer;
 use Webauthn\AttestationStatement\AttestationStatementSupportManager;
 use Webauthn\AttestationStatement\NoneAttestationStatementSupport;
-use Webauthn\AuthenticationExtensions\ExtensionOutputCheckerHandler;
-use Webauthn\AuthenticationExtensions\PaymentExtensionOutputChecker;
 use Webauthn\AuthenticatorAssertionResponseValidator;
 use Webauthn\AuthenticatorAttestationResponseValidator;
 use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
-use Webauthn\ClientDataCollector\ClientDataCollectorManager;
-use Webauthn\ClientDataCollector\PaymentClientDataCollector;
-use Webauthn\ClientDataCollector\WebauthnAuthenticationCollector;
 use Webauthn\Denormalizer\WebauthnSerializerFactory;
 
 $autoload = __DIR__ . '/../vendor/autoload.php';
 if (! is_file($autoload)) {
-    fwrite(\STDERR, "Run `composer install` in docs/examples/spc-demo/ first.\n");
+    fwrite(\STDERR, "Run `composer install` in docs/examples/usernameless-demo/ first.\n");
     exit(1);
 }
 require_once $autoload;
 
+require_once __DIR__ . '/UserStore.php';
+require_once __DIR__ . '/CredentialStore.php';
+
 /**
- * Wires everything the SPC demo needs:
+ * Minimal service container for the usernameless demo.
  *
- *  - The Webauthn serializer (loads every denormalizer the lib ships with,
- *    including the SPC ones for `payment`, `total`, `instrument`, …).
- *  - A `CeremonyStepManagerFactory` configured with a
- *    `ClientDataCollectorManager` that handles BOTH `webauthn.get` /
- *    `webauthn.create` (standard WebAuthn) and `payment.get` (SPC).
- *  - Validators for registration (attestation) and authentication
- *    (assertion).
- *  - A trivial JSON-file storage for credentials so the demo runs
- *    out-of-the-box with `php -S`.
+ * Same wiring as the basic-demo: a serializer, an attestation statement
+ * support manager (none format only), a COSE algorithm manager (ES256 +
+ * RS256), and the two ceremony validators on top of a CeremonyStepManager
+ * configured with the relying party's allowed origins. The difference with
+ * the basic-demo lives entirely in router.php and in the browser pages:
+ *
+ *  - registration uses `residentKey: required` and
+ *    `userVerification: required` so the authenticator stores a discoverable
+ *    credential and remembers the user handle locally;
+ *  - login posts an assertion that the server resolves to a user via the
+ *    credential id alone (no username), then via the user handle returned
+ *    by the authenticator in `response.userHandle`.
+ *
+ * Persistence is delegated to two JSON-file stores. Production code MUST
+ * replace them with a real database behind the framework's repository
+ * interfaces.
  */
 final class Container
 {
     public string $relyingPartyId;
+
     public string $relyingPartyName;
+
     /** @var string[] */
     public array $allowedOrigins;
 
     public AttestationStatementSupportManager $attestationManager;
+
     public Manager $algorithmManager;
+
     public CeremonyStepManagerFactory $ceremonyFactory;
+
     public AuthenticatorAttestationResponseValidator $attestationValidator;
+
     public AuthenticatorAssertionResponseValidator $assertionValidator;
+
     public Serializer $serializer;
+
+    public UserStore $userStore;
+
     public CredentialStore $credentialStore;
-    public ChallengeStore $challengeStore;
 
     public function __construct()
     {
         $this->relyingPartyId = $_ENV['RP_ID'] ?? 'localhost';
-        $this->relyingPartyName = 'SPC Demo Bank';
-        $this->allowedOrigins = explode(',', $_ENV['ALLOWED_ORIGINS'] ?? 'http://localhost:8000,http://localhost:8001');
+        $this->relyingPartyName = 'Usernameless WebAuthn Demo';
+        $this->allowedOrigins = explode(',', $_ENV['ALLOWED_ORIGINS'] ?? 'http://localhost:8000');
 
         $this->attestationManager = new AttestationStatementSupportManager();
         $this->attestationManager->add(new NoneAttestationStatementSupport());
@@ -71,30 +85,20 @@ final class Container
         \assert($serializer instanceof Serializer);
         $this->serializer = $serializer;
 
-        $clientDataManager = new ClientDataCollectorManager([
-            new WebauthnAuthenticationCollector(),
-            new PaymentClientDataCollector($this->serializer),
-        ]);
-
-        $extensionHandler = ExtensionOutputCheckerHandler::create();
-        $extensionHandler->add(new PaymentExtensionOutputChecker());
-
         $this->ceremonyFactory = new CeremonyStepManagerFactory();
         $this->ceremonyFactory->setAttestationStatementSupportManager($this->attestationManager);
         $this->ceremonyFactory->setAlgorithmManager($this->algorithmManager);
-        $this->ceremonyFactory->setExtensionOutputCheckerHandler($extensionHandler);
-        $this->ceremonyFactory->setClientDataCollectorManager($clientDataManager);
         $this->ceremonyFactory->setAllowedOrigins($this->allowedOrigins);
 
         $this->attestationValidator = AuthenticatorAttestationResponseValidator::create(
-            ceremonyStepManager: $this->ceremonyFactory->creationCeremony(),
+            $this->ceremonyFactory->creationCeremony(),
         );
         $this->assertionValidator = AuthenticatorAssertionResponseValidator::create(
-            ceremonyStepManager: $this->ceremonyFactory->requestCeremony(),
+            $this->ceremonyFactory->requestCeremony(),
         );
 
         $varDir = $_ENV['VAR_DIR'] ?? __DIR__ . '/../var';
+        $this->userStore = new UserStore($varDir . '/users.json');
         $this->credentialStore = new CredentialStore($varDir . '/credentials.json', $this->serializer);
-        $this->challengeStore = new ChallengeStore($varDir . '/challenges.json');
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13365,7 +13365,8 @@
                 "@testing-library/dom": "^10.0.0",
                 "babel-jest": "^29.0.0",
                 "jest": "^29.0.0",
-                "jest-environment-jsdom": "^29.0.0"
+                "jest-environment-jsdom": "^29.0.0",
+                "typescript": "^5.0.0"
             },
             "peerDependencies": {
                 "@hotwired/stimulus": "^3.0.0",
@@ -13435,6 +13436,20 @@
             },
             "engines": {
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
+        "src/stimulus/assets/node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
             }
         }
     }


### PR DESCRIPTION
## Summary

Adds four self-contained pure-PHP starter demos under `docs/examples/` to address the most common questions on #649: what to wire up and what to store. Each demo follows the same convention as the existing `prf-demo` / `extensions-demo` / `spc-demo` (composer.json with a local path-repo, `src/` container + stores, `same-origin/router.php` + `public/`, `run.sh`).

### `basic-demo/`

Username-based passkey login. `/register.html`, `/login.html`, `/account.html`. The account page lists, adds, renames and deletes passkeys; the last passkey of an account is protected from deletion (no fallback factor).

### `usernameless-demo/`

Same flow but the sign-in page has no username input. Registration forces `residentKey=required` and `userVerification=required`; login is driven by Conditional UI (`navigator.credentials.get({ mediation: 'conditional', ... })`) with a manual-button fallback; the server resolves the account from the credential id plus the authenticator-returned `userHandle`.

### `passkey-upgrade-demo/`

Real-world rollout pattern. Accounts start password-only (signup + `password_hash` / `password_verify`), the account page exposes an "Enrol a passkey" CTA, the login page supports both factors so users can migrate at their own pace. Deleting the last passkey is allowed because the password remains a usable fallback. README includes a security note about step-up re-auth before enrolment.

### `signal-api-demo/`

Exercises the W3C Signal API: `signalUnknownCredential` after a delete, `signalAllAcceptedCredentials` on load and after every change, `signalCurrentUserDetails` on load and after a profile rename. A new `GET /api/account/signal-payload` endpoint hands the page the authoritative snapshot (rpId, userId, name, displayName, allAcceptedCredentialIds). Each call is feature-detected so the demo degrades gracefully on browsers without Signal support.

### Drive-by cleanup

Tightens the bootstrap of the three pre-existing demos (`prf-demo`, `extensions-demo`, `spc-demo`) to load Composer only from the demo's own `vendor/`, dropping the silent fallback to the framework's parent `vendor/autoload.php`. Each demo is now a self-contained starter as advertised in its README.

Closes #649