### PR TITLE
fix: Webauthn Level 3 compliance fixes

### DIFF
--- a/src/webauthn/src/AuthenticationExtensions/PseudoRandomFunctionInputExtensionBuilder.php
+++ b/src/webauthn/src/AuthenticationExtensions/PseudoRandomFunctionInputExtensionBuilder.php
@@ -36,6 +36,11 @@ final class PseudoRandomFunctionInputExtensionBuilder
         return $this;
     }
 
+    /**
+     * The credential ID is expected in its raw binary form, as stored in a credential record. The specification requires
+     * the keys of the "evalByCredential" map to be the base64url encoding of the credential ID, so the encoding is done
+     * here and MUST NOT be done by the caller.
+     */
     public function withCredentialInputs(string $credentialId, string $first, null|string $second = null): self
     {
         $eval = [
@@ -47,7 +52,7 @@ final class PseudoRandomFunctionInputExtensionBuilder
         if (! array_key_exists('evalByCredential', $this->values)) {
             $this->values['evalByCredential'] = [];
         }
-        $this->values['evalByCredential'][$credentialId] = $eval;
+        $this->values['evalByCredential'][Base64UrlSafe::encodeUnpadded($credentialId)] = $eval;
 
         return $this;
     }

--- a/src/webauthn/src/AuthenticatorData.php
+++ b/src/webauthn/src/AuthenticatorData.php
@@ -23,10 +23,7 @@ class AuthenticatorData
 
     final public const FLAG_BS = 0b00010000;
 
-    /**
-     * TODO: remove bits 3 and 4 as they have been assigned to BE and BS in Webauthn level 3.
-     */
-    final public const FLAG_RFU2 = 0b00111000;
+    final public const FLAG_RFU2 = 0b00100000;
 
     final public const FLAG_AT = 0b01000000;
 

--- a/src/webauthn/src/CollectedClientData.php
+++ b/src/webauthn/src/CollectedClientData.php
@@ -69,12 +69,6 @@ class CollectedClientData
         $crossOrigin = $data['crossOrigin'] ?? false;
         $this->crossOrigin = $crossOrigin;
 
-        $tokenBinding = $data['tokenBinding'] ?? null;
-        $tokenBinding === null || is_array($tokenBinding) || throw InvalidDataException::create(
-            $data,
-            'Invalid parameter "tokenBinding". Shall be an object or .'
-        );
-
         $this->data = $data;
     }
 

