### PR TITLE
fix: conditional create should also not require user verification

### DIFF
--- a/src/webauthn/src/CeremonyStep/CeremonyStepManagerFactory.php
+++ b/src/webauthn/src/CeremonyStep/CeremonyStepManagerFactory.php
@@ -188,7 +188,7 @@ final class CeremonyStepManagerFactory
             new CheckTopOrigin($this->topOriginValidator),
             new CheckRelyingPartyIdIdHash(),
             new CheckUserWasPresent($requireUserPresence),
-            new CheckUserVerification(),
+            new CheckUserVerification($requireUserPresence),
             new CheckBackupBitsAreConsistent(),
             new CheckAlgorithm(),
             new CheckExtensions($this->extensionOutputCheckerHandler),

--- a/src/webauthn/src/CeremonyStep/CheckUserVerification.php
+++ b/src/webauthn/src/CeremonyStep/CheckUserVerification.php
@@ -16,6 +16,11 @@ use Webauthn\PublicKeyCredentialSource;
 
 final class CheckUserVerification implements CeremonyStep
 {
+    public function __construct(
+        private bool $requireUserVerification = true
+    ) {
+    }
+
     public function process(
         CredentialRecord $credentialRecord,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
@@ -31,6 +36,9 @@ final class CheckUserVerification implements CeremonyStep
                 self::class
             );
         }
