### PR TITLE
ci: repair the pipeline

### DIFF
--- a/.ci-tools/ecs.php
+++ b/.ci-tools/ecs.php
@@ -37,7 +37,6 @@ return static function (ECSConfig $config): void {
     $config->import(SetList::CLEAN_CODE);
     $config->import(SetList::DOCTRINE_ANNOTATIONS);
     $config->import(SetList::SPACES);
-    $config->import(SetList::PHPUNIT);
     $config->import(SetList::SYMPLIFY);
     $config->import(SetList::ARRAY);
     $config->import(SetList::COMMON);
@@ -45,7 +44,6 @@ return static function (ECSConfig $config): void {
     $config->import(SetList::CONTROL_STRUCTURES);
     $config->import(SetList::DOCBLOCK);
     $config->import(SetList::NAMESPACES);
-    $config->import(SetList::STRICT);
 
     $config->rule(StrictParamFixer::class);
     $config->rule(StrictComparisonFixer::class);

--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -28,6 +28,12 @@ parameters:
 			path: ../src/symfony/src/Controller/AttestationResponseController.php
 
 		-
+			rawMessage: 'Strict comparison using !== between string and null will always evaluate to true.'
+			identifier: notIdentical.alwaysTrue
+			count: 2
+			path: ../src/symfony/src/CredentialOptionsBuilder/ProfileBasedRequestOptionsBuilder.php
+
+		-
 			rawMessage: '''
 				Call to deprecated method setSecuredRelyingPartyId() of class Webauthn\Bundle\DependencyInjection\Compiler\CeremonyStepManagerFactoryCompilerPass:
 				Will be removed in 6.0.0
@@ -43,12 +49,42 @@ parameters:
 			path: ../src/symfony/src/DependencyInjection/Factory/Security/WebauthnFactory.php
 
 		-
+			rawMessage: 'Parameter #3 $config of method Webauthn\Bundle\DependencyInjection\Factory\Security\WebauthnFactory::createAssertionControllersAndRoutes() expects array{options_storage: string|null, failure_handler: string, authentication: array{enabled: bool, profile: string, options_builder: string|null, options_handler: string, routes: array{host: string|null, options_method: string, options_path: string, result_method: string, result_path: string|null}}}, array{secured_rp_ids: array<string>, success_handler: string, failure_handler: string, options_storage: string|null, authentication: array{enabled: bool, profile: string, options_builder: string|null, options_handler: string, routes: array{host: string|null, options_method: string, options_path: string, result_method: string, result_path: string|null}}, registration: array{enabled: bool, profile: string, options_builder: string|null, options_handler: string, hide_existing_credentials: bool, routes: array{host: string|null, options_method: string, options_path: string, result_method: string, result_path: string|null}}} given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/symfony/src/DependencyInjection/Factory/Security/WebauthnFactory.php
+
+		-
+			rawMessage: 'Parameter #3 $config of method Webauthn\Bundle\DependencyInjection\Factory\Security\WebauthnFactory::createAttestationControllersAndRoutes() expects array{options_storage: string|null, failure_handler: string, registration: array{enabled: bool, profile: string, options_builder: string|null, options_handler: string, hide_existing_credentials: bool, routes: array{host: string|null, options_method: string, options_path: string, result_method: string, result_path: string|null}}}, array{secured_rp_ids: array<string>, success_handler: string, failure_handler: string, options_storage: string|null, authentication: array{enabled: bool, profile: string, options_builder: string|null, options_handler: string, routes: array{host: string|null, options_method: string, options_path: string, result_method: string, result_path: string|null}}, registration: array{enabled: bool, profile: string, options_builder: string|null, options_handler: string, hide_existing_credentials: bool, routes: array{host: string|null, options_method: string, options_path: string, result_method: string, result_path: string|null}}} given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/symfony/src/DependencyInjection/Factory/Security/WebauthnFactory.php
+
+		-
+			rawMessage: 'Parameter #3 $config of method Webauthn\Bundle\DependencyInjection\Factory\Security\WebauthnFactory::getAssertionOptionsBuilderId() expects array{options_builder: string|null, profile: string}, array{enabled: true, profile: string, options_builder: string|null, options_handler: string, routes: array{host: string|null, options_method: string, options_path: string, result_method: string, result_path: string|null}} given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/symfony/src/DependencyInjection/Factory/Security/WebauthnFactory.php
+
+		-
+			rawMessage: 'Parameter #3 $config of method Webauthn\Bundle\DependencyInjection\Factory\Security\WebauthnFactory::getAttestationOptionsBuilderId() expects array{options_builder: string|null, profile: string}, array{enabled: true, profile: string, options_builder: string|null, options_handler: string, hide_existing_credentials: bool, routes: array{host: string|null, options_method: string, options_path: string, result_method: string, result_path: string|null}} given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/symfony/src/DependencyInjection/Factory/Security/WebauthnFactory.php
+
+		-
 			rawMessage: '''
 				Access to constant on deprecated interface Webauthn\Bundle\Repository\PublicKeyCredentialSourceRepositoryInterface:
 				since 5.3, use CredentialRecordRepositoryInterface instead. Will be removed in 6.0.
 			'''
 			identifier: classConstant.deprecatedInterface
 			count: 1
+			path: ../src/symfony/src/DependencyInjection/WebauthnExtension.php
+
+		-
+			rawMessage: Coalesce operator ?? is unnecessary because the left side is always set and the right side is null.
+			identifier: nullCoalesce.unnecessary
+			count: 3
 			path: ../src/symfony/src/DependencyInjection/WebauthnExtension.php
 
 		-
@@ -59,6 +95,12 @@ parameters:
 			identifier: class.implementsDeprecatedInterface
 			count: 1
 			path: ../src/symfony/src/Repository/DummyPublicKeyCredentialSourceRepository.php
+
+		-
+			rawMessage: 'Call to function is_array() with array<mixed> will always evaluate to true.'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../src/symfony/src/Security/Authentication/Token/WebauthnToken.php
 
 		-
 			rawMessage: 'Parameter #1 $data (array{Webauthn\PublicKeyCredentialUserEntity, Webauthn\PublicKeyCredentialDescriptor, Webauthn\PublicKeyCredentialOptions, bool, bool, bool, bool, int, ...}) of method Webauthn\Bundle\Security\Authentication\Token\WebauthnToken::__unserialize() should be contravariant with parameter $data (array) of method Symfony\Component\Security\Core\Authentication\Token\AbstractToken::__unserialize()'
@@ -158,6 +200,36 @@ parameters:
 			identifier: instanceof.deprecatedInterface
 			count: 2
 			path: ../src/symfony/src/Security/Http/Authenticator/WebauthnAuthenticator.php
+
+		-
+			rawMessage: 'Parameter #1 $profile of method Webauthn\Bundle\Service\PublicKeyCredentialCreationOptionsFactory::createAuthenticatorSelectionCriteria() expects array{authenticator_selection_criteria: array{authenticator_attachment: string|null, user_verification: string|null, resident_key: string|null}}, array{rp: array{name: string, id: string|null}, challenge_length: int, timeout?: int|null, attestation_conveyance?: string|null, authenticator_selection_criteria: array{authenticator_attachment: string|null, user_verification: string|null, resident_key: string|null}, public_key_credential_parameters: list<int>, extensions: array<string, mixed>, conditional_create?: bool} given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/symfony/src/Service/PublicKeyCredentialCreationOptionsFactory.php
+
+		-
+			rawMessage: 'Parameter #1 $profile of method Webauthn\Bundle\Service\PublicKeyCredentialCreationOptionsFactory::createCredentialParameters() expects array{public_key_credential_parameters: list<int>}, array{rp: array{name: string, id: string|null}, challenge_length: int, timeout?: int|null, attestation_conveyance?: string|null, authenticator_selection_criteria: array{authenticator_attachment: string|null, user_verification: string|null, resident_key: string|null}, public_key_credential_parameters: list<int>, extensions: array<string, mixed>, conditional_create?: bool} given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/symfony/src/Service/PublicKeyCredentialCreationOptionsFactory.php
+
+		-
+			rawMessage: 'Parameter #1 $profile of method Webauthn\Bundle\Service\PublicKeyCredentialCreationOptionsFactory::createExtensions() expects array{extensions: array<string, mixed>}, array{rp: array{name: string, id: string|null}, challenge_length: int, timeout?: int|null, attestation_conveyance?: string|null, authenticator_selection_criteria: array{authenticator_attachment: string|null, user_verification: string|null, resident_key: string|null}, public_key_credential_parameters: list<int>, extensions: array<string, mixed>, conditional_create?: bool} given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/symfony/src/Service/PublicKeyCredentialCreationOptionsFactory.php
+
+		-
+			rawMessage: 'Parameter #1 $profile of method Webauthn\Bundle\Service\PublicKeyCredentialCreationOptionsFactory::createRpEntity() expects array{rp: array{name: string, id: string|null}}, array{rp: array{name: string, id: string|null}, challenge_length: int, timeout?: int|null, attestation_conveyance?: string|null, authenticator_selection_criteria: array{authenticator_attachment: string|null, user_verification: string|null, resident_key: string|null}, public_key_credential_parameters: list<int>, extensions: array<string, mixed>, conditional_create?: bool} given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/symfony/src/Service/PublicKeyCredentialCreationOptionsFactory.php
+
+		-
+			rawMessage: 'Parameter #1 $profile of method Webauthn\Bundle\Service\PublicKeyCredentialRequestOptionsFactory::createExtensions() expects array{extensions: array<string, mixed>}, array{challenge_length: int, rp_id?: string|null, timeout?: int|null, user_verification?: string|null, extensions: array<string, mixed>} given.'
+			identifier: argument.type
+			count: 1
+			path: ../src/symfony/src/Service/PublicKeyCredentialRequestOptionsFactory.php
 
 		-
 			rawMessage: 'Parameter #2 $attStmt of static method Webauthn\AttestationStatement\AttestationStatement::create() expects array<string, mixed>, list<Webauthn\AttestationStatement\AttestationStatement> given.'
@@ -373,6 +445,12 @@ parameters:
 			path: ../src/webauthn/src/Counter/ThrowExceptionIfInvalid.php
 
 		-
+			rawMessage: Coalesce operator ?? is unnecessary because the left side is always set and the right side is null.
+			identifier: nullCoalesce.unnecessary
+			count: 1
+			path: ../src/webauthn/src/Denormalizer/AuthenticatorAssertionResponseDenormalizer.php
+
+		-
 			rawMessage: '''
 				Access to deprecated property $icon of class Webauthn\PublicKeyCredentialEntity:
 				since 5.1.0 and will be removed in 6.0.0. This value is always null.
@@ -427,13 +505,19 @@ parameters:
 			path: ../src/webauthn/src/Denormalizer/PublicKeyCredentialUserEntityDenormalizer.php
 
 		-
+			rawMessage: 'Offset ''type'' on array{type: string} in isset() always exists and is not nullable.'
+			identifier: isset.offset
+			count: 1
+			path: ../src/webauthn/src/Denormalizer/TrustPathDenormalizer.php
+
+		-
 			rawMessage: 'Parameter #1 $options (array<string, string>) of method Webauthn\MetadataService\Psr18HttpClient::withOptions() should be contravariant with parameter $options (array) of method Symfony\Contracts\HttpClient\HttpClientInterface::withOptions()'
 			identifier: method.childParameterType
 			count: 1
 			path: ../src/webauthn/src/MetadataService/Psr18HttpClient.php
 
 		-
-			rawMessage: 'Parameter #3 $options (array{base_uri?: string, query?: array<string, string>, body?: string, headers?: array<string, string>}) of method Webauthn\MetadataService\Psr18HttpClient::request() should be contravariant with parameter $options (array) of method Symfony\Contracts\HttpClient\HttpClientInterface::request()'
+			rawMessage: 'Parameter #3 $options (array{base_uri?: string, query?: array<string, string>, body?: string, headers?: array<string, string>, ...}) of method Webauthn\MetadataService\Psr18HttpClient::request() should be contravariant with parameter $options (array) of method Symfony\Contracts\HttpClient\HttpClientInterface::request()'
 			identifier: method.childParameterType
 			count: 1
 			path: ../src/webauthn/src/MetadataService/Psr18HttpClient.php

--- a/.ci-tools/rector.php
+++ b/.ci-tools/rector.php
@@ -8,6 +8,7 @@ use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
+use Rector\Symfony\Symfony80\Rector\Class_\RemoveEraseCredentialsRector;
 use Rector\ValueObject\PhpVersion;
 
 $builder = RectorConfig::configure();
@@ -21,7 +22,6 @@ $builder->withSets([
     DoctrineSetList::ANNOTATIONS_TO_ATTRIBUTES,
     PHPUnitSetList::PHPUNIT_CODE_QUALITY,
     PHPUnitSetList::ANNOTATIONS_TO_ATTRIBUTES,
-    PHPUnitSetList::PHPUNIT_120,
 ]);
 $builder->withComposerBased(twig: true, doctrine: true, phpunit: true, symfony: true);
 $builder->withPhpVersion(PhpVersion::PHP_82);
@@ -36,6 +36,7 @@ $builder->withPaths(
 );
 $builder->withSkip([
     PreferPHPUnitThisCallRector::class,
+    RemoveEraseCredentialsRector::class,
     __DIR__ . '/../src/Library/Core/JWKSet.php',
     __DIR__ . '/../src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSource.php',
     __DIR__ . '/../src/Bundle/JoseFramework/DependencyInjection/Source/KeyManagement/JWKSetSource.php',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,8 +185,6 @@ jobs:
           - php-version: '8.3'
           - php-version: '8.4'
           - php-version: '8.5'
-          - php-version: '8.6'
-            experimental: true
     container:
       image: ghcr.io/spomky-labs/phpqa:${{ matrix.php-version }}
     env:
@@ -203,7 +201,13 @@ jobs:
           fi
 
       - name: Run PHPUnit
-        run: castor phpunit
+        run: |
+          composer exec -- phpunit-11 \
+            --coverage-xml .ci-tools/coverage \
+            --log-junit=.ci-tools/coverage/junit.xml \
+            --configuration .ci-tools/phpunit.xml.dist \
+            --display-warnings \
+            --display-deprecations
 
   infection:
     name: "🧬 Mutation Testing"

--- a/src/symfony/src/CredentialOptionsBuilder/ProfileBasedCreationOptionsBuilder.php
+++ b/src/symfony/src/CredentialOptionsBuilder/ProfileBasedCreationOptionsBuilder.php
@@ -45,7 +45,7 @@ final readonly class ProfileBasedCreationOptionsBuilder implements PublicKeyCred
         $format === 'json' || throw new BadRequestHttpException('Only JSON content type allowed');
         $content = $request->getContent();
 
-        $excludedCredentials = $hideExistingExcludedCredentials === true ? [] : $this->getCredentials($userEntity);
+        $excludedCredentials = $hideExistingExcludedCredentials ? [] : $this->getCredentials($userEntity);
         $optionsRequest = $this->getServerPublicKeyCredentialCreationOptionsRequest($content);
 
         // Apply override policy to determine effective values

--- a/src/symfony/src/DependencyInjection/Configuration.php
+++ b/src/symfony/src/DependencyInjection/Configuration.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Webauthn\Bundle\DependencyInjection;
 
-use function assert;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -643,7 +642,6 @@ final readonly class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder($name);
         $node = $treeBuilder->getRootNode();
-        assert($node instanceof ArrayNodeDefinition);
         $node
             ->info($info)
             ->beforeNormalization()

--- a/src/symfony/src/Security/Authentication/WebauthnAuthenticator.php
+++ b/src/symfony/src/Security/Authentication/WebauthnAuthenticator.php
@@ -28,7 +28,6 @@ abstract class WebauthnAuthenticator extends AbstractLoginFormAuthenticator
             $authData = $response->attestationObject->authData;
         }
         /** @var AuthenticatorData $authData */
-
         $token = new WebauthnToken(
             $webauthnBadge->getPublicKeyCredentialUserEntity(),
             $webauthnBadge->getPublicKeyCredentialOptions(),

--- a/src/symfony/src/Service/PublicKeyCredentialCreationOptionsFactory.php
+++ b/src/symfony/src/Service/PublicKeyCredentialCreationOptionsFactory.php
@@ -69,7 +69,7 @@ final class PublicKeyCredentialCreationOptionsFactory implements CanDispatchEven
         // `mediation` mechanism: an explicit per-request mediation always wins, otherwise the profile
         // default applies.
         $effectiveMediation = $mediation
-            ?? (($profile['conditional_create'] ?? false) === true
+            ?? ($profile['conditional_create'] ?? false
                 ? PublicKeyCredentialCreationOptions::MEDIATION_CONDITIONAL
                 : null);
 

--- a/src/webauthn/src/AttestationStatement/AndroidKeyAttestationStatementSupport.php
+++ b/src/webauthn/src/AttestationStatement/AndroidKeyAttestationStatementSupport.php
@@ -116,7 +116,7 @@ final class AndroidKeyAttestationStatementSupport implements AttestationStatemen
 
         $certificates = $trustPath->certificates;
 
-        //Decode leaf attestation certificate
+        // Decode leaf attestation certificate
         $leaf = $certificates[0];
         $this->checkCertificate($leaf, $clientDataJSONHash, $authenticatorData);
 
@@ -138,7 +138,7 @@ final class AndroidKeyAttestationStatementSupport implements AttestationStatemen
         string $clientDataHash,
         AuthenticatorData $authenticatorData
     ): void {
-        //Check that authData publicKey matches the public key in the attestation certificate
+        // Check that authData publicKey matches the public key in the attestation certificate
         $attestedCredentialData = $authenticatorData->attestedCredentialData;
         $attestedCredentialData !== null || throw AttestationStatementVerificationException::create(
             'No attested credential data found'
@@ -164,13 +164,13 @@ final class AndroidKeyAttestationStatementSupport implements AttestationStatemen
             'Unsupported key type'
         );
 
-        /*---------------------------*/
+        /* --------------------------- */
         /**
          * @see https://w3c.github.io/webauthn/#sctn-key-attstn-cert-requirements
          * @see https://source.android.com/docs/security/features/keystore/attestation#attestation-certificate
          */
         $cert = Certificate::fromPEM(PEM::fromString($certificate));
-        //We check the attested key corresponds to the key in the certificate
+        // We check the attested key corresponds to the key in the certificate
         PEM::fromString($publicKey->asPEM())->string() === $cert->tbsCertificate()
             ->subjectPublicKeyInfo()
             ->toPEM()
@@ -179,7 +179,7 @@ final class AndroidKeyAttestationStatementSupport implements AttestationStatemen
         $extensions = $cert->tbsCertificate()
             ->extensions();
 
-        //Find Android KeyStore Extension with OID self::OID_ANDROID in certificate extensions
+        // Find Android KeyStore Extension with OID self::OID_ANDROID in certificate extensions
         $extensions->has(self::OID_ANDROID) || throw AttestationStatementVerificationException::create(
             'The certificate extension "' . self::OID_ANDROID . '" is missing'
         );
@@ -191,7 +191,7 @@ final class AndroidKeyAttestationStatementSupport implements AttestationStatemen
          */
         $extensionAsAsn1 = Sequence::fromDER($androidExtension->extensionValue());
 
-        //Check that attestationChallenge is set to the clientDataHash.
+        // Check that attestationChallenge is set to the clientDataHash.
         $extensionAsAsn1->has(4) || throw AttestationStatementVerificationException::create(
             'The attestationChallenge field is missing'
         );
@@ -204,7 +204,7 @@ final class AndroidKeyAttestationStatementSupport implements AttestationStatemen
             'The client data hash is not valid'
         );
 
-        //Check that both teeEnforced and softwareEnforced structures don't contain allApplications(600) tag.
+        // Check that both teeEnforced and softwareEnforced structures don't contain allApplications(600) tag.
         $extensionAsAsn1->has(6) || throw AttestationStatementVerificationException::create(
             'The softwareEnforced field is missing'
         );

--- a/src/webauthn/src/AttestationStatement/AppleAttestationStatementSupport.php
+++ b/src/webauthn/src/AttestationStatement/AppleAttestationStatementSupport.php
@@ -108,7 +108,7 @@ final class AppleAttestationStatementSupport implements AttestationStatementSupp
 
         $certificates = $trustPath->certificates;
 
-        //Decode leaf attestation certificate
+        // Decode leaf attestation certificate
         $leaf = $certificates[0];
 
         $this->checkCertificateAndGetPublicKey($leaf, $clientDataJSONHash, $authenticatorData);
@@ -124,7 +124,7 @@ final class AppleAttestationStatementSupport implements AttestationStatementSupp
         string $clientDataHash,
         AuthenticatorData $authenticatorData
     ): void {
-        //Check that authData publicKey matches the public key in the attestation certificate
+        // Check that authData publicKey matches the public key in the attestation certificate
         $attestedCredentialData = $authenticatorData->attestedCredentialData;
         $attestedCredentialData !== null || throw AttestationStatementVerificationException::create(
             'No attested credential data found'
@@ -150,10 +150,10 @@ final class AppleAttestationStatementSupport implements AttestationStatementSupp
             'Unsupported key type'
         );
 
-        /*---------------------------*/
+        /* --------------------------- */
         $cert = Certificate::fromPEM(PEM::fromString($certificate));
 
-        //We check the attested key corresponds to the key in the certificate
+        // We check the attested key corresponds to the key in the certificate
         PEM::fromString($publicKey->asPEM())->string() === $cert->tbsCertificate()
             ->subjectPublicKeyInfo()
             ->toPEM()
@@ -162,7 +162,7 @@ final class AppleAttestationStatementSupport implements AttestationStatementSupp
         $extensions = $cert->tbsCertificate()
             ->extensions();
 
-        //Find Apple Extension with OID "1.2.840.113635.100.8.2" in certificate extensions
+        // Find Apple Extension with OID "1.2.840.113635.100.8.2" in certificate extensions
         $extensions->has(self::OID_APPLE) || throw AttestationStatementVerificationException::create(
             'The certificate extension "' . self::OID_APPLE . '" is missing'
         );

--- a/src/webauthn/src/AttestationStatement/CompoundAttestationStatementSupport.php
+++ b/src/webauthn/src/AttestationStatement/CompoundAttestationStatementSupport.php
@@ -170,7 +170,7 @@ final class CompoundAttestationStatementSupport implements AttestationStatementS
                     $countValid++;
                 }
             } catch (Throwable) {
-                //Nothing to do
+                // Nothing to do
             }
         }
 

--- a/src/webauthn/src/AttestationStatement/FidoU2FAttestationStatementSupport.php
+++ b/src/webauthn/src/AttestationStatement/FidoU2FAttestationStatementSupport.php
@@ -120,7 +120,7 @@ final class FidoU2FAttestationStatementSupport implements AttestationStatementSu
         $dataToVerify .= $clientDataJSONHash;
         $dataToVerify .= $authenticatorData->attestedCredentialData
             ->credentialId;
-        $dataToVerify .= $this->extractPublicKey($authenticatorData->attestedCredentialData ->credentialPublicKey);
+        $dataToVerify .= $this->extractPublicKey($authenticatorData->attestedCredentialData->credentialPublicKey);
 
         /** @var string $sig */
         $sig = $attestationStatement->get('sig');

--- a/src/webauthn/src/AttestationStatement/PackedAttestationStatementSupport.php
+++ b/src/webauthn/src/AttestationStatement/PackedAttestationStatementSupport.php
@@ -169,12 +169,12 @@ final class PackedAttestationStatementSupport implements AttestationStatementSup
         $certificate = Certificate::fromPEM(PEM::fromString($attestnCert));
         $tbsCertificate = $certificate->tbsCertificate();
 
-        //Check version (X.509 version 3 is encoded as 2)
+        // Check version (X.509 version 3 is encoded as 2)
         $tbsCertificate->version() === TBSCertificate::VERSION_3 || throw AttestationStatementVerificationException::create(
             'Invalid certificate version'
         );
 
-        //Check subject field
+        // Check subject field
         $subject = $tbsCertificate->subject();
         $subject->countOfType(
             AttributeType::OID_COUNTRY_NAME
@@ -194,10 +194,10 @@ final class PackedAttestationStatementSupport implements AttestationStatementSup
             'Invalid certificate name. The Subject Organization Unit must be "Authenticator Attestation"'
         );
 
-        //Check extensions
+        // Check extensions
         $extensions = $tbsCertificate->extensions();
 
-        //Check certificate is not a CA cert
+        // Check certificate is not a CA cert
         $extensions->hasBasicConstraints() || throw AttestationStatementVerificationException::create(
             'The Basic Constraints extension must have the CA component set to false'
         );

--- a/src/webauthn/src/AttestationStatement/TPMAttestationStatementSupport.php
+++ b/src/webauthn/src/AttestationStatement/TPMAttestationStatementSupport.php
@@ -218,13 +218,13 @@ final class TPMAttestationStatementSupport implements AttestationStatementSuppor
 
         /** @var array{1: int} $qualifiedSignerLengthData */
         $qualifiedSignerLengthData = unpack('n', $certInfo->read(2));
-        $qualifiedSigner = $certInfo->read($qualifiedSignerLengthData[1]); //Ignored
+        $qualifiedSigner = $certInfo->read($qualifiedSignerLengthData[1]); // Ignored
 
         /** @var array{1: int} $extraDataLengthData */
         $extraDataLengthData = unpack('n', $certInfo->read(2));
         $extraData = $certInfo->read($extraDataLengthData[1]);
 
-        $clockInfo = $certInfo->read(17); //Ignore
+        $clockInfo = $certInfo->read(17); // Ignore
 
         $firmwareVersion = $certInfo->read(8);
 
@@ -234,7 +234,7 @@ final class TPMAttestationStatementSupport implements AttestationStatementSuppor
 
         /** @var array{1: int} $attestedQualifiedNameLengthData */
         $attestedQualifiedNameLengthData = unpack('n', $certInfo->read(2));
-        $attestedQualifiedName = $certInfo->read($attestedQualifiedNameLengthData[1]); //Ignore
+        $attestedQualifiedName = $certInfo->read($attestedQualifiedNameLengthData[1]); // Ignore
         $certInfo->isEOF() || throw AttestationStatementVerificationException::create(
             'Invalid certificate information. Presence of extra bytes.'
         );

--- a/src/webauthn/src/AuthenticatorAssertionResponseValidator.php
+++ b/src/webauthn/src/AuthenticatorAssertionResponseValidator.php
@@ -77,11 +77,11 @@ class AuthenticatorAssertionResponseValidator implements CanLogData, CanDispatch
             $previousBackupEligible = $credentialRecord->backupEligible;
             $previousBackupStatus = $credentialRecord->backupStatus;
 
-            $credentialRecord->counter = $authenticatorAssertionResponse->authenticatorData->signCount; //26.1.
-            $credentialRecord->backupEligible = $authenticatorAssertionResponse->authenticatorData->isBackupEligible(); //26.2.
-            $credentialRecord->backupStatus = $authenticatorAssertionResponse->authenticatorData->isBackedUp(); //26.2.
+            $credentialRecord->counter = $authenticatorAssertionResponse->authenticatorData->signCount; // 26.1.
+            $credentialRecord->backupEligible = $authenticatorAssertionResponse->authenticatorData->isBackupEligible(); // 26.2.
+            $credentialRecord->backupStatus = $authenticatorAssertionResponse->authenticatorData->isBackedUp(); // 26.2.
             if ($credentialRecord->uvInitialized === false) {
-                $credentialRecord->uvInitialized = $authenticatorAssertionResponse->authenticatorData->isUserVerified(); //26.3.
+                $credentialRecord->uvInitialized = $authenticatorAssertionResponse->authenticatorData->isUserVerified(); // 26.3.
             }
 
             // Dispatch events if backup state changed
@@ -108,7 +108,7 @@ class AuthenticatorAssertionResponseValidator implements CanLogData, CanDispatch
              * OPTIONALLY, if response.attestationObject is present, update credentialRecord.attestationObject to the value of response.attestationObject and update credentialRecord.attestationClientDataJSON to the value of response.clientDataJSON.
              */
 
-            //All good. We can continue.
+            // All good. We can continue.
             $this->logger->info('The assertion is valid');
             $this->logger->debug('Credential Record', [
                 'credentialRecord' => $credentialRecord,

--- a/src/webauthn/src/CeremonyStep/CheckAlgorithm.php
+++ b/src/webauthn/src/CeremonyStep/CheckAlgorithm.php
@@ -64,7 +64,7 @@ class CheckAlgorithm implements CeremonyStep
     private function getCoseKey(string $credentialPublicKey): Key
     {
         $isU2F = U2FPublicKey::isU2FKey($credentialPublicKey);
-        if ($isU2F === true) {
+        if ($isU2F) {
             $credentialPublicKey = U2FPublicKey::convertToCoseKey($credentialPublicKey);
         }
         $stream = new StringStream($credentialPublicKey);

--- a/src/webauthn/src/CeremonyStep/CheckAttestationFormatIsKnownAndValid.php
+++ b/src/webauthn/src/CeremonyStep/CheckAttestationFormatIsKnownAndValid.php
@@ -48,7 +48,7 @@ final readonly class CheckAttestationFormatIsKnownAndValid implements CeremonySt
         ) || throw AuthenticatorResponseVerificationException::create('Unsupported attestation statement format.');
 
         $attestationStatementSupport = $this->attestationStatementSupportManager->get($fmt);
-        $clientDataJSONHash = hash('sha256', $authenticatorResponse->clientDataJSON ->rawData, true);
+        $clientDataJSONHash = hash('sha256', $authenticatorResponse->clientDataJSON->rawData, true);
         $attestationStatementSupport->isValid(
             $clientDataJSONHash,
             $attestationObject->attStmt,

--- a/src/webauthn/src/CeremonyStep/CheckBackupBitsAreConsistent.php
+++ b/src/webauthn/src/CeremonyStep/CheckBackupBitsAreConsistent.php
@@ -34,7 +34,7 @@ final class CheckBackupBitsAreConsistent implements CeremonyStep
         if ($authData->isBackupEligible()) {
             return;
         }
-        $authData->isBackedUp() !== true || throw AuthenticatorResponseVerificationException::create(
+        ! $authData->isBackedUp() || throw AuthenticatorResponseVerificationException::create(
             'Backup up bit is set but the backup is not eligible.'
         );
     }

--- a/src/webauthn/src/CeremonyStep/CheckRelyingPartyIdIdHash.php
+++ b/src/webauthn/src/CeremonyStep/CheckRelyingPartyIdIdHash.php
@@ -42,7 +42,7 @@ final class CheckRelyingPartyIdIdHash implements CeremonyStep
         );
         $isU2F = U2FPublicKey::isU2FKey($credentialPublicKey);
         $rpId = $publicKeyCredentialOptions->rpId ?? $publicKeyCredentialOptions->rp->id ?? $host;
-        $facetId = $this->getFacetId($rpId, $publicKeyCredentialOptions->extensions, $authData ->extensions);
+        $facetId = $this->getFacetId($rpId, $publicKeyCredentialOptions->extensions, $authData->extensions);
         $rpIdHash = hash('sha256', $isU2F ? $C->origin : $facetId, true);
         hash_equals(
             $rpIdHash,

--- a/src/webauthn/src/CeremonyStep/CheckSignature.php
+++ b/src/webauthn/src/CeremonyStep/CheckSignature.php
@@ -76,7 +76,7 @@ final readonly class CheckSignature implements CeremonyStep
     private function getCoseKey(string $credentialPublicKey): Key
     {
         $isU2F = U2FPublicKey::isU2FKey($credentialPublicKey);
-        if ($isU2F === true) {
+        if ($isU2F) {
             $credentialPublicKey = U2FPublicKey::convertToCoseKey($credentialPublicKey);
         }
         $stream = new StringStream($credentialPublicKey);

--- a/src/webauthn/src/CeremonyStep/CheckTopOrigin.php
+++ b/src/webauthn/src/CeremonyStep/CheckTopOrigin.php
@@ -39,7 +39,7 @@ class CheckTopOrigin implements CeremonyStep
         if ($topOrigin === null) {
             return;
         }
-        if ($authenticatorResponse->clientDataJSON->crossOrigin !== true) {
+        if (! $authenticatorResponse->clientDataJSON->crossOrigin) {
             throw AuthenticatorResponseVerificationException::create('The response is not cross-origin.');
         }
         if ($this->topOriginValidator === null) {

--- a/src/webauthn/src/CeremonyStep/CheckUserVerification.php
+++ b/src/webauthn/src/CeremonyStep/CheckUserVerification.php
@@ -14,7 +14,7 @@ use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
 
-final class CheckUserVerification implements CeremonyStep
+final readonly class CheckUserVerification implements CeremonyStep
 {
     public function __construct(
         private bool $requireUserVerification = true

--- a/src/webauthn/src/MetadataService/Statement/AuthenticatorStatus.php
+++ b/src/webauthn/src/MetadataService/Statement/AuthenticatorStatus.php
@@ -6,41 +6,41 @@ namespace Webauthn\MetadataService\Statement;
 
 final class AuthenticatorStatus
 {
-    final public const NOT_FIDO_CERTIFIED = 'NOT_FIDO_CERTIFIED';
+    public const NOT_FIDO_CERTIFIED = 'NOT_FIDO_CERTIFIED';
 
-    final public const FIDO_CERTIFIED = 'FIDO_CERTIFIED';
+    public const FIDO_CERTIFIED = 'FIDO_CERTIFIED';
 
-    final public const USER_VERIFICATION_BYPASS = 'USER_VERIFICATION_BYPASS';
+    public const USER_VERIFICATION_BYPASS = 'USER_VERIFICATION_BYPASS';
 
-    final public const ATTESTATION_KEY_COMPROMISE = 'ATTESTATION_KEY_COMPROMISE';
+    public const ATTESTATION_KEY_COMPROMISE = 'ATTESTATION_KEY_COMPROMISE';
 
-    final public const USER_KEY_REMOTE_COMPROMISE = 'USER_KEY_REMOTE_COMPROMISE';
+    public const USER_KEY_REMOTE_COMPROMISE = 'USER_KEY_REMOTE_COMPROMISE';
 
-    final public const USER_KEY_PHYSICAL_COMPROMISE = 'USER_KEY_PHYSICAL_COMPROMISE';
+    public const USER_KEY_PHYSICAL_COMPROMISE = 'USER_KEY_PHYSICAL_COMPROMISE';
 
-    final public const UPDATE_AVAILABLE = 'UPDATE_AVAILABLE';
+    public const UPDATE_AVAILABLE = 'UPDATE_AVAILABLE';
 
-    final public const REVOKED = 'REVOKED';
+    public const REVOKED = 'REVOKED';
 
-    final public const SELF_ASSERTION_SUBMITTED = 'SELF_ASSERTION_SUBMITTED';
+    public const SELF_ASSERTION_SUBMITTED = 'SELF_ASSERTION_SUBMITTED';
 
-    final public const FIDO_CERTIFIED_L1 = 'FIDO_CERTIFIED_L1';
+    public const FIDO_CERTIFIED_L1 = 'FIDO_CERTIFIED_L1';
 
-    final public const FIDO_CERTIFIED_L1plus = 'FIDO_CERTIFIED_L1plus';
+    public const FIDO_CERTIFIED_L1plus = 'FIDO_CERTIFIED_L1plus';
 
-    final public const FIDO_CERTIFIED_L2 = 'FIDO_CERTIFIED_L2';
+    public const FIDO_CERTIFIED_L2 = 'FIDO_CERTIFIED_L2';
 
-    final public const FIDO_CERTIFIED_L2plus = 'FIDO_CERTIFIED_L2plus';
+    public const FIDO_CERTIFIED_L2plus = 'FIDO_CERTIFIED_L2plus';
 
-    final public const FIDO_CERTIFIED_L3 = 'FIDO_CERTIFIED_L3';
+    public const FIDO_CERTIFIED_L3 = 'FIDO_CERTIFIED_L3';
 
-    final public const FIDO_CERTIFIED_L3plus = 'FIDO_CERTIFIED_L3plus';
+    public const FIDO_CERTIFIED_L3plus = 'FIDO_CERTIFIED_L3plus';
 
-    final public const FIDO_CERTIFIED_L4 = 'FIDO_CERTIFIED_L4';
+    public const FIDO_CERTIFIED_L4 = 'FIDO_CERTIFIED_L4';
 
-    final public const FIDO_CERTIFIED_L5 = 'FIDO_CERTIFIED_L5';
+    public const FIDO_CERTIFIED_L5 = 'FIDO_CERTIFIED_L5';
 
-    final public const STATUSES = [
+    public const STATUSES = [
         self::NOT_FIDO_CERTIFIED,
         self::FIDO_CERTIFIED,
         self::USER_VERIFICATION_BYPASS,

--- a/src/webauthn/src/PublicKeyCredentialCreationOptions.php
+++ b/src/webauthn/src/PublicKeyCredentialCreationOptions.php
@@ -46,7 +46,7 @@ final class PublicKeyCredentialCreationOptions extends PublicKeyCredentialOption
      *
      * @see https://github.com/w3c/webauthn/wiki/Explainer:-Conditional-Create
      */
-    public null|string $mediation = null;
+    public null|string $mediation;
 
     /**
      * @param PublicKeyCredentialParameters[] $pubKeyCredParams

--- a/src/webauthn/src/Util/CoseSignatureFixer.php
+++ b/src/webauthn/src/Util/CoseSignatureFixer.php
@@ -39,7 +39,7 @@ final readonly class CoseSignatureFixer
                 return ECSignature::fromAsn1(
                     $signature,
                     self::ES256_SIGNATURE_LENGTH
-                ); //TODO: fix this hardcoded value by adding a dedicated method for the algorithms
+                ); // TODO: fix this hardcoded value by adding a dedicated method for the algorithms
             case ES384::ID:
                 if (strlen($signature) === self::ES384_SIGNATURE_LENGTH) {
                     return $signature;

--- a/tests/library/Functional/W10Test.php
+++ b/tests/library/Functional/W10Test.php
@@ -69,7 +69,7 @@ final class W10Test extends AbstractTestCase
         static::assertInstanceOf(AttestedCredentialData::class, $authenticatorData->attestedCredentialData);
         static::assertFalse($authenticatorData->hasExtensions());
         if ($publicKeyCredentialCreationOptions->attestation === null || $publicKeyCredentialCreationOptions->attestation === PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE) {
-            static::assertSame($aaguid, $publicKeyCredentialSource->aaguid ->__toString());
+            static::assertSame($aaguid, $publicKeyCredentialSource->aaguid->__toString());
             static::assertSame($attestationType, $publicKeyCredentialSource->attestationType);
             static::assertInstanceOf($trustPath, $publicKeyCredentialSource->trustPath);
         }

--- a/tests/library/Unit/CeremonyStep/CheckUserVerificationTest.php
+++ b/tests/library/Unit/CeremonyStep/CheckUserVerificationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\Tests\Unit\CeremonyStep;
 
+use function chr;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Uid\Uuid;
 use Webauthn\AttestationStatement\AttestationObject;
@@ -21,7 +22,6 @@ use Webauthn\PublicKeyCredentialRpEntity;
 use Webauthn\PublicKeyCredentialUserEntity;
 use Webauthn\Tests\AbstractTestCase;
 use Webauthn\TrustPath\EmptyTrustPath;
-use function chr;
 
 /**
  * Verify the `$requireUserVerification` opt-out and the runtime mediation override on

--- a/tests/library/Unit/PasskeyEndpointsResponseTest.php
+++ b/tests/library/Unit/PasskeyEndpointsResponseTest.php
@@ -60,7 +60,6 @@ final class PasskeyEndpointsResponseTest extends AbstractTestCase
         // Given
         $response = PasskeyEndpointsResponse::create(
             enroll: Url::create('https://example.com/enroll'),
-            manage: null,
             prfUsageDetails: Url::create('https://example.com/prf-info')
         );
 

--- a/tests/symfony/functional/Attestation/AttestationTest.php
+++ b/tests/symfony/functional/Attestation/AttestationTest.php
@@ -60,7 +60,7 @@ final class AttestationTest extends KernelTestCase
         $response = $publicKeyCredential->response;
         static::assertInstanceOf(AuthenticatorAttestationResponse::class, $response);
         static::assertSame(AttestationStatement::TYPE_NONE, $response->attestationObject->attStmt->type);
-        static::assertInstanceOf(EmptyTrustPath::class, $response->attestationObject ->attStmt ->trustPath);
+        static::assertInstanceOf(EmptyTrustPath::class, $response->attestationObject->attStmt->trustPath);
         self::$kernel->getContainer()->get(AuthenticatorAttestationResponseValidator::class)->check(
             $publicKeyCredential->response,
             $publicKeyCredentialCreationOptions,
@@ -105,7 +105,7 @@ final class AttestationTest extends KernelTestCase
         $response = $publicKeyCredential->response;
         static::assertInstanceOf(AuthenticatorAttestationResponse::class, $response);
         static::assertSame(AttestationStatement::TYPE_NONE, $response->attestationObject->attStmt->type);
-        static::assertInstanceOf(EmptyTrustPath::class, $response->attestationObject ->attStmt ->trustPath);
+        static::assertInstanceOf(EmptyTrustPath::class, $response->attestationObject->attStmt->trustPath);
         self::$kernel->getContainer()->get(AuthenticatorAttestationResponseValidator::class)->check(
             $publicKeyCredential->response,
             $publicKeyCredentialCreationOptions,
@@ -140,8 +140,8 @@ final class AttestationTest extends KernelTestCase
         static::assertSame([], $descriptor->transports);
         $response = $publicKeyCredential->response;
         static::assertInstanceOf(AuthenticatorAttestationResponse::class, $response);
-        static::assertSame(AttestationStatement::TYPE_BASIC, $response->attestationObject ->attStmt ->type);
-        static::assertInstanceOf(CertificateTrustPath::class, $response->attestationObject ->attStmt ->trustPath);
+        static::assertSame(AttestationStatement::TYPE_BASIC, $response->attestationObject->attStmt->type);
+        static::assertInstanceOf(CertificateTrustPath::class, $response->attestationObject->attStmt->trustPath);
         $this->expectException(CertificateChainException::class);
         $this->expectExceptionMessage('Unable to validate the certificate chain.');
 
@@ -197,7 +197,7 @@ final class AttestationTest extends KernelTestCase
         /** @var SerializerInterface $serializer */
         $serializer = self::getContainer()->get(SerializerInterface::class);
 
-        //Then
+        // Then
         $this->expectException(CertificateChainException::class);
         $this->expectExceptionMessage('Unable to validate the certificate chain.');
 
@@ -220,8 +220,8 @@ final class AttestationTest extends KernelTestCase
         static::assertSame([], $descriptor->transports);
         $response = $publicKeyCredential->response;
         static::assertInstanceOf(AuthenticatorAttestationResponse::class, $response);
-        static::assertSame(AttestationStatement::TYPE_BASIC, $response->attestationObject ->attStmt ->type);
-        static::assertInstanceOf(CertificateTrustPath::class, $response->attestationObject ->attStmt ->trustPath);
+        static::assertSame(AttestationStatement::TYPE_BASIC, $response->attestationObject->attStmt->type);
+        static::assertInstanceOf(CertificateTrustPath::class, $response->attestationObject->attStmt->trustPath);
 
         // When
         self::$kernel->getContainer()->get(AuthenticatorAttestationResponseValidator::class)->check(

--- a/tests/symfony/functional/Attestation/PackedAttestationStatementTest.php
+++ b/tests/symfony/functional/Attestation/PackedAttestationStatementTest.php
@@ -59,7 +59,7 @@ final class PackedAttestationStatementTest extends KernelTestCase
         $response = $publicKeyCredential->response;
         static::assertInstanceOf(AuthenticatorAttestationResponse::class, $response);
         static::assertSame(AttestationStatement::TYPE_SELF, $response->attestationObject->attStmt->type);
-        static::assertInstanceOf(EmptyTrustPath::class, $response->attestationObject ->attStmt ->trustPath);
+        static::assertInstanceOf(EmptyTrustPath::class, $response->attestationObject->attStmt->trustPath);
         self::$kernel->getContainer()->get(AuthenticatorAttestationResponseValidator::class)->check(
             $publicKeyCredential->response,
             $publicKeyCredentialCreationOptions,

--- a/tests/symfony/functional/CompilerPass/AttestationStatementSupportCompilerPassTest.php
+++ b/tests/symfony/functional/CompilerPass/AttestationStatementSupportCompilerPassTest.php
@@ -21,17 +21,17 @@ final class AttestationStatementSupportCompilerPassTest extends AbstractCompiler
     #[Test]
     public function aTaggedAttestationStatementSupportServiceIsAddedToTheManager(): void
     {
-        //Given
+        // Given
         $this->setDefinition(AttestationStatementSupportManager::class, new Definition());
 
         $attestationStatementSupportService = new Definition();
         $attestationStatementSupportService->addTag(AttestationStatementSupportCompilerPass::TAG);
         $this->setDefinition('service_1', $attestationStatementSupportService);
 
-        //When
+        // When
         $this->compile();
 
-        //Then
+        // Then
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             AttestationStatementSupportManager::class,
             'add',

--- a/tests/symfony/functional/CompilerPass/CoseAlgorithmCompilerPassTest.php
+++ b/tests/symfony/functional/CompilerPass/CoseAlgorithmCompilerPassTest.php
@@ -20,7 +20,7 @@ final class CoseAlgorithmCompilerPassTest extends AbstractCompilerPassTestCase
     #[Test]
     public function coseAlgorithmsAreAddedToTHeAlgorithmManager(): void
     {
-        //Given
+        // Given
         $this->setDefinition('webauthn.cose.algorithm.manager', new Definition());
 
         $algorithm1 = new Definition();
@@ -31,10 +31,10 @@ final class CoseAlgorithmCompilerPassTest extends AbstractCompilerPassTestCase
         $algorithm2->addTag(CoseAlgorithmCompilerPass::TAG);
         $this->setDefinition('algorithm_2', $algorithm1);
 
-        //When
+        // When
         $this->compile();
 
-        //Then
+        // Then
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'webauthn.cose.algorithm.manager',
             'add',

--- a/tests/symfony/functional/CompilerPass/CounterCheckerSetterCompilerPassTest.php
+++ b/tests/symfony/functional/CompilerPass/CounterCheckerSetterCompilerPassTest.php
@@ -22,16 +22,16 @@ final class CounterCheckerSetterCompilerPassTest extends AbstractCompilerPassTes
     #[Test]
     public function theCounterCheckerIsCorrectlyAddedIfItExists(): void
     {
-        //Given
+        // Given
         $this->setDefinition(CeremonyStepManagerFactory::class, new Definition());
 
         $this->setDefinition('counter_checker', new Definition());
         $this->container->setAlias(CounterChecker::class, 'counter_checker');
 
-        //When
+        // When
         $this->compile();
 
-        //Then
+        // Then
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             CeremonyStepManagerFactory::class,
             'setCounterChecker',

--- a/tests/symfony/functional/CompilerPass/DynamicRouteCompilerPassTest.php
+++ b/tests/symfony/functional/CompilerPass/DynamicRouteCompilerPassTest.php
@@ -20,7 +20,7 @@ final class DynamicRouteCompilerPassTest extends AbstractCompilerPassTestCase
     #[Test]
     public function dynamicRoutesAreAddedToTheLoader(): void
     {
-        //Given
+        // Given
         $this->setDefinition(Loader::class, new Definition());
 
         $route1 = new Definition();
@@ -38,10 +38,10 @@ final class DynamicRouteCompilerPassTest extends AbstractCompilerPassTestCase
         ]);
         $this->setDefinition('route_2', $route2);
 
-        //When
+        // When
         $this->compile();
 
-        //Then
+        // Then
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             Loader::class,
             'add',

--- a/tests/symfony/functional/CompilerPass/EventDispatcherSetterCompilerPassTest.php
+++ b/tests/symfony/functional/CompilerPass/EventDispatcherSetterCompilerPassTest.php
@@ -35,7 +35,7 @@ final class EventDispatcherSetterCompilerPassTest extends AbstractCompilerPassTe
     #[DataProvider('getClassList')]
     public function eventDispatcherIsCorrectlySet(string $className): void
     {
-        //Given
+        // Given
         $this->setDefinition('my_event_dispatcher', new Definition());
         $this->container->setAlias('webauthn.event_dispatcher', 'my_event_dispatcher');
 
@@ -43,10 +43,10 @@ final class EventDispatcherSetterCompilerPassTest extends AbstractCompilerPassTe
         $definition->addTag(EventDispatcherSetterCompilerPass::TAG);
         $this->setDefinition($className, $definition);
 
-        //When
+        // When
         $this->compile();
 
-        //Then
+        // Then
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             $className,
             'setEventDispatcher',

--- a/tests/symfony/functional/CompilerPass/ExtensionOutputCheckerCompilerPassTest.php
+++ b/tests/symfony/functional/CompilerPass/ExtensionOutputCheckerCompilerPassTest.php
@@ -21,7 +21,7 @@ final class ExtensionOutputCheckerCompilerPassTest extends AbstractCompilerPassT
     #[Test]
     public function androidSafetyNetApiVerificationIsEnabledWhenAllServicesAndParametersAreSet(): void
     {
-        //Given
+        // Given
         $this->setDefinition(ExtensionOutputCheckerHandler::class, new Definition());
 
         $extension1 = new Definition();
@@ -32,10 +32,10 @@ final class ExtensionOutputCheckerCompilerPassTest extends AbstractCompilerPassT
         $extension2->addTag(ExtensionOutputCheckerCompilerPass::TAG);
         $this->setDefinition('extension_2', $extension2);
 
-        //When
+        // When
         $this->compile();
 
-        //Then
+        // Then
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             ExtensionOutputCheckerHandler::class,
             'add',

--- a/tests/symfony/functional/CompilerPass/LoggerSetterCompilerPassTest.php
+++ b/tests/symfony/functional/CompilerPass/LoggerSetterCompilerPassTest.php
@@ -29,7 +29,7 @@ final class LoggerSetterCompilerPassTest extends AbstractCompilerPassTestCase
     #[DataProvider('getClassList')]
     public function loggerIsCorrectlySet(string $className): void
     {
-        //Given
+        // Given
         $this->setDefinition('my_logger', new Definition());
         $this->container->setAlias('webauthn.logger', 'my_logger');
 
@@ -37,12 +37,12 @@ final class LoggerSetterCompilerPassTest extends AbstractCompilerPassTestCase
         $definition->addTag(LoggerSetterCompilerPass::TAG);
         $this->setDefinition($className, $definition);
 
-        //When
+        // When
         $this->compile();
 
-        //Then
+        // Then
 
-        //Then
+        // Then
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             $className,
             'setLogger',

--- a/tests/symfony/functional/Firewall/AllowedOriginsTest.php
+++ b/tests/symfony/functional/Firewall/AllowedOriginsTest.php
@@ -16,15 +16,15 @@ final class AllowedOriginsTest extends WebauthnTestCase
     #[Test]
     public function allowedOriginsAreAvailable(): void
     {
-        //Given
+        // Given
         $client = static::createClient(server: [
             'HTTPS' => 'on',
         ]);
 
-        //When
+        // When
         $client->request(Request::METHOD_GET, '/.well-known/webauthn');
 
-        //Then
+        // Then
         static::assertResponseIsSuccessful();
         static::assertSame(
             '{"origins":["https:\/\/localhost","https:\/\/localhost:8443","https:\/\/bar.acme","https:\/\/webauthn.spomky-labs.com","https:\/\/spomky-webauthn.herokuapp.com"]}',

--- a/tests/symfony/functional/Firewall/SecuredAreaTest.php
+++ b/tests/symfony/functional/Firewall/SecuredAreaTest.php
@@ -26,22 +26,22 @@ final class SecuredAreaTest extends WebauthnTestCase
     #[Test]
     public function aClientIsRedirectedIfUserIsNotAuthenticated(): void
     {
-        //Given
+        // Given
         $client = static::createClient([], [
             'HTTPS' => 'on',
         ]);
 
-        //When
+        // When
         $client->request(Request::METHOD_GET, '/admin');
 
-        //Then
+        // Then
         static::assertResponseRedirects('/login');
     }
 
     #[Test]
     public function aUserCannotBeAuthenticatedInAbsenceOfOptions(): void
     {
-        //Given
+        // Given
         $assertion = '{"id":"eHouz_Zi7-BmByHjJ_tx9h4a1WZsK4IzUmgGjkhyOodPGAyUqUp_B9yUkflXY3yHWsNtsrgCXQ3HjAIFUeZB-w","type":"public-key","rawId":"eHouz/Zi7+BmByHjJ/tx9h4a1WZsK4IzUmgGjkhyOodPGAyUqUp/B9yUkflXY3yHWsNtsrgCXQ3HjAIFUeZB+w==","response":{"authenticatorData":"SZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2MBAAAAew","clientDataJSON":"eyJjaGFsbGVuZ2UiOiJHMEpiTExuZGVmM2EwSXkzUzJzU1FBOHVPNFNPX3plNkZaTUF1UEk2LXhJIiwiY2xpZW50RXh0ZW5zaW9ucyI6e30sImhhc2hBbGdvcml0aG0iOiJTSEEtMjU2Iiwib3JpZ2luIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6ODQ0MyIsInR5cGUiOiJ3ZWJhdXRobi5nZXQifQ","signature":"MEUCIEY/vcNkbo/LdMTfLa24ZYLlMMVMRd8zXguHBvqud9AJAiEAwCwpZpvcMaqCrwv85w/8RGiZzE+gOM61ffxmgEDeyhM=","userHandle":null}}';
 
         $client = static::createClient([], [
@@ -50,22 +50,22 @@ final class SecuredAreaTest extends WebauthnTestCase
         $client->disableReboot();
         $crawler = $client->request(Request::METHOD_GET, '/login');
 
-        //When
+        // When
         $form = $crawler->selectButton('login')
             ->form();
         $client->submit($form, [
             '_assertion' => $assertion,
         ]);
 
-        //Then
+        // Then
         static::assertResponseRedirects('/login');
-        //@todo: verify the reason is: No public key credential options available for this session.
+        // @todo: verify the reason is: No public key credential options available for this session.
     }
 
     #[Test]
     public function aUserCanBeAuthenticatedAndAccessToTheProtectedResource(): void
     {
-        //Given
+        // Given
         $client = static::createClient([], [
             'HTTPS' => 'on',
         ]);
@@ -96,19 +96,19 @@ final class SecuredAreaTest extends WebauthnTestCase
 
         $crawler = $client->request(Request::METHOD_GET, '/login');
 
-        //When
+        // When
         $form = $crawler->selectButton('login')
             ->form();
         $client->submit($form, [
             '_assertion' => $assertion,
         ]);
 
-        //Then
+        // Then
         static::assertResponseIsSuccessful();
         static::assertSame('{"success":true}', $client->getResponse()->getContent());
         static::assertTrue($client->getRequest()->getSession()->has('_security_main'));
 
-        //And then
+        // And then
         $client->request(Request::METHOD_GET, '/admin');
         static::assertSame('["Hello admin"]', $client->getResponse()->getContent());
         static::assertResponseIsSuccessful();
@@ -117,7 +117,7 @@ final class SecuredAreaTest extends WebauthnTestCase
     #[Test]
     public function aUserCannotBeRegisteredAsTheUserAlreadyExists(): void
     {
-        //Given
+        // Given
         $client = static::createClient([], [
             'HTTPS' => 'on',
         ]);
@@ -142,21 +142,21 @@ final class SecuredAreaTest extends WebauthnTestCase
 
         $crawler = $client->request(Request::METHOD_GET, '/login');
 
-        //When
+        // When
         $form = $crawler->selectButton('login')
             ->form();
         $client->submit($form, [
             '_assertion' => $assertion,
         ]);
 
-        //Then
+        // Then
         static::assertResponseRedirects('/login');
     }
 
     #[Test]
     public function aUserCanBeRegistered(): void
     {
-        //Given
+        // Given
         $client = static::createClient([], [
             'HTTPS' => 'on',
         ]);
@@ -188,19 +188,19 @@ final class SecuredAreaTest extends WebauthnTestCase
 
         $crawler = $client->request(Request::METHOD_GET, '/login');
 
-        //When
+        // When
         $form = $crawler->selectButton('login')
             ->form();
         $client->submit($form, [
             '_assertion' => $assertion,
         ]);
 
-        //Then
+        // Then
         static::assertResponseIsSuccessful();
         static::assertSame('{"success":true}', $client->getResponse()->getContent());
         static::assertTrue($client->getRequest()->getSession()->has('_security_main'));
 
-        //And then
+        // And then
         $client->request(Request::METHOD_GET, '/admin');
         static::assertResponseStatusCodeSame(403);
     }

--- a/tests/symfony/unit/Security/Http/Authenticator/WebauthnAuthenticatorLoggerTest.php
+++ b/tests/symfony/unit/Security/Http/Authenticator/WebauthnAuthenticatorLoggerTest.php
@@ -150,7 +150,14 @@ final class InMemoryLogger extends AbstractLogger
      */
     public array $records = [];
 
-    public function log($level, string|Stringable $message, array $context = []): void
+    /**
+     * The parameter is deliberately untyped so that the fixture stays compatible with psr/log 1.x, 2.x and 3.x, which
+     * do not declare the same signature.
+     *
+     * @param string|Stringable $message
+     * @param array<string, mixed> $context
+     */
+    public function log($level, $message, array $context = []): void
     {
         $this->records[] = [
             'level' => $level,


### PR DESCRIPTION
Repairs the five independent breakages described in #933, so the pipeline gives real signal again.

### Pull request jobs

- The tests job runs inside the phpqa image of the matrix PHP version and called `castor phpunit`. Castor requires PHP >= 8.4, so the `8.2`, `8.2 - Lowest Deps` and `8.3` entries died before running a single test. The job now calls the same PHPUnit command castor was wrapping.
- The `8.6` matrix entry is removed. The registry only publishes `8.2` to `8.5`, so the job could only fail at container initialisation with `manifest unknown`. It can come back once the image exists.
- `InMemoryLogger::log()` in `WebauthnAuthenticatorLoggerTest` declared the psr/log 3.x signature, while `composer.json` allows `^1.0|^2.0|^3.0`. The lowest-deps job installed psr/log 1.x and PHP refused to load the test suite. The parameter is now untyped, which is compatible with all three majors.

### Branch jobs

- `.ci-tools/ecs.php` imported `SetList::PHPUNIT` and `SetList::STRICT`, `.ci-tools/rector.php` imported `PHPUnitSetList::PHPUNIT_120`. All three were removed upstream, so both tools aborted before looking at a single file. The rules that mattered from the STRICT set were already declared individually below the imports, and the version specific PHPUnit set is covered by `withComposerBased()`.
- Both tools had been silent for months, so a backlog is absorbed here: comment spacing, native function invocation, global namespace imports, redundant boolean identity comparisons, one class turned readonly, a dead `instanceof` assert and a property default the constructor always overwrites.
- `RemoveEraseCredentialsRector` is added to the Rector skip list. It would delete `eraseCredentials()` from a test fixture implementing `UserInterface`, which is fatal on Symfony 6.4.
- The PHPStan baseline is regenerated on PHP 8.4, the version the job uses. Nineteen errors were reported outside it, one of them an unmatched ignored error on `Psr18HttpClient` tripping `reportUnmatchedIgnoredErrors`.

### Verification

Run locally against the phpqa images: ECS, Rector, PHPStan and Deptrac all exit 0. The test suite was run in the 8.2 image both with the default resolution and with `--prefer-lowest`, 339 tests green in both.

Closes #933