--- a/tests/library/Unit/AuthenticationExtensions/PseudoRandomFunctionInputExtensionBuilderTest.php
+++ b/tests/library/Unit/AuthenticationExtensions/PseudoRandomFunctionInputExtensionBuilderTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Unit\AuthenticationExtensions;
+
+use ParagonIE\ConstantTime\Base64UrlSafe;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Webauthn\AuthenticationExtensions\PseudoRandomFunctionInputExtensionBuilder;
+
+/**
+ * @internal
+ */
+final class PseudoRandomFunctionInputExtensionBuilderTest extends TestCase
+{
+    #[Test]
+    public function theInputsAreBase64UrlEncoded(): void
+    {
+        // Given
+        $builder = PseudoRandomFunctionInputExtensionBuilder::create();
+
+        // When
+        $extension = $builder->withInputs('first-salt', 'second-salt')
+            ->build();
+
+        // Then
+        static::assertSame('prf', $extension->name);
+        static::assertSame([
+            'eval' => [
+                'first' => Base64UrlSafe::encodeUnpadded('first-salt'),
+                'second' => Base64UrlSafe::encodeUnpadded('second-salt'),
+            ],
+        ], $extension->value);
+    }
+
+    #[Test]
+    public function theSecondInputIsOmittedWhenNotProvided(): void
+    {
+        // Given
+        $builder = PseudoRandomFunctionInputExtensionBuilder::create();
+
+        // When
+        $extension = $builder->withInputs('first-salt')
+            ->build();
+
+        // Then
+        static::assertSame([
+            'eval' => [
+                'first' => Base64UrlSafe::encodeUnpadded('first-salt'),
+            ],
+        ], $extension->value);
+    }
+
+    /**
+     * The keys of the "evalByCredential" map must be the base64url encoding of the credential ID, otherwise the client
+     * rejects the ceremony with a SyntaxError.
+     */
+    #[Test]
+    public function theCredentialIdIsUsedAsABase64UrlEncodedKey(): void
+    {
+        // Given
+        $credentialId = hex2bin('0102030405060708090a0b0c0d0e0f10');
+        $builder = PseudoRandomFunctionInputExtensionBuilder::create();
+
+        // When
+        $extension = $builder->withCredentialInputs($credentialId, 'first-salt')
+            ->build();
+
+        // Then
+        static::assertSame([
+            'evalByCredential' => [
+                Base64UrlSafe::encodeUnpadded($credentialId) => [
+                    'first' => Base64UrlSafe::encodeUnpadded('first-salt'),
+                ],
+            ],
+        ], $extension->value);
+    }
+
+    #[Test]
+    public function severalCredentialsCanBeEvaluated(): void
+    {
+        // Given
+        $firstCredentialId = hex2bin('aabb');
+        $secondCredentialId = hex2bin('ccdd');
+        $builder = PseudoRandomFunctionInputExtensionBuilder::create();
+
+        // When
+        $extension = $builder->withCredentialInputs($firstCredentialId, 'first-salt')
+            ->withCredentialInputs($secondCredentialId, 'other-salt', 'second-salt')
+            ->build();
+
+        // Then
+        static::assertSame([
+            'evalByCredential' => [
+                Base64UrlSafe::encodeUnpadded($firstCredentialId) => [
+                    'first' => Base64UrlSafe::encodeUnpadded('first-salt'),
+                ],
+                Base64UrlSafe::encodeUnpadded($secondCredentialId) => [
+                    'first' => Base64UrlSafe::encodeUnpadded('other-salt'),
+                    'second' => Base64UrlSafe::encodeUnpadded('second-salt'),
+                ],
+            ],
+        ], $extension->value);
+    }
+}

--- a/tests/library/Unit/AuthenticatorDataTest.php
+++ b/tests/library/Unit/AuthenticatorDataTest.php
@@ -46,4 +46,40 @@ final class AuthenticatorDataTest extends TestCase
         static::assertFalse($authenticatorData->hasExtensions());
         static::assertSame(0, $authenticatorData->extensions->count());
     }
+
+    /**
+     * Bits 3 and 4 were reserved in Webauthn Level 2 and have been assigned to BE and BS in Level 3, so only bit 5 is
+     * still reported as reserved.
+     */
+    #[Test]
+    public function theBackupFlagsAreNotReportedAsReservedForFutureUse(): void
+    {
+        // Given
+        $flags = chr(
+            AuthenticatorData::FLAG_UP | AuthenticatorData::FLAG_UV | AuthenticatorData::FLAG_BE | AuthenticatorData::FLAG_BS
+        );
+
+        // When
+        $authenticatorData = AuthenticatorData::create('auth_data', 'rp_id_hash', $flags, 0);
+
+        // Then
+        static::assertTrue($authenticatorData->isBackupEligible());
+        static::assertTrue($authenticatorData->isBackedUp());
+        static::assertSame(0, $authenticatorData->getReservedForFutureUse1());
+        static::assertSame(0, $authenticatorData->getReservedForFutureUse2());
+    }
+
+    #[Test]
+    public function theRemainingReservedBitIsStillReported(): void
+    {
+        // Given
+        $flags = chr(AuthenticatorData::FLAG_UP | AuthenticatorData::FLAG_RFU1 | AuthenticatorData::FLAG_RFU2);
+
+        // When
+        $authenticatorData = AuthenticatorData::create('auth_data', 'rp_id_hash', $flags, 0);
+
+        // Then
+        static::assertSame(AuthenticatorData::FLAG_RFU1, $authenticatorData->getReservedForFutureUse1());
+        static::assertSame(AuthenticatorData::FLAG_RFU2, $authenticatorData->getReservedForFutureUse2());
+    }
 }

