### PR TITLE
fix(top-origin): reject cross-origin responses when no validator is configured

### DIFF
--- a/src/webauthn/src/CeremonyStep/CheckTopOrigin.php
+++ b/src/webauthn/src/CeremonyStep/CheckTopOrigin.php
@@ -43,7 +43,11 @@ class CheckTopOrigin implements CeremonyStep
             throw AuthenticatorResponseVerificationException::create('The response is not cross-origin.');
         }
         if ($this->topOriginValidator === null) {
-            return;
+            throw AuthenticatorResponseVerificationException::create(
+                'A cross-origin response was received but no TopOriginValidator is configured. '
+                . 'Configure one via CeremonyStepManagerFactory::enableTopOriginValidator() '
+                . 'to opt in to cross-origin (iframe) ceremonies.'
+            );
         }
         $this->topOriginValidator->validate($topOrigin);
     }

--- a/tests/library/Unit/CeremonyStep/CheckTopOriginTest.php
+++ b/tests/library/Unit/CeremonyStep/CheckTopOriginTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Unit\CeremonyStep;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\AuthenticatorData;
+use Webauthn\CeremonyStep\CheckTopOrigin;
+use Webauthn\CeremonyStep\TopOriginValidator;
+use Webauthn\CollectedClientData;
+use Webauthn\CredentialRecord;
+use Webauthn\Exception\AuthenticatorResponseVerificationException;
+use Webauthn\PublicKeyCredentialDescriptor;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\Tests\AbstractTestCase;
+use Webauthn\TrustPath\EmptyTrustPath;
+
+/**
+ * Issue #900: a cross-origin response must not be silently accepted when no
+ * TopOriginValidator is configured. The WebAuthn spec requires the RP to
+ * verify topOrigin, so the step must fail closed.
+ *
+ * @internal
+ */
+final class CheckTopOriginTest extends AbstractTestCase
+{
+    #[Test]
+    public function stepIsSkippedWhenTopOriginIsAbsent(): void
+    {
+        $step = new CheckTopOrigin();
+
+        $step->process(
+            $this->credentialRecord(),
+            $this->assertionResponse(topOrigin: null, crossOrigin: false),
+            $this->requestOptions(),
+            null,
+            'example.com',
+        );
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function stepThrowsWhenTopOriginIsPresentButCrossOriginIsFalse(): void
+    {
+        $step = new CheckTopOrigin();
+
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+        $this->expectExceptionMessage('The response is not cross-origin.');
+
+        $step->process(
+            $this->credentialRecord(),
+            $this->assertionResponse(topOrigin: 'https://wallet.example.com', crossOrigin: false),
+            $this->requestOptions(),
+            null,
+            'example.com',
+        );
+    }
+
+    #[Test]
+    public function stepThrowsWhenTopOriginIsPresentAndNoValidatorIsConfigured(): void
+    {
+        $step = new CheckTopOrigin();
+
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+        $this->expectExceptionMessage('no TopOriginValidator is configured');
+
+        $step->process(
+            $this->credentialRecord(),
+            $this->assertionResponse(topOrigin: 'https://wallet.example.com', crossOrigin: true),
+            $this->requestOptions(),
+            null,
+            'example.com',
+        );
+    }
+
+    #[Test]
+    public function stepDelegatesToTheConfiguredValidatorWhenCrossOriginIsLegitimate(): void
+    {
+        $received = null;
+        $step = new CheckTopOrigin(new class($received) implements TopOriginValidator {
+            public function __construct(
+                private mixed &$captured
+            ) {
+            }
+
+            public function validate(string $topOrigin): void
+            {
+                $this->captured = $topOrigin;
+            }
+        });
+
+        $step->process(
+            $this->credentialRecord(),
+            $this->assertionResponse(topOrigin: 'https://wallet.example.com', crossOrigin: true),
+            $this->requestOptions(),
+            null,
+            'example.com',
+        );
+
+        static::assertSame('https://wallet.example.com', $received);
+    }
+
+    #[Test]
+    public function stepPropagatesRejectionFromTheConfiguredValidator(): void
+    {
+        $step = new CheckTopOrigin(new class() implements TopOriginValidator {
+            public function validate(string $topOrigin): void
+            {
+                throw AuthenticatorResponseVerificationException::create('rejected by validator');
+            }
+        });
+
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+        $this->expectExceptionMessage('rejected by validator');
+
+        $step->process(
+            $this->credentialRecord(),
+            $this->assertionResponse(topOrigin: 'https://attacker.example.com', crossOrigin: true),
+            $this->requestOptions(),
+            null,
+            'example.com',
+        );
+    }
+
+    private function credentialRecord(): CredentialRecord
+    {
+        return CredentialRecord::create(
+            'credential-id',
+            PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
+            [],
+            'none',
+            EmptyTrustPath::create(),
+            Uuid::v4(),
+            'public-key',
+            'user-handle',
+            0,
+        );
+    }
+
+    private function requestOptions(): PublicKeyCredentialRequestOptions
+    {
+        return PublicKeyCredentialRequestOptions::create('challenge-bytes');
+    }
+
+    private function assertionResponse(?string $topOrigin, bool $crossOrigin): AuthenticatorAssertionResponse
+    {
+        $clientData = [
+            'type' => 'webauthn.get',
+            'challenge' => 'challenge-bytes',
+            'origin' => 'https://example.com',
+            'crossOrigin' => $crossOrigin,
+        ];
+        if ($topOrigin !== null) {
+            $clientData['topOrigin'] = $topOrigin;
+        }
+
+        $authData = AuthenticatorData::create(
+            authData: '',
+            rpIdHash: str_repeat("\0", 32),
+            flags: "\0",
+            signCount: 0,
+        );
+
+        return AuthenticatorAssertionResponse::create(
+            CollectedClientData::create('{}', $clientData),
+            $authData,
+            'signature',
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- The WebAuthn L3 spec requires the RP to verify `topOrigin` when present (see [§7.1 step 9](https://www.w3.org/TR/webauthn-3/#sctn-validating-origin)).
- Since #821, `CheckTopOrigin` silently returned when no `TopOriginValidator` was configured, accepting any cross-origin assertion or attestation. That is fail-open behavior and a security regression.
- `CheckTopOrigin` now throws when `topOrigin` is present and no validator is configured. To opt in to legitimate iframe ceremonies, register a `TopOriginValidator` via `CeremonyStepManagerFactory::enableTopOriginValidator()`.

## Notes

The behavior change is intentional and conservative: an app that never receives cross-origin (iframed) ceremonies is unaffected. Apps that legitimately handle iframed flows need to register a validator, which is exactly what `enableTopOriginValidator()` was designed for.

Fixes #900