### PR TITLE
ci: install dependencies in the analysis jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,22 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/spomky-labs/phpqa:8.4
-    outputs:
-      cache-key: ${{ steps.cache-key-generator.outputs.key }}
     steps:
       - uses: actions/checkout@v6
-
-      - id: cache-key-generator
-        run: echo "key=composer-${{ runner.os }}-${{ hashFiles('composer.lock') }}" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v5
-        with:
-          path: |
-            vendor
-            ~/.composer/cache
-          key: ${{ steps.cache-key-generator.outputs.key }}
-          restore-keys: |
-            composer-${{ runner.os }}-
 
       - uses: ramsey/composer-install@v4
         with:
@@ -87,12 +73,10 @@ jobs:
       image: ghcr.io/spomky-labs/phpqa:8.4
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/cache@v5
+      - uses: ramsey/composer-install@v4
         with:
-          path: |
-            vendor
-            ~/.composer/cache
-          key: ${{ needs.prepare_dependencies.outputs.cache-key }}
+          dependency-versions: highest
+          composer-options: --optimize-autoloader
       - run: castor ecs
 
   rector:
@@ -104,12 +88,10 @@ jobs:
       image: ghcr.io/spomky-labs/phpqa:8.4
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/cache@v5
+      - uses: ramsey/composer-install@v4
         with:
-          path: |
-            vendor
-            ~/.composer/cache
-          key: ${{ needs.prepare_dependencies.outputs.cache-key }}
+          dependency-versions: highest
+          composer-options: --optimize-autoloader
       - run: castor rector
 
   validate:
@@ -120,12 +102,10 @@ jobs:
       image: ghcr.io/spomky-labs/phpqa:8.4
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/cache@v5
+      - uses: ramsey/composer-install@v4
         with:
-          path: |
-            vendor
-            ~/.composer/cache
-          key: ${{ needs.prepare_dependencies.outputs.cache-key }}
+          dependency-versions: highest
+          composer-options: --optimize-autoloader
       - run: |
           composer dump-autoload --optimize --strict-psr
           composer validate --strict
@@ -161,12 +141,10 @@ jobs:
       image: ghcr.io/spomky-labs/phpqa:8.4
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/cache@v5
+      - uses: ramsey/composer-install@v4
         with:
-          path: |
-            vendor
-            ~/.composer/cache
-          key: ${{ needs.prepare_dependencies.outputs.cache-key }}
+          dependency-versions: highest
+          composer-options: --optimize-autoloader
       - run: castor deptrac
 
   tests:

--- a/tests/library/Unit/AttestationStatement/AndroidKeyAttestationStatementSupportTest.php
+++ b/tests/library/Unit/AttestationStatement/AndroidKeyAttestationStatementSupportTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\Tests\Unit\AttestationStatement;
 
+use const JSON_THROW_ON_ERROR;
 use ParagonIE\ConstantTime\Base64UrlSafe;
 use PHPUnit\Framework\Attributes\Test;
 use Webauthn\AttestationStatement\AndroidKeyAttestationStatementSupport;

--- a/tests/library/Unit/AuthenticatorDataTest.php
+++ b/tests/library/Unit/AuthenticatorDataTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Webauthn\Tests\Unit;
 
+use function chr;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Uid\Uuid;