--- a/tests/library/Unit/CollectedClientDataTest.php
+++ b/tests/library/Unit/CollectedClientDataTest.php
@@ -46,4 +46,26 @@ final class CollectedClientDataTest extends TestCase
         static::assertTrue($collectedClientData->has('extensions'));
         static::assertSame('extensions', $collectedClientData->get('extensions'));
     }
+
+    /**
+     * The tokenBinding member is [RESERVED] since Webauthn Level 3. It is never read by the Relying Party, so whatever
+     * a client puts under that key must not fail the ceremony.
+     */
+    #[Test]
+    public function aReservedTokenBindingMemberIsNotValidated(): void
+    {
+        // Given
+        $data = [
+            'type' => 'type',
+            'origin' => 'origin',
+            'challenge' => Base64UrlSafe::encodeUnpadded('challenge'),
+            'tokenBinding' => 'supported',
+        ];
+
+        // When
+        $collectedClientData = CollectedClientData::create('raw_data', $data);
+
+        // Then
+        static::assertSame('supported', $collectedClientData->get('tokenBinding'));
+    }
 }

--- a/tests/library/Unit/Util/CoseSignatureFixerTest.php
+++ b/tests/library/Unit/Util/CoseSignatureFixerTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webauthn\Tests\Unit\Util;
+
+use Cose\Algorithm\Signature\ECDSA\ES256;
+use Cose\Algorithm\Signature\ECDSA\ES384;
+use Cose\Algorithm\Signature\ECDSA\ES512;
+use Cose\Algorithm\Signature\EdDSA\EdDSA;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Webauthn\Util\CoseSignatureFixer;
+
+/**
+ * The ASN.1 DER encoding of an ECDSA signature has a variable length: each INTEGER component is minimally encoded, so it
+ * gets a leading zero byte when its high bit is set and loses its leading zero bytes otherwise.
+ *
+ * @internal
+ *
+ * @see https://w3c.github.io/webauthn/#sctn-signature-attestation-types
+ */
+final class CoseSignatureFixerTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function es256Signatures(): iterable
+    {
+        yield 'both components padded with a leading zero byte' => [
+            '3046'
+            . '022100' . str_repeat('ff', 32)
+            . '022100' . '80' . str_repeat('00', 31),
+            str_repeat('ff', 32) . '80' . str_repeat('00', 31),
+        ];
+
+        yield 'both components exactly 32 bytes long' => [
+            '3044'
+            . '0220' . '7f' . str_repeat('ff', 31)
+            . '0220' . '01' . str_repeat('00', 31),
+            '7f' . str_repeat('ff', 31) . '01' . str_repeat('00', 31),
+        ];
+
+        yield 'specification example with a 33-byte and a 30-byte component' => [
+            '3043'
+            . '022100' . '89909504e14f1e29dba8158fa7c387e888ffbe07d824bb2143205506ab159c3e'
+            . '021e' . '56554fb5819b12845e85be2f78371cf3cb95e387f451cb362b9478d183d2',
+            '89909504e14f1e29dba8158fa7c387e888ffbe07d824bb2143205506ab159c3e'
+            . '0000' . '56554fb5819b12845e85be2f78371cf3cb95e387f451cb362b9478d183d2',
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('es256Signatures')]
+    public function anEs256DerSignatureIsConvertedIntoItsRawForm(string $der, string $expected): void
+    {
+        // Given
+        $signature = hex2bin($der);
+
+        // When
+        $fixed = CoseSignatureFixer::fix($signature, new ES256());
+
+        // Then
+        static::assertSame(64, strlen($fixed));
+        static::assertSame($expected, bin2hex($fixed));
+    }
+
+    #[Test]
+    public function anEs256RawSignatureIsLeftUntouched(): void
+    {
+        // Given
+        $signature = hex2bin(str_repeat('ab', 64));
+
+        // When
+        $fixed = CoseSignatureFixer::fix($signature, new ES256());
+
+        // Then
+        static::assertSame($signature, $fixed);
+    }
+
+    #[Test]
+    public function anEs384DerSignatureIsConvertedIntoItsRawForm(): void
+    {
+        // Given
+        $signature = hex2bin(
+            '3064'
+            . '0230' . '7f' . str_repeat('ff', 47)
+            . '0230' . '01' . str_repeat('00', 47)
+        );
+
+        // When
+        $fixed = CoseSignatureFixer::fix($signature, new ES384());
+
+        // Then
+        static::assertSame(96, strlen($fixed));
+        static::assertSame(
+            '7f' . str_repeat('ff', 47) . '01' . str_repeat('00', 47),
+            bin2hex($fixed)
+        );
+    }
+
+    #[Test]
+    public function anEs512DerSignatureUsingTheLongFormLengthIsConvertedIntoItsRawForm(): void
+    {
+        // Given
+        $signature = hex2bin(
+            '308188'
+            . '0242' . '01' . str_repeat('00', 64) . 'ff'
+            . '0242' . '01' . str_repeat('ff', 64) . '00'
+        );
+
+        // When
+        $fixed = CoseSignatureFixer::fix($signature, new ES512());
+
+        // Then
+        static::assertSame(132, strlen($fixed));
+        static::assertSame(
+            '01' . str_repeat('00', 64) . 'ff' . '01' . str_repeat('ff', 64) . '00',
+            bin2hex($fixed)
+        );
+    }
+
+    #[Test]
+    public function anEs512DerSignatureWithAShorterComponentIsLeftPadded(): void
+    {
+        // Given
+        $signature = hex2bin(
+            '308186'
+            . '0241' . str_repeat('11', 65)
+            . '0242' . '01' . str_repeat('22', 65)
+        );
+
+        // When
+        $fixed = CoseSignatureFixer::fix($signature, new ES512());
+
+        // Then
+        static::assertSame(132, strlen($fixed));
+        static::assertSame(
+            '00' . str_repeat('11', 65) . '01' . str_repeat('22', 65),
+            bin2hex($fixed)
+        );
+    }
+
+    #[Test]
+    public function aSignatureOfANonEcdsaAlgorithmIsLeftUntouched(): void
+    {
+        // Given
+        $signature = hex2bin(str_repeat('cd', 64));
+
+        // When
+        $fixed = CoseSignatureFixer::fix($signature, new EdDSA());
+
+        // Then
+        static::assertSame($signature, $fixed);
+    }
+}