+        if (! $this->isUserVerificationRequired($publicKeyCredentialOptions)) {
+            return;
+        }
         $userVerification = $publicKeyCredentialOptions instanceof PublicKeyCredentialRequestOptions ? $publicKeyCredentialOptions->userVerification : $publicKeyCredentialOptions->authenticatorSelection?->userVerification;
         if ($userVerification !== AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_REQUIRED) {
             return;
@@ -39,5 +47,20 @@ final class CheckUserVerification implements CeremonyStep
         $authData->isUserVerified() || throw AuthenticatorResponseVerificationException::create(
             'User authentication required.'
         );
+    }
+
+    private function isUserVerificationRequired(
+        PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions
+    ): bool {
+        if (! $this->requireUserVerification) {
+            return false;
+        }
+
+        if ($publicKeyCredentialOptions instanceof PublicKeyCredentialCreationOptions
+            && $publicKeyCredentialOptions->mediation === PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/tests/library/Unit/CeremonyStep/CheckUserVerificationTest.php
+++ b/tests/library/Unit/CeremonyStep/CheckUserVerificationTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Unit\CeremonyStep;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+use Webauthn\AttestationStatement\AttestationObject;
+use Webauthn\AttestationStatement\AttestationStatement;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\AuthenticatorData;
+use Webauthn\AuthenticatorSelectionCriteria;
+use Webauthn\CeremonyStep\CheckUserVerification;
+use Webauthn\CollectedClientData;
+use Webauthn\CredentialRecord;
+use Webauthn\Exception\AuthenticatorResponseVerificationException;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialDescriptor;
+use Webauthn\PublicKeyCredentialRpEntity;
+use Webauthn\PublicKeyCredentialUserEntity;
+use Webauthn\Tests\AbstractTestCase;
+use Webauthn\TrustPath\EmptyTrustPath;
+use function chr;
+
+/**
+ * Verify the `$requireUserVerification` opt-out and the runtime mediation override on
+ * `PublicKeyCredentialCreationOptions::$mediation` are honored by CheckUserVerification.
+ *
+ * @internal
+ */
+final class CheckUserVerificationTest extends AbstractTestCase
+{
+    #[Test]
+    public function strictStepThrowsWhenUserWasNotVerifiedAndOptionsHaveNoMediation(): void
+    {
+        $step = new CheckUserVerification(requireUserVerification: true);
+
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+        $this->expectExceptionMessage('User authentication required.');
+
+        $step->process(
+            $this->credentialRecord(),
+            $this->attestationResponseWithUvFlag(false),
+            $this->creationOptions(mediation: null),
+            null,
+            'example.com',
+        );
+    }
+
+    #[Test]
+    public function strictStepIsBypassedWhenOptionsRequestConditionalMediation(): void
+    {
+        $step = new CheckUserVerification(requireUserVerification: true);
+
+        // Must NOT throw — `mediation: conditional` opts out of the User Verification requirement at runtime.
+        $step->process(
+            $this->credentialRecord(),
+            $this->attestationResponseWithUvFlag(false),
+            $this->creationOptions(mediation: PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL),
+            null,
+            'example.com',
+        );
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function lenientStepIsBypassedRegardlessOfMediation(): void
+    {
+        // CeremonyStepManagerFactory::conditionalCreateCeremony() builds the step with requireUserVerification=false.
+        // That static fallback must keep working when no mediation hint is set on the options.
+        $step = new CheckUserVerification(requireUserVerification: false);
+
+        $step->process(
+            $this->credentialRecord(),
+            $this->attestationResponseWithUvFlag(false),
+            $this->creationOptions(mediation: null),
+            null,
+            'example.com',
+        );
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function strictStepAllowsValidUserVerificationRegardlessOfMediation(): void
+    {
+        $step = new CheckUserVerification(requireUserVerification: true);
+
+        $step->process(
+            $this->credentialRecord(),
+            $this->attestationResponseWithUvFlag(true),
+            $this->creationOptions(mediation: null),
+            null,
+            'example.com',
+        );
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    private function credentialRecord(): CredentialRecord
+    {
+        return CredentialRecord::create(
+            'credential-id',
+            PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
+            [],
+            'none',
+            EmptyTrustPath::create(),
+            Uuid::v4(),
+            'public-key',
+            'user-handle',
+            0,
+        );
+    }
+
+    private function creationOptions(?string $mediation): PublicKeyCredentialCreationOptions
+    {
+        return PublicKeyCredentialCreationOptions::create(
+            PublicKeyCredentialRpEntity::create('Test RP'),
+            PublicKeyCredentialUserEntity::create('alice', 'uid', 'Alice'),
+            'challenge-bytes',
+            authenticatorSelection: AuthenticatorSelectionCriteria::create(
+                userVerification: AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_REQUIRED,
+            ),
+            mediation: $mediation,
+        );
+    }
+
+    private function attestationResponseWithUvFlag(bool $userVerified): AuthenticatorAttestationResponse
+    {
+        $flags = chr(AuthenticatorData::FLAG_UP | ($userVerified ? AuthenticatorData::FLAG_UV : 0));
+        $authData = AuthenticatorData::create(
+            authData: '',
+            rpIdHash: str_repeat("\0", 32),
+            flags: $flags,
+            signCount: 0,
+        );
+
+        return AuthenticatorAttestationResponse::create(
+            CollectedClientData::create('{}', [
+                'type' => 'webauthn.create',
+                'challenge' => 'challenge-bytes',
+                'origin' => 'https://example.com',
+            ]),
+            AttestationObject::create(
+                rawAttestationObject: '',
+                attStmt: AttestationStatement::createNone('none', [], EmptyTrustPath::create()),
+                authData: $authData,
+            ),
+        );
+    }
+}


### PR DESCRIPTION
Target branch: 5.3.x
Resolves issue: n/a

In https://github.com/web-auth/webauthn-framework/issues/719 we talked about the support of Conditional Create in this library. It was built in PR https://github.com/web-auth/webauthn-framework/pull/748 and released with v5.3.0.

When I tested the implementation back then with on the development branch, it worked perfectly in Chrome. However, when I was implementing it with the stable version the `CheckUserVerification` validator failed. The `uv` bit is also set to `false` when doing a conditional create. It's stated explicitly [in the Chrome docs (now)](https://developer.chrome.com/docs/identity/webauthn-conditional-create?hl=en#ignore_user_presence_and_user_verification_on_the_server): that both "User Presence" and "User Verified" are `false`. Either I missed something back then, or something has changed between then and the release. Nevertheless, I hereby propose a change to align with this behaviour targetted at the 5.3-branch (I saw the 5.4 branch already quite active, but I think this is a bug fix on 5.3 in the first place).