--- a/tests/library/Unit/Util/CoseSignatureFixerTest.php
+++ b/tests/library/Unit/Util/CoseSignatureFixerTest.php
@@ -11,6 +11,7 @@ use Cose\Algorithm\Signature\EdDSA\EdDSA;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use function strlen;
 use Webauthn\Util\CoseSignatureFixer;
 
 /**
@@ -31,23 +32,23 @@ final class CoseSignatureFixerTest extends TestCase
         yield 'both components padded with a leading zero byte' => [
             '3046'
             . '022100' . str_repeat('ff', 32)
-            . '022100' . '80' . str_repeat('00', 31),
+            . '02210080' . str_repeat('00', 31),
             str_repeat('ff', 32) . '80' . str_repeat('00', 31),
         ];
 
         yield 'both components exactly 32 bytes long' => [
             '3044'
-            . '0220' . '7f' . str_repeat('ff', 31)
-            . '0220' . '01' . str_repeat('00', 31),
+            . '02207f' . str_repeat('ff', 31)
+            . '022001' . str_repeat('00', 31),
             '7f' . str_repeat('ff', 31) . '01' . str_repeat('00', 31),
         ];
 
         yield 'specification example with a 33-byte and a 30-byte component' => [
             '3043'
-            . '022100' . '89909504e14f1e29dba8158fa7c387e888ffbe07d824bb2143205506ab159c3e'
-            . '021e' . '56554fb5819b12845e85be2f78371cf3cb95e387f451cb362b9478d183d2',
+            . '02210089909504e14f1e29dba8158fa7c387e888ffbe07d824bb2143205506ab159c3e'
+            . '021e56554fb5819b12845e85be2f78371cf3cb95e387f451cb362b9478d183d2',
             '89909504e14f1e29dba8158fa7c387e888ffbe07d824bb2143205506ab159c3e'
-            . '0000' . '56554fb5819b12845e85be2f78371cf3cb95e387f451cb362b9478d183d2',
+            . '000056554fb5819b12845e85be2f78371cf3cb95e387f451cb362b9478d183d2',
         ];
     }
 
@@ -85,8 +86,8 @@ final class CoseSignatureFixerTest extends TestCase
         // Given
         $signature = hex2bin(
             '3064'
-            . '0230' . '7f' . str_repeat('ff', 47)
-            . '0230' . '01' . str_repeat('00', 47)
+            . '02307f' . str_repeat('ff', 47)
+            . '023001' . str_repeat('00', 47)
         );
 
         // When
@@ -106,8 +107,8 @@ final class CoseSignatureFixerTest extends TestCase
         // Given
         $signature = hex2bin(
             '308188'
-            . '0242' . '01' . str_repeat('00', 64) . 'ff'
-            . '0242' . '01' . str_repeat('ff', 64) . '00'
+            . '024201' . str_repeat('00', 64) . 'ff'
+            . '024201' . str_repeat('ff', 64) . '00'
         );
 
         // When
@@ -116,7 +117,7 @@ final class CoseSignatureFixerTest extends TestCase
         // Then
         static::assertSame(132, strlen($fixed));
         static::assertSame(
-            '01' . str_repeat('00', 64) . 'ff' . '01' . str_repeat('ff', 64) . '00',
+            '01' . str_repeat('00', 64) . 'ff01' . str_repeat('ff', 64) . '00',
             bin2hex($fixed)
         );
     }
@@ -128,7 +129,7 @@ final class CoseSignatureFixerTest extends TestCase
         $signature = hex2bin(
             '308186'
             . '0241' . str_repeat('11', 65)
-            . '0242' . '01' . str_repeat('22', 65)
+            . '024201' . str_repeat('22', 65)
         );
 
         // When


### PR DESCRIPTION
Now that the pipeline repaired in #934 runs to completion, two problems are visible on the `5.3.x` and `5.4.x` branch runs.

### The analysis jobs worked against a vendor frozen months ago

ECS, Rector, Deptrac and the composer validation job did not install dependencies. They restored `vendor` from a cache keyed on `hashFiles('composer.lock')`, and `composer.lock` is gitignored, so the expression resolved to an empty string and the key was the constant `composer-Linux-`. GitHub never overwrites an existing cache entry, so every run since the first one restored the same archive. The Rector job restored 5 MB of `vendor`, nowhere near a complete install.

Rector reads `vendor/composer/installed.json` through `withComposerBased(phpunit: true)` to pick its PHPUnit rule set. With the stale install it selected the PHPUnit 12 renames and asked to rewrite every `expectExceptionMessage()` call into `expectExceptionMessageIsOrContains()`: 38 files on `5.4.x`, 19 on `5.3.x`. None of it reproduces against a real install, where Rector exits 0.

The four jobs now install dependencies with `ramsey/composer-install`, exactly as the PHPStan job already did, which is why PHPStan has been the only analysis job giving trustworthy results. The now-unused `cache-key` output is dropped from the preparation job.

### Three ECS violations that nothing could catch

The test files added by #931 and #932 violate `NoUselessConcatOperatorFixer`, `GlobalNamespaceImportFixer` and `OrderedImportsFixer`. They reached `5.3.x` because the analysis jobs are guarded by `if: endsWith(github.ref_name, '.x')`, which is false on a pull request, so ECS and Rector never run on a PR. The branch that repaired the pipeline predated those test files, so nothing checked them either.

### Verification

Against a real install on the phpqa 8.4 image: ECS, Rector, PHPStan and Deptrac all exit 0, 358 tests green.

Note that this PR itself cannot demonstrate the fix, since the jobs it repairs do not run on pull requests. That guard is worth revisiting separately: as things stand a PR can only be validated after being merged, which is how both rounds of breakage reached the branch.

Closes #935