### PR DESCRIPTION
Four Level 3 compliance fixes found while reviewing everything accepted upstream on `w3c/webauthn` since January 2025.

### `FLAG_RFU2` still masked the `BE` and `BS` bits

Bits 3 and 4 were reserved in Level 2 and have been assigned to Backup Eligibility and Backup State in Level 3. The mask was never narrowed, so `getReservedForFutureUse2()` counted the backup flags a second time: a synced passkey returned `24` instead of `0`, which surfaces in every `WebauthnToken` dump.

Closes #920

### `evalByCredential` keys were not base64url encoded

The specification requires those keys to be the base64url encoding of the credential ID, and the client rejects the ceremony with a `SyntaxError` otherwise. The builder encoded the salts but used the credential ID as given, so a raw credential ID produced an invalid key. The method had no test and no usage in the repository, so the ambiguity had never been resolved either way.

Closes #924

### `tokenBinding` is \[RESERVED]

The member was validated but never read, never stored and never exposed, so the only effect of the check was to fail a ceremony over something the Relying Party does not use, with a truncated error message. The raw client data remains reachable through the `data` property.

Closes #929

### Missing coverage on the DER signature conversion

w3c/webauthn#2315 replaced the DER example in the specification to make explicit that the encoding length varies with the INTEGER magnitude and the curve size. `CoseSignatureFixer` already handles it correctly, but it had no test at all, which is a poor place to have none since it decides whether an incoming signature is raw or DER-encoded.

Closes #930

### Note on the CI tooling

The ECS and Rector jobs are red on `5.3.x` since 2026-07-12, independently of this branch. The configurations reference `SetList::PHPUNIT` and `PHPUnitSetList::PHPUNIT_120`, which no longer exist in the versions shipped by the `phpqa` images, so both tools abort before looking at any file. PHPStan runs and reports the same 19 pre-existing errors with and without this branch.
